### PR TITLE
Make use of TrimPrefix for binary headers

### DIFF
--- a/v01/http.go
+++ b/v01/http.go
@@ -97,8 +97,8 @@ func (e *Event) UnmarshalBinary(req *http.Request) error {
 			continue
 		}
 
-		k = strings.TrimLeft(k, "Ce-")
-		k = strings.TrimLeft(k, "X-")
+		k = strings.TrimPrefix(k, "Ce-")
+		k = strings.TrimPrefix(k, "X-")
 		k = strings.Replace(k, "-", "", -1)
 
 		fieldName, ok := fieldNames[strings.ToLower(k)]

--- a/v01/http_test.go
+++ b/v01/http_test.go
@@ -24,6 +24,7 @@ func TestHTTPMarshallerFromRequestBinaryBase64Success(t *testing.T) {
 	header.Set("CE-MyExtension", "myvalue")
 	header.Set("CE-AnotherExtension", "anothervalue")
 	header.Set("CE-EventTime", "2018-04-05T17:31:00Z")
+	header.Set("CE-CloudEventsVersion", "0.1")
 
 	body := bytes.NewBufferString("This is a byte array of data.")
 	req := httptest.NewRequest("GET", "localhost:8080", ioutil.NopCloser(body))
@@ -34,12 +35,13 @@ func TestHTTPMarshallerFromRequestBinaryBase64Success(t *testing.T) {
 
 	timestamp, err := time.Parse(time.RFC3339, "2018-04-05T17:31:00Z")
 	expected := &v01.Event{
-		ContentType: "application/octet-stream",
-		EventType:   "com.example.someevent",
-		Source:      "/mycontext",
-		EventID:     "1234-1234-1234",
-		EventTime:   &timestamp,
-		Data:        []byte("This is a byte array of data."),
+		CloudEventsVersion: "0.1",
+		ContentType:        "application/octet-stream",
+		EventType:          "com.example.someevent",
+		Source:             "/mycontext",
+		EventID:            "1234-1234-1234",
+		EventTime:          &timestamp,
+		Data:               []byte("This is a byte array of data."),
 	}
 
 	expected.Set("myextension", "myvalue")


### PR DESCRIPTION
Currently the Header processing in UnmarshalBinary makes use of `TrimLeft` which will have undesirable effects when a character in the cutset immediately follows the hyphen.  For example a header value of `CE-CloudEventsVersion` would be converted to `loudEventsVersion`.

This change amends TestHTTPMarshallerFromRequestBinaryBase64Success to add a header to exercise the identified issue and also changes TrimLeft to TrimPrefix within http.go.

Signed-off-by: Richard Gee <richard@technologee.co.uk>