### PR TITLE
Adding Client Option for default ID and Time when using client.Send()

### DIFF
--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -21,6 +21,8 @@ type Client interface {
 type ceClient struct {
 	transport transport.Sender
 	receiver  Receiver
+
+	eventDefaulterFns []EventDefaulter
 }
 
 func (c *ceClient) Send(ctx context.Context, event cloudevents.Event) error {
@@ -29,6 +31,11 @@ func (c *ceClient) Send(ctx context.Context, event cloudevents.Event) error {
 	}
 	if err := event.Validate(); err != nil {
 		return err
+	}
+	if len(c.eventDefaulterFns) > 0 {
+		for _, fn := range c.eventDefaulterFns {
+			event = fn(event)
+		}
 	}
 	return c.transport.Send(ctx, event)
 }

--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -26,17 +26,21 @@ type ceClient struct {
 }
 
 func (c *ceClient) Send(ctx context.Context, event cloudevents.Event) error {
+	// Confirm we have a transport set.
 	if c.transport == nil {
 		return fmt.Errorf("client not ready, transport not initalized")
 	}
-	if err := event.Validate(); err != nil {
-		return err
-	}
+	// Apply the defaulter chain to the incoming event.
 	if len(c.eventDefaulterFns) > 0 {
 		for _, fn := range c.eventDefaulterFns {
 			event = fn(event)
 		}
 	}
+	// Validate the event conforms to the CloudEvents Spec.
+	if err := event.Validate(); err != nil {
+		return err
+	}
+	// Send the event over the transport.
 	return c.transport.Send(ctx, event)
 }
 

--- a/pkg/cloudevents/client/defaulters.go
+++ b/pkg/cloudevents/client/defaulters.go
@@ -2,7 +2,9 @@ package client
 
 import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 	"github.com/google/uuid"
+	"time"
 )
 
 type EventDefaulter func(event cloudevents.Event) cloudevents.Event
@@ -26,6 +28,32 @@ func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 			ec := event.Context.AsV03()
 			if ec.ID == "" {
 				ec.ID = uuid.New().String()
+				event.Context = ec
+			}
+		}
+	}
+	return event
+}
+
+func DefaultTimeToNowIfNotSet(event cloudevents.Event) cloudevents.Event {
+	if event.Context != nil {
+		switch event.Context.GetSpecVersion() {
+		case cloudevents.CloudEventsVersionV01:
+			ec := event.Context.AsV01()
+			if ec.EventTime == nil || ec.EventTime.IsZero() {
+				ec.EventTime = &types.Timestamp{Time: time.Now()}
+				event.Context = ec
+			}
+		case cloudevents.CloudEventsVersionV02:
+			ec := event.Context.AsV02()
+			if ec.Time == nil || ec.Time.IsZero() {
+				ec.Time = &types.Timestamp{Time: time.Now()}
+				event.Context = ec
+			}
+		case cloudevents.CloudEventsVersionV03:
+			ec := event.Context.AsV03()
+			if ec.Time == nil || ec.Time.IsZero() {
+				ec.Time = &types.Timestamp{Time: time.Now()}
 				event.Context = ec
 			}
 		}

--- a/pkg/cloudevents/client/defaulters.go
+++ b/pkg/cloudevents/client/defaulters.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/google/uuid"
+)
+
+type EventDefaulter func(event cloudevents.Event) cloudevents.Event
+
+func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
+	if event.Context != nil {
+		switch event.Context.GetSpecVersion() {
+		case cloudevents.CloudEventsVersionV01:
+			ec := event.Context.AsV01()
+			if ec.EventID == "" {
+				ec.EventID = uuid.New().String()
+				event.Context = ec
+			}
+		case cloudevents.CloudEventsVersionV02:
+			ec := event.Context.AsV02()
+			if ec.ID == "" {
+				ec.ID = uuid.New().String()
+				event.Context = ec
+			}
+		case cloudevents.CloudEventsVersionV03:
+			ec := event.Context.AsV03()
+			if ec.ID == "" {
+				ec.ID = uuid.New().String()
+				event.Context = ec
+			}
+		}
+	}
+	return event
+}

