### PR TITLE
Add client.StopReceiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ func Receive(event cloudevents.Event) {
 
 func main() {
 	ctx := context.Background()
-	_, err := client.StartHTTPReceiver(ctx, Receive)
+	_, _, err := client.StartHTTPReceiver(ctx, Receive)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/samples/complex/httptonats/main.go
+++ b/cmd/samples/complex/httptonats/main.go
@@ -68,7 +68,7 @@ func _main(args []string, env envConfig) int {
 
 	r := &Receiver{Client: nc}
 
-	_, err = client.StartHTTPReceiver(ctx, r.Receive, client.WithHTTPPort(env.Port))
+	_, _, err = client.StartHTTPReceiver(ctx, r.Receive, client.WithHTTPPort(env.Port))
 	if err != nil {
 		log.Printf("failed to StartHTTPReceiver, %v", err)
 	}

--- a/cmd/samples/http/receiver/main.go
+++ b/cmd/samples/http/receiver/main.go
@@ -43,7 +43,7 @@ func gotEvent(event cloudevents.Event) {
 func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 
-	_, err := client.StartHTTPReceiver(ctx, gotEvent,
+	_, _, err := client.StartHTTPReceiver(ctx, gotEvent,
 		client.WithHTTPPort(env.Port),
 		client.WithHTTPPath(env.Path),
 	)

--- a/cmd/samples/http/sender/main.go
+++ b/cmd/samples/http/sender/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	count = 1
+	count = 100
 )
 
 type envConfig struct {
@@ -95,10 +95,11 @@ func _main(args []string, env envConfig) int {
 				}.AsV01()
 				if err := d.Send(ctx, seq); err != nil {
 					log.Printf("failed to send: %v", err)
-					return 1
+				} else {
+					log.Printf("event sent at %s", time.Now())
 				}
 				seq++
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(500 * time.Millisecond)
 			}
 		}
 	}

--- a/cmd/samples/http/sleepy/main.go
+++ b/cmd/samples/http/sleepy/main.go
@@ -44,7 +44,7 @@ func gotEvent(event cloudevents.Event) {
 func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 
-	c, err := client.StartHTTPReceiver(ctx, gotEvent,
+	_, c, err := client.StartHTTPReceiver(ctx, gotEvent,
 		client.WithHTTPPort(env.Port),
 		client.WithHTTPPath(env.Path),
 	)
@@ -63,7 +63,7 @@ func _main(args []string, env envConfig) int {
 		log.Printf("stopped @ %s", time.Now())
 
 		time.Sleep(5 * time.Second)
-		if err := c.StartReceiver(ctx, gotEvent); err != nil {
+		if _, err := c.StartReceiver(ctx, gotEvent); err != nil {
 			log.Fatalf("failed to start receiver: %s", err.Error())
 		}
 		log.Printf("started @ %s", time.Now())

--- a/cmd/samples/http/sleepy/main.go
+++ b/cmd/samples/http/sleepy/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
+	"github.com/kelseyhightower/envconfig"
+	"log"
+	"os"
+	"time"
+)
+
+type envConfig struct {
+	// Port on which to listen for cloudevents
+	Port int    `envconfig:"RCV_PORT" default:"8080"`
+	Path string `envconfig:"RCV_PATH" default:"/"`
+}
+
+func main() {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		log.Printf("[ERROR] Failed to process env var: %s", err)
+		os.Exit(1)
+	}
+	os.Exit(_main(os.Args[1:], env))
+}
+
+type Example struct {
+	Sequence int    `json:"id"`
+	Message  string `json:"message"`
+}
+
+func gotEvent(event cloudevents.Event) {
+	fmt.Printf("Got Event Context: %+v\n", event.Context)
+	data := &Example{}
+	if err := event.DataAs(data); err != nil {
+		fmt.Printf("Got Data Error: %s\n", err.Error())
+	}
+	fmt.Printf("Got Data: %+v\n", data)
+	fmt.Printf("----------------------------\n")
+}
+
+func _main(args []string, env envConfig) int {
+	ctx := context.Background()
+
+	c, err := client.StartHTTPReceiver(ctx, gotEvent,
+		client.WithHTTPPort(env.Port),
+		client.WithHTTPPath(env.Path),
+	)
+
+	if err != nil {
+		log.Fatalf("failed to start receiver: %s", err.Error())
+	}
+
+	log.Printf("listening on :%d%s\n", env.Port, env.Path)
+
+	for {
+		time.Sleep(5 * time.Second)
+		if err := c.StopReceiver(ctx); err != nil {
+			log.Fatalf("failed to stop receiver: %s", err.Error())
+		}
+		log.Printf("stopped @ %s", time.Now())
+
+		time.Sleep(5 * time.Second)
+		if err := c.StartReceiver(ctx, gotEvent); err != nil {
+			log.Fatalf("failed to start receiver: %s", err.Error())
+		}
+		log.Printf("started @ %s", time.Now())
+	}
+}

--- a/cmd/samples/nats/receiver/main.go
+++ b/cmd/samples/nats/receiver/main.go
@@ -51,7 +51,7 @@ func _main(args []string, env envConfig) int {
 		log.Fatalf("failed to create nats client, %s", err.Error())
 	}
 
-	if err := c.StartReceiver(ctx, receive); err != nil {
+	if _, err := c.StartReceiver(ctx, receive); err != nil {
 		log.Fatalf("failed to start nats receiver, %s", err.Error())
 	}
 

--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -12,7 +12,7 @@ type Receiver func(event cloudevents.Event)
 type Client interface {
 	Send(ctx context.Context, event cloudevents.Event) error
 
-	StartReceiver(ctx context.Context, fn Receiver) error
+	StartReceiver(ctx context.Context, fn Receiver) (context.Context, error)
 	StopReceiver(ctx context.Context) error
 
 	Receive(event cloudevents.Event)
@@ -50,12 +50,12 @@ func (c *ceClient) Receive(event cloudevents.Event) {
 	}
 }
 
-func (c *ceClient) StartReceiver(ctx context.Context, fn Receiver) error {
+func (c *ceClient) StartReceiver(ctx context.Context, fn Receiver) (context.Context, error) {
 	if c.transport == nil {
-		return fmt.Errorf("client not ready, transport not initialized")
+		return ctx, fmt.Errorf("client not ready, transport not initialized")
 	}
 	if c.receiver != nil {
-		return fmt.Errorf("client already has a receiver")
+		return ctx, fmt.Errorf("client already has a receiver")
 	}
 
 	c.receiver = fn

--- a/pkg/cloudevents/client/client_http.go
+++ b/pkg/cloudevents/client/client_http.go
@@ -22,6 +22,7 @@ func NewHTTPClient(opts ...Option) (Client, error) {
 	return c, nil
 }
 
+// TODO: It is very easy to start the client now. It might make sense to remove this method.
 func StartHTTPReceiver(ctx context.Context, fn Receiver, opts ...Option) (context.Context, Client, error) {
 	c, err := NewHTTPClient(opts...)
 	if err != nil {
@@ -30,6 +31,7 @@ func StartHTTPReceiver(ctx context.Context, fn Receiver, opts ...Option) (contex
 
 	if ctx, err := c.StartReceiver(ctx, fn); err != nil {
 		return ctx, nil, err
+	} else {
+		return ctx, c, nil
 	}
-	return ctx, c, nil
 }

--- a/pkg/cloudevents/client/client_http.go
+++ b/pkg/cloudevents/client/client_http.go
@@ -22,14 +22,14 @@ func NewHTTPClient(opts ...Option) (Client, error) {
 	return c, nil
 }
 
-func StartHTTPReceiver(ctx context.Context, fn Receiver, opts ...Option) (Client, error) {
+func StartHTTPReceiver(ctx context.Context, fn Receiver, opts ...Option) (context.Context, Client, error) {
 	c, err := NewHTTPClient(opts...)
 	if err != nil {
-		return nil, err
+		return ctx, nil, err
 	}
 
-	if err := c.StartReceiver(ctx, fn); err != nil {
-		return nil, err
+	if ctx, err := c.StartReceiver(ctx, fn); err != nil {
+		return ctx, nil, err
 	}
-	return c, nil
+	return ctx, c, nil
 }

--- a/pkg/cloudevents/client/client_nats.go
+++ b/pkg/cloudevents/client/client_nats.go
@@ -1,11 +1,8 @@
 package client
 
 import (
-	"context"
-	"fmt"
 	cloudeventsnats "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/nats"
 	"github.com/nats-io/go-nats"
-	"log"
 )
 
 func NewNATSClient(natsServer, subject string, opts ...Option) (Client, error) {
@@ -26,27 +23,4 @@ func NewNATSClient(natsServer, subject string, opts ...Option) (Client, error) {
 	}
 
 	return c, nil
-}
-
-func (c *ceClient) startNATSReceiver(ctx context.Context, t *cloudeventsnats.Transport, fn Receiver) error {
-	if t.Conn == nil {
-		return fmt.Errorf("nats connection is required to be set")
-	}
-	if c.receiver != nil {
-		return fmt.Errorf("client already has a receiver")
-	}
-	if t.Receiver != nil {
-		return fmt.Errorf("transport already has a receiver")
-	}
-
-	c.receiver = fn
-	t.Receiver = c
-
-	go func() {
-		if err := t.Listen(ctx); err != nil {
-			log.Fatalf("failed to listen, %s", err.Error())
-		}
-	}()
-
-	return nil
 }

--- a/pkg/cloudevents/client/options.go
+++ b/pkg/cloudevents/client/options.go
@@ -112,7 +112,7 @@ func WithHTTPStructuredEncoding() Option {
 func WithHTTPPort(port int) Option {
 	return func(c *ceClient) error {
 		if t, ok := c.transport.(*http.Transport); ok {
-			if port == 0 {
+			if port < 0 {
 				return fmt.Errorf("client option was given an invalid port: %d", port)
 			}
 			t.Port = port

--- a/pkg/cloudevents/client/options.go
+++ b/pkg/cloudevents/client/options.go
@@ -115,7 +115,7 @@ func WithHTTPPort(port int) Option {
 			if port < 0 {
 				return fmt.Errorf("client option was given an invalid port: %d", port)
 			}
-			t.Port = port
+			t.Port = &port
 			return nil
 		}
 		return fmt.Errorf("port: invalid client option received for non-HTTP transport type")

--- a/pkg/cloudevents/client/options_test.go
+++ b/pkg/cloudevents/client/options_test.go
@@ -252,6 +252,10 @@ func TestWithHTTPClient(t *testing.T) {
 	}
 }
 
+func intptr(i int) *int {
+	return &i
+}
+
 func TestWithPort(t *testing.T) {
 	testCases := map[string]struct {
 		c       *ceClient
@@ -265,7 +269,7 @@ func TestWithPort(t *testing.T) {
 			},
 			port: 8181,
 			want: &ceClient{transport: &http.Transport{
-				Port: 8181,
+				Port: intptr(8181),
 			}},
 		},
 		"invalid port": {

--- a/pkg/cloudevents/client/options_test.go
+++ b/pkg/cloudevents/client/options_test.go
@@ -272,8 +272,8 @@ func TestWithPort(t *testing.T) {
 			c: &ceClient{
 				transport: &http.Transport{},
 			},
-			port:    0,
-			wantErr: `client option was given an invalid port: 0`,
+			port:    -1,
+			wantErr: `client option was given an invalid port: -1`,
 		},
 		"empty transport": {
 			c:       &ceClient{},

--- a/pkg/cloudevents/context/context.go
+++ b/pkg/cloudevents/context/context.go
@@ -1,0 +1,24 @@
+package context
+
+import (
+	"context"
+)
+
+// Opaque key type used to store port
+type portKeyType struct{}
+
+var portKey = portKeyType{}
+
+func ContextWithPort(ctx context.Context, port int) context.Context {
+	return context.WithValue(ctx, portKey, port)
+}
+
+func PortFromContext(ctx context.Context) int {
+	c := ctx.Value(portKey)
+	if c != nil {
+		if port, ok := c.(int); ok {
+			return port
+		}
+	}
+	return 0
+}

--- a/pkg/cloudevents/context/context.go
+++ b/pkg/cloudevents/context/context.go
@@ -14,9 +14,9 @@ func ContextWithPort(ctx context.Context, port int) context.Context {
 }
 
 func PortFromContext(ctx context.Context) int {
-	c := ctx.Value(portKey)
-	if c != nil {
-		if port, ok := c.(int); ok {
+	v := ctx.Value(portKey)
+	if v != nil {
+		if port, ok := v.(int); ok {
 			return port
 		}
 	}

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -95,7 +95,6 @@ func (t *Transport) Send(ctx context.Context, event cloudevents.Event) error {
 	return fmt.Errorf("failed to encode Event into a Message")
 }
 
-// This is blocking until the http server returns.
 func (t *Transport) StartReceiver(ctx context.Context) (context.Context, error) {
 	if t.server == nil {
 		if t.handler == nil {
@@ -208,7 +207,6 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		go t.Receiver.Receive(*event)
 	}
 
-	// TODO: respond correctly based on decode.
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/pkg/cloudevents/transport/nats/transport.go
+++ b/pkg/cloudevents/transport/nats/transport.go
@@ -58,22 +58,22 @@ func (t *Transport) Send(ctx context.Context, event cloudevents.Event) error {
 	return fmt.Errorf("failed to encode Event into a Message")
 }
 
-func (t *Transport) StartReceiver(ctx context.Context) error {
+func (t *Transport) StartReceiver(ctx context.Context) (context.Context, error) {
 	if t.Conn == nil {
-		return fmt.Errorf("no active nats connection")
+		return ctx, fmt.Errorf("no active nats connection")
 	}
 	if t.sub != nil {
-		return fmt.Errorf("already subscribed")
+		return ctx, fmt.Errorf("already subscribed")
 	}
 	if ok := t.loadCodec(); !ok {
-		return fmt.Errorf("unknown encoding set on transport: %d", t.Encoding)
+		return ctx, fmt.Errorf("unknown encoding set on transport: %d", t.Encoding)
 	}
 
 	// TODO: there could be more than one subscription. Might have to do a map
 	// of subject to subscription.
 
 	if t.Subject == "" {
-		return fmt.Errorf("subject required for nats listen")
+		return ctx, fmt.Errorf("subject required for nats listen")
 	}
 
 	var err error
@@ -89,7 +89,7 @@ func (t *Transport) StartReceiver(ctx context.Context) error {
 		}
 		t.Receiver.Receive(*event)
 	})
-	return err
+	return ctx, err
 }
 
 func (t *Transport) StopReceiver(ctx context.Context) error {

--- a/pkg/cloudevents/transport/nats/transport.go
+++ b/pkg/cloudevents/transport/nats/transport.go
@@ -58,11 +58,13 @@ func (t *Transport) Send(ctx context.Context, event cloudevents.Event) error {
 	return fmt.Errorf("failed to encode Event into a Message")
 }
 
-func (t *Transport) Listen(ctx context.Context) error {
+func (t *Transport) StartReceiver(ctx context.Context) error {
+	if t.Conn == nil {
+		return fmt.Errorf("no active nats connection")
+	}
 	if t.sub != nil {
 		return fmt.Errorf("already subscribed")
 	}
-
 	if ok := t.loadCodec(); !ok {
 		return fmt.Errorf("unknown encoding set on transport: %d", t.Encoding)
 	}
@@ -88,4 +90,13 @@ func (t *Transport) Listen(ctx context.Context) error {
 		t.Receiver.Receive(*event)
 	})
 	return err
+}
+
+func (t *Transport) StopReceiver(ctx context.Context) error {
+	if t.sub != nil {
+		err := t.sub.Unsubscribe()
+		t.sub = nil
+		return err
+	}
+	return nil
 }

--- a/pkg/cloudevents/transport/transport.go
+++ b/pkg/cloudevents/transport/transport.go
@@ -10,7 +10,7 @@ import (
 type Sender interface {
 	Send(context.Context, cloudevents.Event) error
 
-	StartReceiver(context.Context) error
+	StartReceiver(context.Context) (context.Context, error)
 	StopReceiver(context.Context) error
 }
 

--- a/pkg/cloudevents/transport/transport.go
+++ b/pkg/cloudevents/transport/transport.go
@@ -9,6 +9,9 @@ import (
 // over the underlying transport.
 type Sender interface {
 	Send(context.Context, cloudevents.Event) error
+
+	StartReceiver(context.Context) error
+	StopReceiver(context.Context) error
 }
 
 // Receiver TODO not sure yet.


### PR DESCRIPTION
## Changes

* StartReceiver now returns a context. This is intended to be an fyi for the caller of the client. to extract data around how the transport was setup. If the client knows it is using an http transport, then it can fetch out the port or path that is being used and advertise it. This is demoed in the unit test for client.
* client.WithPort can now accept 0 as a valid port and the transport will pick a valid open port for you.
* The `transport.Sender` interface was modified to support Stop: `StartReceiver(context.Context) (context.Context, error)` and `StopReceiver(context.Context) error` are added. The logic on starting and stopping a transport is now inside the transport and removed from the client object code.

Fixes https://github.com/cloudevents/sdk-go/issues/43, https://github.com/cloudevents/sdk-go/issues/33

## client.Client API Changes

Modified Method:

```go
StartReceiver(ctx context.Context, fn Receiver) error
```

becomes

```go
StartReceiver(ctx context.Context, fn Receiver) (context.Context, error)
```

New Method: 

```go
StopReceiver(ctx context.Context) error
```




Signed-off-by: Scott Nichols <nicholss@google.com>