### PR TITLE
Adding the option to set the handle path for http client.

### DIFF
--- a/cmd/samples/http/receiver/main.go
+++ b/cmd/samples/http/receiver/main.go
@@ -12,7 +12,8 @@ import (
 
 type envConfig struct {
 	// Port on which to listen for cloudevents
-	Port int `envconfig:"PORT" default:"8080"`
+	Port int    `envconfig:"RCV_PORT" default:"8080"`
+	Path string `envconfig:"RCV_PATH" default:"/"`
 }
 
 func main() {
@@ -42,12 +43,15 @@ func gotEvent(event cloudevents.Event) {
 func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 
-	_, err := client.StartHTTPReceiver(ctx, gotEvent, client.WithHTTPPort(env.Port))
+	_, err := client.StartHTTPReceiver(ctx, gotEvent,
+		client.WithHTTPPort(env.Port),
+		client.WithHTTPPath(env.Path),
+	)
 	if err != nil {
 		log.Fatalf("failed to start receiver: %s", err.Error())
 	}
 
-	log.Printf("listening on port %d\n", env.Port)
+	log.Printf("listening on :%d%s\n", env.Port, env.Path)
 	<-ctx.Done()
 
 	return 0

--- a/pkg/cloudevents/client/client_http.go
+++ b/pkg/cloudevents/client/client_http.go
@@ -46,8 +46,11 @@ func (c *ceClient) startHTTPReceiver(ctx context.Context, t *cloudeventshttp.Tra
 	c.receiver = fn
 	t.Receiver = c
 
+	// Handle cloudevents receive on a path, normally "/"
+	http.HandleFunc(t.GetPath(), t.ServeHTTP)
+
 	go func() {
-		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", t.GetPort()), t))
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", t.GetPort()), nil))
 	}()
 
 	return nil

--- a/pkg/cloudevents/client/options.go
+++ b/pkg/cloudevents/client/options.go
@@ -118,7 +118,22 @@ func WithHTTPPort(port int) Option {
 			t.Port = port
 			return nil
 		}
-		return fmt.Errorf("invalid HTTP port client option received for transport type")
+		return fmt.Errorf("port: invalid client option received for non-HTTP transport type")
+	}
+}
+
+// WithHTTPPath sets the path to receive cloudevents on for clients with HTTP transports.
+func WithHTTPPath(path string) Option {
+	return func(c *ceClient) error {
+		if t, ok := c.transport.(*http.Transport); ok {
+			path = strings.TrimSpace(path)
+			if len(path) == 0 {
+				return fmt.Errorf("client option was given an invalid path: %q", path)
+			}
+			t.Path = path
+			return nil
+		}
+		return fmt.Errorf("path: invalid client option received for non-HTTP transport type")
 	}
 }
 

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 )
 
 type EncodingSelector func(e cloudevents.Event) Encoding
@@ -26,7 +27,8 @@ type Transport struct {
 	Req    *http.Request
 
 	// Receiving
-	Port     int
+	Port     int    // default 8080
+	Path     string // default "/"
 	Receiver transport.Receiver
 
 	codec transport.Codec
@@ -161,4 +163,12 @@ func (t *Transport) GetPort() int {
 		return t.Port
 	}
 	return 8080 // default
+}
+
+func (t *Transport) GetPath() string {
+	path := strings.TrimSpace(t.Path)
+	if len(path) > 0 {
+		return path
+	}
+	return "/" // default
 }


### PR DESCRIPTION
Integrating with https://github.com/mchmarny/knative-ws-example I found that in this example it was impossible to use the sdk because the sdk did not let me choose which path the handler should use.

Moved the http internals to use a handler and add the ability to set that handler to something else.

Signed-off-by: Scott Nichols <nicholss@google.com>