--- a/pkg/cloudevents/client/defaulters_test.go
+++ b/pkg/cloudevents/client/defaulters_test.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestDefaultIDToUUIDIfNotSet(t *testing.T) {
+	testCases := map[string]struct {
+		event cloudevents.Event
+	}{
+		"nil context": {
+			event: cloudevents.Event{},
+		},
+		"v0.1 empty": {
+			event: cloudevents.Event{
+				Context: cloudevents.EventContextV01{},
+			},
+		},
+		"v0.2 empty": {
+			event: cloudevents.Event{
+				Context: cloudevents.EventContextV02{},
+			},
+		},
+		"v0.3 empty": {
+			event: cloudevents.Event{
+				Context: cloudevents.EventContextV03{},
+			},
+		},
+		"v0.1 no change": {
+			event: cloudevents.Event{
+				Context: cloudevents.EventContextV01{EventID: "abc"}.AsV01(),
+			},
+		},
+		"v0.2 no change": {
+			event: cloudevents.Event{
+				Context: cloudevents.EventContextV02{ID: "abc"}.AsV02(),
+			},
+		},
+		"v0.3 no change": {
+			event: cloudevents.Event{
+				Context: cloudevents.EventContextV03{ID: "abc"}.AsV03(),
+			},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			got := DefaultIDToUUIDIfNotSet(tc.event)
+
+			if got.Context != nil && got.Context.AsV02().ID == "" {
+				t.Errorf("failed to generate an id for event")
+			}
+		})
+	}
+}
+
+func TestDefaultIDToUUIDIfNotSetImmutable(t *testing.T) {
+	event := cloudevents.Event{
+		Context: cloudevents.EventContextV01{},
+	}
+
+	got := DefaultIDToUUIDIfNotSet(event)
+
+	want := "0.1"
+
+	if diff := cmp.Diff(want, got.SpecVersion()); diff != "" {
+		t.Errorf("unexpected (-want, +got) = %v", diff)
+	}
+
+	if event.Context.AsV01().EventID != "" {
+		t.Errorf("modified the original event")
+	}
+
+	if got.Context.AsV01().EventID == "" {
+		t.Errorf("failed to generate an id for event")
+	}
+}

--- a/pkg/cloudevents/client/options.go
+++ b/pkg/cloudevents/client/options.go
@@ -147,13 +147,31 @@ func WithNATSEncoding(encoding nats.Encoding) Option {
 	}
 }
 
-// WithEventDefaulter adds an event default to the end of the defaulter chain.
+// WithEventDefaulter adds an event defaulter to the end of the defaulter chain.
 func WithEventDefaulter(fn EventDefaulter) Option {
 	return func(c *ceClient) error {
 		if fn == nil {
 			return fmt.Errorf("client option was given an nil event defaulter")
 		}
 		c.eventDefaulterFns = append(c.eventDefaulterFns, fn)
+		return nil
+	}
+}
+
+// WithUUIDs adds DefaultIDToUUIDIfNotSet event defaulter to the end of the
+// defaulter chain.
+func WithUUIDs() Option {
+	return func(c *ceClient) error {
+		c.eventDefaulterFns = append(c.eventDefaulterFns, DefaultIDToUUIDIfNotSet)
+		return nil
+	}
+}
+
+// WithTimeNow adds DefaultTimeToNowIfNotSet event defaulter to the end of the
+// defaulter chain.
+func WithTimeNow() Option {
+	return func(c *ceClient) error {
+		c.eventDefaulterFns = append(c.eventDefaulterFns, DefaultTimeToNowIfNotSet)
 		return nil
 	}
 }

--- a/pkg/cloudevents/client/options.go
+++ b/pkg/cloudevents/client/options.go
@@ -146,3 +146,14 @@ func WithNATSEncoding(encoding nats.Encoding) Option {
 		return fmt.Errorf("invalid NATS encoding client option received for transport type")
 	}
 }
+
+// WithEventDefaulter adds an event default to the end of the defaulter chain.
+func WithEventDefaulter(fn EventDefaulter) Option {
+	return func(c *ceClient) error {
+		if fn == nil {
+			return fmt.Errorf("client option was given an nil event defaulter")
+		}
+		c.eventDefaulterFns = append(c.eventDefaulterFns, fn)
+		return nil
+	}
+}

--- a/pkg/cloudevents/client/options_test.go
+++ b/pkg/cloudevents/client/options_test.go
@@ -624,3 +624,76 @@ func TestWithNATSEncoding(t *testing.T) {
 		})
 	}
 }
