### PR TITLE
Add circleci badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Go SDK for [CloudEvents](https://github.com/cloudevents/spec)
 
 [![go-doc](https://godoc.org/github.com/cloudevents/sdk-go?status.svg)](https://godoc.org/github.com/cloudevents/sdk-go)
+[![CircleCI](https://circleci.com/gh/cloudevents/sdk-go.svg?style=svg)](https://circleci.com/gh/cloudevents/sdk-go)
 
 **NOTE: This SDK is still considered work in progress, things might (and will)
 break with every update.**


### PR DESCRIPTION
Now that automation is turned on for the repo we can show a status badge in the README.

Signed-off-by: Mark Peek <markpeek@vmware.com>