### PR TITLE
Pass headers from transport request setup to out-bound request.

### DIFF
--- a/cmd/samples/http/sender/main.go
+++ b/cmd/samples/http/sender/main.go
@@ -59,6 +59,7 @@ func _main(args []string, env envConfig) int {
 				log.Printf("failed to create transport, %v", err)
 				return 1
 			}
+
 			c, err := client.New(t,
 				client.WithTimeNow(),
 			)

--- a/cmd/samples/simple/http/receiver/main.go
+++ b/cmd/samples/simple/http/receiver/main.go
@@ -33,5 +33,5 @@ func gotEvent(event cloudevents.Event) {
 		return
 	}
 
-	fmt.Printf("%s: %d - %q\n", event.Context.GetType(), data.Sequence, data.Message)
+	fmt.Printf("%s", event)
 }

--- a/pkg/cloudevents/client/client_test.go
+++ b/pkg/cloudevents/client/client_test.go
@@ -25,6 +25,7 @@ var (
 		"accept-encoding",
 		"content-length",
 		"user-agent",
+		"connection",
 	}
 )
 

--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -2,6 +2,7 @@ package cloudevents_test
 
 import (
 	"encoding/json"
+	"fmt"
 	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
@@ -235,58 +236,160 @@ func TestString(t *testing.T) {
 			event: ce.Event{
 				Context: ce.EventContextV01{},
 			},
-			want: "SpecVersion: 0.1",
+			want: `Validation: invalid
+Validation Error: 
+eventType: MUST be a non-empty string
+cloudEventsVersion: MUST be a non-empty string
+source: REQUIRED
+eventID: MUST be a non-empty string
+Context Attributes,
+  cloudEventsVersion: 
+  eventType: 
+  source: 
+  eventID: 
+`,
 		},
 		"empty v0.2": {
 			event: ce.Event{
 				Context: ce.EventContextV02{},
 			},
-			want: "SpecVersion: 0.2",
+			want: `Validation: invalid
+Validation Error: 
+type: MUST be a non-empty string
+specversion: MUST be a non-empty string
+source: REQUIRED
+id: MUST be a non-empty string
+Context Attributes,
+  specversion: 
+  type: 
+  source: 
+  id: 
+`,
 		},
 		"empty v0.3": {
 			event: ce.Event{
 				Context: ce.EventContextV03{},
 			},
-			want: "SpecVersion: 0.3",
+			want: `Validation: invalid
+Validation Error: 
+type: MUST be a non-empty string
+specversion: MUST be a non-empty string
+source: REQUIRED
+id: MUST be a non-empty string
+Context Attributes,
+  specversion: 
+  type: 
+  source: 
+  id: 
+`,
 		},
 		"min v0.1": {
 			event: ce.Event{
 				Context: MinEventContextV01(),
 			},
-			want: "SpecVersion: 0.1\nType: com.example.simple",
+			want: `Validation: valid
+Context Attributes,
+  cloudEventsVersion: 0.1
+  eventType: com.example.simple
+  source: http://example.com/source
+  eventID: ABC-123
+`,
 		},
 		"min v0.2": {
 			event: ce.Event{
 				Context: MinEventContextV02(),
 			},
-			want: "SpecVersion: 0.2\nType: com.example.simple",
+			want: `Validation: valid
+Context Attributes,
+  specversion: 0.2
+  type: com.example.simple
+  source: http://example.com/source
+  id: ABC-123
+`,
 		},
 		"min v0.3": {
 			event: ce.Event{
 				Context: MinEventContextV03(),
 			},
-			want: "SpecVersion: 0.3\nType: com.example.simple",
+			want: `Validation: valid
+Context Attributes,
+  specversion: 0.3
+  type: com.example.simple
+  source: http://example.com/source
+  id: ABC-123
+`,
 		},
 		"json simple, v0.1": {
 			event: ce.Event{
 				Context: FullEventContextV01(now),
 				Data:    []byte(`{"a":"apple","b":"banana"}`),
 			},
-			want: "SpecVersion: 0.1\nType: com.example.simple\nDataContentType: application/json",
+			want: fmt.Sprintf(`Validation: valid
+Context Attributes,
+  cloudEventsVersion: 0.1
+  eventType: com.example.simple
+  eventTypeVersion: v1alpha1
+  source: http://example.com/source
+  eventID: ABC-123
+  eventTime: %s
+  schemaURL: http://example.com/schema
+  contentType: application/json
+Extensions,
+  test: extended
+Data,
+  {
+    "a": "apple",
+    "b": "banana"
+  }
+`, now.String()),
 		},
 		"json simple, v0.2": {
 			event: ce.Event{
 				Context: FullEventContextV02(now),
 				Data:    []byte(`{"a":"apple","b":"banana"}`),
 			},
-			want: "SpecVersion: 0.2\nType: com.example.simple\nDataContentType: application/json",
+			want: fmt.Sprintf(`Validation: valid
+Context Attributes,
+  specversion: 0.2
+  type: com.example.simple
+  source: http://example.com/source
+  id: ABC-123
+  time: %s
+  schemaurl: http://example.com/schema
+  contenttype: application/json
+Extensions,
+  eventTypeVersion: v1alpha1
+  test: extended
+Data,
+  {
+    "a": "apple",
+    "b": "banana"
+  }
+`, now.String()),
 		},
 		"json simple, v0.3": {
 			event: ce.Event{
 				Context: FullEventContextV03(now),
 				Data:    []byte(`{"a":"apple","b":"banana"}`),
 			},
-			want: "SpecVersion: 0.3\nType: com.example.simple\nDataContentType: application/json",
+			want: fmt.Sprintf(`Validation: valid
+Context Attributes,
+  specversion: 0.3
+  type: com.example.simple
+  source: http://example.com/source
+  id: ABC-123
+  time: %s
+  schemaurl: http://example.com/schema
+  datacontenttype: application/json
+Extensions,
+  eventTypeVersion: v1alpha1
+  test: extended
+Data,
+  {
+    "a": "apple",
+    "b": "banana"
+  }
+`, now.String()),
 		},
 	}
 	for n, tc := range testCases {
@@ -295,6 +398,7 @@ func TestString(t *testing.T) {
 			got := tc.event.String()
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Log(got)
 				t.Errorf("unexpected string (-want, +got) = %v", diff)
 			}
 		})