+
+func TestWithEventDefaulter(t *testing.T) {
+
+	v1 := func(event cloudevents.Event) cloudevents.Event {
+		event.Context = event.Context.AsV01()
+		return event
+	}
+
+	v2 := func(event cloudevents.Event) cloudevents.Event {
+		event.Context = event.Context.AsV02()
+		return event
+	}
+
+	v3 := func(event cloudevents.Event) cloudevents.Event {
+		event.Context = event.Context.AsV03()
+		return event
+	}
+
+	testCases := map[string]struct {
+		c       *ceClient
+		fns     []EventDefaulter
+		want    int // number of defaulters
+		wantErr string
+	}{
+		"none": {
+			c:    &ceClient{},
+			want: 0,
+		},
+		"one": {
+			c:    &ceClient{},
+			fns:  []EventDefaulter{v1},
+			want: 1,
+		},
+		"three": {
+			c:    &ceClient{},
+			fns:  []EventDefaulter{v1, v2, v3},
+			want: 3,
+		},
+		"nil fn": {
+			c:       &ceClient{},
+			fns:     []EventDefaulter{nil},
+			wantErr: "client option was given an nil event defaulter",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			var err error
+			for _, fn := range tc.fns {
+				err = tc.c.applyOptions(WithEventDefaulter(fn))
+				if err != nil {
+					break
+				}
+			}
+
+			if tc.wantErr != "" || err != nil {
+				var gotErr string
+				if err != nil {
+					gotErr = err.Error()
+				}
+				if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+					t.Errorf("unexpected error (-want, +got) = %v", diff)
+				}
+				return
+			}
+
+			got := len(tc.c.eventDefaulterFns)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/cloudevents/client/options_test.go
+++ b/pkg/cloudevents/client/options_test.go
@@ -697,3 +697,58 @@ func TestWithEventDefaulter(t *testing.T) {
 		})
 	}
 }
+
+func TestWith_Defaulters(t *testing.T) {
+
+	testCases := map[string]struct {
+		c       *ceClient
+		opts    []Option
+		want    int // number of defaulters
+		wantErr string
+	}{
+		"none": {
+			c:    &ceClient{},
+			want: 0,
+		},
+		"uuid": {
+			c:    &ceClient{},
+			opts: []Option{WithUUIDs()},
+			want: 1,
+		},
+		"time": {
+			c:    &ceClient{},
+			opts: []Option{WithTimeNow()},
+			want: 1,
+		},
+		"uuid and time": {
+			c:    &ceClient{},
+			opts: []Option{WithUUIDs(), WithTimeNow()},
+			want: 2,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			var err error
+			if len(tc.opts) > 0 {
+				err = tc.c.applyOptions(tc.opts...)
+			}
+
+			if tc.wantErr != "" || err != nil {
+				var gotErr string
+				if err != nil {
+					gotErr = err.Error()
+				}
+				if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+					t.Errorf("unexpected error (-want, +got) = %v", diff)
+				}
+				return
+			}
+
+			got := len(tc.c.eventDefaulterFns)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected (-want, +got) = %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes: https://github.com/cloudevents/sdk-go/issues/22

Attempting to reduce friction for the producer of events when using the client.

At the moment we need to do something like this to make a event context:

```go
func (d *Demo) context() cloudevents.EventContext {
	now := time.Now()
	ctx := cloudevents.EventContextV01{
		EventID:     uuid.New().String(),
		EventType:   d.EventType,
		EventTime:   &types.Timestamp{Time: now},
		Source:      types.URLRef{URL: d.Source},
		ContentType: &d.ContentType,
	}.AsV01()
	return ctx
}
```

But with this change, we can add new client options to enable defaulting:

```go
c, err := client.NewHTTPClient(
	client.WithTarget(env.HTTPTarget),
	client.WithHTTPEncoding(encoding),
	client.WithUUIDs(),
	client.WithTimeNow(),
)
```

And now the producer of the event has less to think about:

```go
func (d *Demo) context() cloudevents.EventContext {
	now := time.Now()
	ctx := cloudevents.EventContextV01{
		EventType:   d.EventType,
		Source:      types.URLRef{URL: d.Source},
		ContentType: &d.ContentType,
	}.AsV01()
	return ctx
}
```

Signed-off-by: Scott Nichols <nicholss@google.com>