### PR TITLE
Check the header name's length before slicing it

### DIFF
--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -165,7 +165,7 @@ func (v CodecV01) fromHeaders(h http.Header) (cloudevents.EventContextV01, error
 
 	extensions := make(map[string]interface{})
 	for k, v := range h {
-		if strings.EqualFold(k[:len("CE-X-")], "CE-X-") {
+		if len(k) > len("CE-X-") && strings.EqualFold(k[:len("CE-X-")], "CE-X-") {
 			key := k[len("CE-X-"):]
 			var tmp interface{}
 			if err := json.Unmarshal([]byte(v[0]), &tmp); err == nil {

--- a/pkg/cloudevents/transport/http/codec_v01_test.go
+++ b/pkg/cloudevents/transport/http/codec_v01_test.go
@@ -366,6 +366,28 @@ func TestCodecV01_Decode(t *testing.T) {
 				}),
 			},
 		},
+		"simple v0.1 binary with short header": {
+			codec: http.CodecV01{},
+			msg: &http.Message{
+				Header: map[string][]string{
+					"CE-CloudEventsVersion": {"0.1"},
+					"CE-EventID":            {"ABC-123"},
+					"CE-EventType":          {"com.example.test"},
+					"CE-Source":             {"http://example.com/source"},
+					"Content-Type":          {"application/json"},
+					"X":                     {"Notice how short the header's name is"},
+				},
+			},
+			want: &cloudevents.Event{
+				Context: cloudevents.EventContextV01{
+					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
+					EventType:          "com.example.test",
+					Source:             *source,
+					EventID:            "ABC-123",
+					ContentType:        cloudevents.StringOfApplicationJSON(),
+				},
+			},
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -186,7 +186,7 @@ func (v CodecV02) fromHeaders(h http.Header) (cloudevents.EventContextV02, error
 
 	extensions := make(map[string]interface{})
 	for k, v := range h {
-		if strings.EqualFold(k[:len("ce-")], "ce-") {
+		if len(k) > len("ce-") && strings.EqualFold(k[:len("ce-")], "ce-") {
 			ak := strings.ToLower(k[len("ce-"):])
 			if i := strings.Index(ak, "-"); i > 0 {
 				// attrib-key

--- a/pkg/cloudevents/transport/http/codec_v02_test.go
+++ b/pkg/cloudevents/transport/http/codec_v02_test.go
@@ -377,6 +377,28 @@ func TestCodecV02_Decode(t *testing.T) {
 				}),
 			},
 		},
+		"simple v0.2 binary with short header": {
+			codec: http.CodecV02{},
+			msg: &http.Message{
+				Header: map[string][]string{
+					"ce-specversion": {"0.2"},
+					"ce-id":          {"ABC-123"},
+					"ce-type":        {"com.example.test"},
+					"ce-source":      {"http://example.com/source"},
+					"Content-Type":   {"application/json"},
+					"X":              {"Notice how short the header's name is"},
+				},
+			},
+			want: &cloudevents.Event{
+				Context: cloudevents.EventContextV02{
+					SpecVersion: cloudevents.CloudEventsVersionV02,
+					ContentType: cloudevents.StringOfApplicationJSON(),
+					Type:        "com.example.test",
+					Source:      *source,
+					ID:          "ABC-123",
+				},
+			},
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -191,7 +191,7 @@ func (v CodecV03) fromHeaders(h http.Header) (cloudevents.EventContextV03, error
 
 	extensions := make(map[string]interface{})
 	for k, v := range h {
-		if strings.EqualFold(k[:len("ce-")], "ce-") {
+		if len(k) > len("ce-") && strings.EqualFold(k[:len("ce-")], "ce-") {
 			ak := strings.ToLower(k[len("ce-"):])
 			if i := strings.Index(ak, "-"); i > 0 {
 				// attrib-key

--- a/pkg/cloudevents/transport/http/codec_v03_test.go
+++ b/pkg/cloudevents/transport/http/codec_v03_test.go
@@ -377,6 +377,28 @@ func TestCodecV03_Decode(t *testing.T) {
 				}),
 			},
 		},
+		"simple v0.3 binary with short header": {
+			codec: http.CodecV03{},
+			msg: &http.Message{
+				Header: map[string][]string{
+					"ce-specversion": {"0.3"},
+					"ce-id":          {"ABC-123"},
+					"ce-type":        {"com.example.test"},
+					"ce-source":      {"http://example.com/source"},
+					"Content-Type":   {"application/json"},
+					"X":              {"Notice how short the header's name is"},
+				},
+			},
+			want: &cloudevents.Event{
+				Context: cloudevents.EventContextV03{
+					SpecVersion:     cloudevents.CloudEventsVersionV03,
+					DataContentType: cloudevents.StringOfApplicationJSON(),
+					Type:            "com.example.test",
+					Source:          *source,
+					ID:              "ABC-123",
+				},
+			},
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
Check the header name's length before slicing it.

Without this, I was getting problems when sending an `http.Request`'s headers to `Decode`. In particular the `Host` header using `CodecV01` in binary mode.