--- a/pkg/cloudevents/transport/http/context.go
+++ b/pkg/cloudevents/transport/http/context.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"strings"
 )
 
 // TransportContext allows a Receiver to understand the context of a request.
@@ -9,6 +10,17 @@ type TransportContext struct {
 	URI    string
 	Host   string
 	Method string
+}
+
+func (tx TransportContext) String() string {
+	b := strings.Builder{}
+
+	b.WriteString("Transport Context,\n")
+	b.WriteString("  URI: " + tx.URI + "\n")
+	b.WriteString("  Host: " + tx.Host + "\n")
+	b.WriteString("  Method: " + tx.Method + "\n")
+
+	return b.String()
 }
 
 // Opaque key type used to store TransportContext

--- a/pkg/cloudevents/transport/http/options.go
+++ b/pkg/cloudevents/transport/http/options.go
@@ -56,6 +56,28 @@ func WithMethod(method string) Option {
 	}
 }
 
+// WithHeader sets an additional default outbound header for all cloudevents
+// when using an HTTP request.
+func WithHeader(key, value string) Option {
+	return func(t *Transport) error {
+		if t == nil {
+			return fmt.Errorf("http header option can not set nil transport")
+		}
+		key = strings.TrimSpace(key)
+		if key != "" {
+			if t.Req == nil {
+				t.Req = &nethttp.Request{}
+			}
+			if t.Req.Header == nil {
+				t.Req.Header = nethttp.Header{}
+			}
+			t.Req.Header.Add(key, value)
+			return nil
+		}
+		return fmt.Errorf("http header option was empty string")
+	}
+}
+
 // WithEncoding sets the encoding for clients with HTTP transports.
 func WithEncoding(encoding Encoding) Option {
 	return func(t *Transport) error {

--- a/pkg/cloudevents/transport/http/options_test.go
+++ b/pkg/cloudevents/transport/http/options_test.go
@@ -166,6 +166,89 @@ func TestWithMethod(t *testing.T) {
 	}
 }
 
+func TestWithHeader(t *testing.T) {
+	testCases := map[string]struct {
+		t       *Transport
+		key     string
+		value   string
+		want    *Transport
+		wantErr string
+	}{
+		"valid header": {
+			t: &Transport{
+				Req: &http.Request{},
+			},
+			key:   "unit",
+			value: "test",
+			want: &Transport{
+				Req: &http.Request{
+					Header: http.Header{
+						"Unit": {
+							"test",
+						},
+					},
+				},
+			},
+		},
+		"valid header, unset req": {
+			t:     &Transport{},
+			key:   "unit",
+			value: "test",
+			want: &Transport{
+				Req: &http.Request{
+					Header: http.Header{
+						"Unit": {
+							"test",
+						},
+					},
+				},
+			},
+		},
+		"empty header key": {
+			t: &Transport{
+				Req: &http.Request{},
+			},
+			value:   "test",
+			wantErr: `http header option was empty string`,
+		},
+		"whitespace key": {
+			t: &Transport{
+				Req: &http.Request{},
+			},
+			key:     " \t\n",
+			value:   "test",
+			wantErr: `http header option was empty string`,
+		},
+		"nil transport": {
+			wantErr: `http header option can not set nil transport`,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.t.applyOptions(WithHeader(tc.key, tc.value))
+
+			if tc.wantErr != "" || err != nil {
+				var gotErr string
+				if err != nil {
+					gotErr = err.Error()
+				}
+				if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+					t.Errorf("unexpected error (-want, +got) = %v", diff)
+				}
+				return
+			}
+
+			got := tc.t
+
+			if diff := cmp.Diff(tc.want, got,
+				cmpopts.IgnoreUnexported(Transport{}), cmpopts.IgnoreUnexported(http.Request{})); diff != "" {
+				t.Errorf("unexpected (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
 func intptr(i int) *int {
 	return &i
 }

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -93,6 +93,13 @@ func (t *Transport) Send(ctx context.Context, event cloudevents.Event) (*cloudev
 	if t.Req != nil {
 		req.Method = t.Req.Method
 		req.URL = t.Req.URL
+		if t.Req.Header != nil && len(t.Req.Header) > 0 {
+			for header, values := range t.Req.Header {
+				for _, value := range values {
+					req.Header.Add(header, value)
+				}
+			}
+		}
 	}
 
 	// Override the default request with target from context.


### PR DESCRIPTION
This change adds the option for `httptransport.WithHeader(key, value)`. This will add a header to the outbound http request for custom http headers. 

Also added full pretty printing to help debug this for event and http TransportContext.

Supersedes https://github.com/cloudevents/sdk-go/pull/73

Thanks @matzew for pointing out the `req.Close` option, and for testing the client out!!


Signed-off-by: Scott Nichols <nicholss@google.com>
