### PR TITLE
Adding more documentation to the implementation.

### DIFF
--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -55,7 +55,7 @@ func New(t transport.Transport, opts ...Option) (Client, error) {
 // transport option applied to it. The client will always send Binary
 // encoding but will inspect the outbound event context and match the version.
 // The WithtimeNow and WithUUIDs client options are also applied to the client,
-// all outbound events will have a time and id set if not set.
+// all outbound events will have a time and id set if not already present.
 func NewDefault() (Client, error) {
 	t, err := http.New(http.WithBinaryEncoding())
 	if err != nil {

--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 )
 
+// Client interface defines the runtime contract the CloudEvents client supports.
 type Client interface {
 	// Send will transmit the given event over the client's configured transport.
 	Send(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, error)
@@ -36,6 +37,8 @@ type Client interface {
 	StartReceiver(ctx context.Context, fn interface{}) error
 }
 
+// New produces a new client with the provided transport object and applied
+// client options.
 func New(t transport.Transport, opts ...Option) (Client, error) {
 	c := &ceClient{
 		transport: t,
@@ -48,7 +51,11 @@ func New(t transport.Transport, opts ...Option) (Client, error) {
 }
 
 // NewDefault provides the good defaults for the common case using an HTTP
-// Transport client.
+// Transport client. The http transport has had WithBinaryEncoding http
+// transport option applied to it. The client will always send Binary
+// encoding but will inspect the outbound event context and match the version.
+// The WithtimeNow and WithUUIDs client options are also applied to the client,
+// all outbound events will have a time and id set if not set.
 func NewDefault() (Client, error) {
 	t, err := http.New(http.WithBinaryEncoding())
 	if err != nil {
@@ -69,8 +76,12 @@ type ceClient struct {
 	eventDefaulterFns []EventDefaulter
 }
 
+// Send transmits the provided event on a preconfigured Transport.
+// Send returns a response event if there is a response or an error if there
+// was an an issue validating the outbound event or the transport returns an
+// error.
 func (c *ceClient) Send(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, error) {
-	ctx, r := observability.NewReporter(ctx, ReportSend)
+	ctx, r := observability.NewReporter(ctx, reportSend)
 	resp, err := c.obsSend(ctx, event)
 	if err != nil {
 		r.Error()
@@ -101,7 +112,7 @@ func (c *ceClient) obsSend(ctx context.Context, event cloudevents.Event) (*cloud
 
 // Receive is called from from the transport on event delivery.
 func (c *ceClient) Receive(ctx context.Context, event cloudevents.Event, resp *cloudevents.EventResponse) error {
-	ctx, r := observability.NewReporter(ctx, ReportReceive)
+	ctx, r := observability.NewReporter(ctx, reportReceive)
 	err := c.obsReceive(ctx, event, resp)
 	if err != nil {
 		r.Error()
@@ -113,7 +124,7 @@ func (c *ceClient) Receive(ctx context.Context, event cloudevents.Event, resp *c
 
 func (c *ceClient) obsReceive(ctx context.Context, event cloudevents.Event, resp *cloudevents.EventResponse) error {
 	if c.fn != nil {
-		ctx, rFn := observability.NewReporter(ctx, ReportReceiveFn)
+		ctx, rFn := observability.NewReporter(ctx, reportReceiveFn)
 		err := c.fn.invoke(ctx, event, resp)
 		if err != nil {
 			rFn.Error()
@@ -136,7 +147,8 @@ func (c *ceClient) obsReceive(ctx context.Context, event cloudevents.Event, resp
 	return nil
 }
 
-// Blocking Call
+// StartReceiver sets up the given fn to handle Receive.
+// See Client.StartReceiver for details. This is a blocking call.
 func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 	c.receiverMu.Lock()
 	defer c.receiverMu.Unlock()

--- a/pkg/cloudevents/client/defaulters.go
+++ b/pkg/cloudevents/client/defaulters.go
@@ -11,7 +11,7 @@ import (
 // to perform event defaulting.
 type EventDefaulter func(event cloudevents.Event) cloudevents.Event
 
-// DefaultIDToUUIDIfNotSet will inspect provided event and assign a UUID to
+// DefaultIDToUUIDIfNotSet will inspect the provided event and assign a UUID to
 // context.ID if it is found to be empty.
 func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {

--- a/pkg/cloudevents/client/defaulters.go
+++ b/pkg/cloudevents/client/defaulters.go
@@ -7,8 +7,12 @@ import (
 	"time"
 )
 
+// EventDefaulter is the function signature for extensions that are able
+// to perform event defaulting.
 type EventDefaulter func(event cloudevents.Event) cloudevents.Event
 
+// DefaultIDToUUIDIfNotSet will inspect provided event and assign a UUID to
+// context.ID if it is found to be empty.
 func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {
 		switch event.Context.GetSpecVersion() {
@@ -35,6 +39,8 @@ func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 	return event
 }
 
+// DefaultTimeToNowIfNotSet will inspect the provided event and assign a new
+// Timestamp to context.Time if it is found to be nil or zero.
 func DefaultTimeToNowIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {
 		switch event.Context.GetSpecVersion() {

--- a/pkg/cloudevents/client/observability.go
+++ b/pkg/cloudevents/client/observability.go
@@ -11,7 +11,7 @@ var (
 )
 
 var (
-	// LatencyView is a OpenCensus view that shows client method latency.
+	// LatencyView is an OpenCensus view that shows client method latency.
 	LatencyView = &view.View{
 		Name:        "client/latency",
 		Measure:     latencyMs,

--- a/pkg/cloudevents/client/observability.go
+++ b/pkg/cloudevents/client/observability.go
@@ -7,53 +7,60 @@ import (
 )
 
 var (
-	LatencyMs = stats.Float64("client/latency", "The latency in milliseconds for the CloudEvents client methods.", "ms")
+	latencyMs = stats.Float64("client/latency", "The latency in milliseconds for the CloudEvents client methods.", "ms")
 )
 
 var (
+	// LatencyView is a OpenCensus view that shows client method latency.
 	LatencyView = &view.View{
 		Name:        "client/latency",
-		Measure:     LatencyMs,
+		Measure:     latencyMs,
 		Description: "The distribution of latency inside of client for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
 	}
 )
 
-type Observed int32
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
 
 const (
-	ReportSend Observed = iota
-	ReportReceive
-	ReportReceiveFn
+	reportSend observed = iota
+	reportReceive
+	reportReceiveFn
 )
 
-func (o Observed) TraceName() string {
+// TraceName implements Observable.TraceName
+func (o observed) TraceName() string {
 	switch o {
-	case ReportSend:
+	case reportSend:
 		return "client/send"
-	case ReportReceive:
+	case reportReceive:
 		return "client/receive"
-	case ReportReceiveFn:
+	case reportReceiveFn:
 		return "client/receive/fn"
 	default:
 		return "client/unknown"
 	}
 }
 
-func (o Observed) MethodName() string {
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
 	switch o {
-	case ReportSend:
+	case reportSend:
 		return "send"
-	case ReportReceive:
+	case reportReceive:
 		return "receive"
-	case ReportReceiveFn:
+	case reportReceiveFn:
 		return "receive/fn"
 	default:
 		return "unknown"
 	}
 }
 
-func (o Observed) LatencyMs() *stats.Float64Measure {
-	return LatencyMs
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return latencyMs
 }

--- a/pkg/cloudevents/codec/jsoncodec.go
+++ b/pkg/cloudevents/codec/jsoncodec.go
@@ -13,7 +13,7 @@ import (
 // JsonEncodeV01 takes in a cloudevent.Event and outputs the byte representation of that event using CloudEvents
 // version 0.1 structured json formatting rules.
 func JsonEncodeV01(e cloudevents.Event) ([]byte, error) {
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportEncode, v: "v0.1"})
+	_, r := observability.NewReporter(context.Background(), codecObserved{o: reportEncode, v: "v0.1"})
 	b, err := obsJsonEncodeV01(e)
 	if err != nil {
 		r.Error()
@@ -34,7 +34,7 @@ func obsJsonEncodeV01(e cloudevents.Event) ([]byte, error) {
 // JsonEncodeV02 takes in a cloudevent.Event and outputs the byte representation of that event using CloudEvents
 // version 0.2 structured json formatting rules.
 func JsonEncodeV02(e cloudevents.Event) ([]byte, error) {
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportEncode, v: "v0.2"})
+	_, r := observability.NewReporter(context.Background(), codecObserved{o: reportEncode, v: "v0.2"})
 	b, err := obsJsonEncodeV02(e)
 	if err != nil {
 		r.Error()
@@ -55,7 +55,7 @@ func obsJsonEncodeV02(e cloudevents.Event) ([]byte, error) {
 // JsonEncodeV03 takes in a cloudevent.Event and outputs the byte representation of that event using CloudEvents
 // version 0.3 structured json formatting rules.
 func JsonEncodeV03(e cloudevents.Event) ([]byte, error) {
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportEncode, v: "v0.3"})
+	_, r := observability.NewReporter(context.Background(), codecObserved{o: reportEncode, v: "v0.3"})
 	b, err := obsJsonEncodeV03(e)
 	if err != nil {
 		r.Error()
@@ -113,7 +113,7 @@ func jsonEncode(ctx cloudevents.EventContext, data interface{}) ([]byte, error) 
 // JsonDecodeV01 takes in the byte representation of a version 0.1 structured json CloudEvent and returns a
 // cloudevent.Event or an error if there are parsing errors.
 func JsonDecodeV01(body []byte) (*cloudevents.Event, error) {
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportDecode, v: "v0.1"})
+	_, r := observability.NewReporter(context.Background(), codecObserved{o: reportDecode, v: "v0.1"})
 	e, err := obsJsonDecodeV01(body)
 	if err != nil {
 		r.Error()
@@ -148,7 +148,7 @@ func obsJsonDecodeV01(body []byte) (*cloudevents.Event, error) {
 // JsonDecodeV02 takes in the byte representation of a version 0.2 structured json CloudEvent and returns a
 // cloudevent.Event or an error if there are parsing errors.
 func JsonDecodeV02(body []byte) (*cloudevents.Event, error) {
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportDecode, v: "v0.2"})
+	_, r := observability.NewReporter(context.Background(), codecObserved{o: reportDecode, v: "v0.2"})
 	e, err := obsJsonDecodeV02(body)
 	if err != nil {
 		r.Error()
@@ -183,7 +183,7 @@ func obsJsonDecodeV02(body []byte) (*cloudevents.Event, error) {
 // JsonDecodeV03 takes in the byte representation of a version 0.3 structured json CloudEvent and returns a
 // cloudevent.Event or an error if there are parsing errors.
 func JsonDecodeV03(body []byte) (*cloudevents.Event, error) {
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportDecode, v: "v0.3"})
+	_, r := observability.NewReporter(context.Background(), codecObserved{o: reportDecode, v: "v0.3"})
 	e, err := obsJsonDecodeV03(body)
 	if err != nil {
 		r.Error()

--- a/pkg/cloudevents/codec/observability.go
+++ b/pkg/cloudevents/codec/observability.go
@@ -8,68 +8,81 @@ import (
 )
 
 var (
-	LatencyMs = stats.Float64("codec/json/latency", "The latency in milliseconds for the CloudEvents json codec methods.", "ms")
+	latencyMs = stats.Float64("codec/json/latency", "The latency in milliseconds for the CloudEvents json codec methods.", "ms")
 )
 
 var (
+	// LatencyView is a OpenCensus view that shows codec/json method latency.
 	LatencyView = &view.View{
 		Name:        "codec/json/latency",
-		Measure:     LatencyMs,
+		Measure:     latencyMs,
 		Description: "The distribution of latency inside of the json codec for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
 	}
 )
 
-type Observed int32
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
 
 const (
-	ReportEncode Observed = iota
-	ReportDecode
+	reportEncode observed = iota
+	reportDecode
 )
 
-func (o Observed) TraceName() string {
+// TraceName implements Observable.TraceName
+func (o observed) TraceName() string {
 	switch o {
-	case ReportEncode:
+	case reportEncode:
 		return "codec/json/encode"
-	case ReportDecode:
+	case reportDecode:
 		return "codec/json/decode"
 	default:
 		return "codec/unknown"
 	}
 }
 
-func (o Observed) MethodName() string {
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
 	switch o {
-	case ReportEncode:
+	case reportEncode:
 		return "encode"
-	case ReportDecode:
+	case reportDecode:
 		return "decode"
 	default:
 		return "unknown"
 	}
 }
 
-func (o Observed) LatencyMs() *stats.Float64Measure {
-	return LatencyMs
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return latencyMs
 }
 
-// CodecObserved is a wrapper to append version to Observed.
-type CodecObserved struct {
+// codecObserved is a wrapper to append version to observed.
+type codecObserved struct {
 	// Method
-	o Observed
+	o observed
 	// Version
 	v string
 }
 
-func (c CodecObserved) TraceName() string {
+// Adheres to Observable
+var _ observability.Observable = (*codecObserved)(nil)
+
+// TraceName implements Observable.TraceName
+func (c codecObserved) TraceName() string {
 	return fmt.Sprintf("%s/%s", c.o.TraceName(), c.v)
 }
 
-func (c CodecObserved) MethodName() string {
+// MethodName implements Observable.MethodName
+func (c codecObserved) MethodName() string {
 	return fmt.Sprintf("%s/%s", c.o.MethodName(), c.v)
 }
 
-func (c CodecObserved) LatencyMs() *stats.Float64Measure {
+// LatencyMs implements Observable.LatencyMs
+func (c codecObserved) LatencyMs() *stats.Float64Measure {
 	return c.o.LatencyMs()
 }

--- a/pkg/cloudevents/codec/observability.go
+++ b/pkg/cloudevents/codec/observability.go
@@ -12,7 +12,7 @@ var (
 )
 
 var (
-	// LatencyView is a OpenCensus view that shows codec/json method latency.
+	// LatencyView is an OpenCensus view that shows codec/json method latency.
 	LatencyView = &view.View{
 		Name:        "codec/json/latency",
 		Measure:     latencyMs,

--- a/pkg/cloudevents/datacodec/codec.go
+++ b/pkg/cloudevents/datacodec/codec.go
@@ -50,7 +50,7 @@ func AddEncoder(contentType string, fn Encoder) {
 // content type.
 func Decode(contentType string, in, out interface{}) error {
 	// TODO: wire in context.
-	_, r := observability.NewReporter(context.Background(), ReportDecode)
+	_, r := observability.NewReporter(context.Background(), reportDecode)
 	err := obsDecode(contentType, in, out)
 	if err != nil {
 		r.Error()
@@ -72,7 +72,7 @@ func obsDecode(contentType string, in, out interface{}) error {
 // content type.
 func Encode(contentType string, in interface{}) ([]byte, error) {
 	// TODO: wire in context.
-	_, r := observability.NewReporter(context.Background(), ReportEncode)
+	_, r := observability.NewReporter(context.Background(), reportEncode)
 	b, err := obsEncode(contentType, in)
 	if err != nil {
 		r.Error()

--- a/pkg/cloudevents/datacodec/json/data.go
+++ b/pkg/cloudevents/datacodec/json/data.go
@@ -14,7 +14,7 @@ import (
 // to convert those bytes to `out`. Returns and error if this process fails.
 func Decode(in, out interface{}) error {
 	// TODO: wire in context.
-	_, r := observability.NewReporter(context.Background(), ReportDecode)
+	_, r := observability.NewReporter(context.Background(), reportDecode)
 	err := obsDecode(in, out)
 	if err != nil {
 		r.Error()
@@ -64,7 +64,7 @@ func obsDecode(in, out interface{}) error {
 // Or json.Marshal errors.
 func Encode(in interface{}) ([]byte, error) {
 	// TODO: wire in context.
-	_, r := observability.NewReporter(context.Background(), ReportEncode)
+	_, r := observability.NewReporter(context.Background(), reportEncode)
 	b, err := obsEncode(in)
 	if err != nil {
 		r.Error()

--- a/pkg/cloudevents/datacodec/json/observability.go
+++ b/pkg/cloudevents/datacodec/json/observability.go
@@ -7,48 +7,55 @@ import (
 )
 
 var (
-	LatencyMs = stats.Float64("datacodec/json/latency", "The latency in milliseconds for the CloudEvents json data codec methods.", "ms")
+	latencyMs = stats.Float64("datacodec/json/latency", "The latency in milliseconds for the CloudEvents json data codec methods.", "ms")
 )
 
 var (
+	// LatencyView is a OpenCensus view that shows data codec json method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/json/latency",
-		Measure:     LatencyMs,
+		Measure:     latencyMs,
 		Description: "The distribution of latency inside of the json data codec for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
 	}
 )
 
-type Observed int32
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
 
 const (
-	ReportEncode Observed = iota
-	ReportDecode
+	reportEncode observed = iota
+	reportDecode
 )
 
-func (o Observed) TraceName() string {
+// TraceName implements Observable.TraceName
+func (o observed) TraceName() string {
 	switch o {
-	case ReportEncode:
+	case reportEncode:
 		return "datacodec/json/encode"
-	case ReportDecode:
+	case reportDecode:
 		return "datacodec/json/decode"
 	default:
 		return "datacodec/json/unknown"
 	}
 }
 
-func (o Observed) MethodName() string {
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
 	switch o {
-	case ReportEncode:
+	case reportEncode:
 		return "encode"
-	case ReportDecode:
+	case reportDecode:
 		return "decode"
 	default:
 		return "unknown"
 	}
 }
 
-func (o Observed) LatencyMs() *stats.Float64Measure {
-	return LatencyMs
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return latencyMs
 }

--- a/pkg/cloudevents/datacodec/json/observability.go
+++ b/pkg/cloudevents/datacodec/json/observability.go
@@ -11,7 +11,7 @@ var (
 )
 
 var (
-	// LatencyView is a OpenCensus view that shows data codec json method latency.
+	// LatencyView is an OpenCensus view that shows data codec json method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/json/latency",
 		Measure:     latencyMs,

--- a/pkg/cloudevents/datacodec/observability.go
+++ b/pkg/cloudevents/datacodec/observability.go
@@ -11,7 +11,7 @@ var (
 )
 
 var (
-	// LatencyView is a OpenCensus view that shows data codec method latency.
+	// LatencyView is an OpenCensus view that shows data codec method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/latency",
 		Measure:     latencyMs,

--- a/pkg/cloudevents/datacodec/observability.go
+++ b/pkg/cloudevents/datacodec/observability.go
@@ -7,48 +7,55 @@ import (
 )
 
 var (
-	LatencyMs = stats.Float64("datacodec/latency", "The latency in milliseconds for the CloudEvents generic data codec methods.", "ms")
+	latencyMs = stats.Float64("datacodec/latency", "The latency in milliseconds for the CloudEvents generic data codec methods.", "ms")
 )
 
 var (
+	// LatencyView is a OpenCensus view that shows data codec method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/latency",
-		Measure:     LatencyMs,
+		Measure:     latencyMs,
 		Description: "The distribution of latency inside of the generic data codec for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
 	}
 )
 
-type Observed int32
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
 
 const (
-	ReportEncode Observed = iota
-	ReportDecode
+	reportEncode observed = iota
+	reportDecode
 )
 
-func (o Observed) TraceName() string {
+// TraceName implements Observable.TraceName
+func (o observed) TraceName() string {
 	switch o {
-	case ReportEncode:
+	case reportEncode:
 		return "datacodec/encode"
-	case ReportDecode:
+	case reportDecode:
 		return "datacodec/decode"
 	default:
 		return "datacodec/unknown"
 	}
 }
 
-func (o Observed) MethodName() string {
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
 	switch o {
-	case ReportEncode:
+	case reportEncode:
 		return "encode"
-	case ReportDecode:
+	case reportDecode:
 		return "decode"
 	default:
 		return "unknown"
 	}
 }
 
-func (o Observed) LatencyMs() *stats.Float64Measure {
-	return LatencyMs
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return latencyMs
 }

--- a/pkg/cloudevents/datacodec/xml/data.go
+++ b/pkg/cloudevents/datacodec/xml/data.go
@@ -14,7 +14,7 @@ import (
 // to convert those bytes to `out`. Returns and error if this process fails.
 func Decode(in, out interface{}) error {
 	// TODO: wire in context.
-	_, r := observability.NewReporter(context.Background(), ReportDecode)
+	_, r := observability.NewReporter(context.Background(), reportDecode)
 	err := obsDecode(in, out)
 	if err != nil {
 		r.Error()
@@ -69,7 +69,7 @@ func obsDecode(in, out interface{}) error {
 // Or xml.Marshal errors.
 func Encode(in interface{}) ([]byte, error) {
 	// TODO: wire in context.
-	_, r := observability.NewReporter(context.Background(), ReportEncode)
+	_, r := observability.NewReporter(context.Background(), reportEncode)
 	b, err := obsEncode(in)
 	if err != nil {
 		r.Error()

--- a/pkg/cloudevents/datacodec/xml/observability.go
+++ b/pkg/cloudevents/datacodec/xml/observability.go
@@ -11,7 +11,7 @@ var (
 )
 
 var (
-	// LatencyView is a OpenCensus view that shows data codec xml method latency.
+	// LatencyView is an OpenCensus view that shows data codec xml method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/xml/latency",
 		Measure:     latencyMs,

--- a/pkg/cloudevents/datacodec/xml/observability.go
+++ b/pkg/cloudevents/datacodec/xml/observability.go
@@ -7,48 +7,55 @@ import (
 )
 
 var (
-	LatencyMs = stats.Float64("datacodec/xml/latency", "The latency in milliseconds for the CloudEvents xml data codec methods.", "ms")
+	latencyMs = stats.Float64("datacodec/xml/latency", "The latency in milliseconds for the CloudEvents xml data codec methods.", "ms")
 )
 
 var (
+	// LatencyView is a OpenCensus view that shows data codec xml method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/xml/latency",
-		Measure:     LatencyMs,
+		Measure:     latencyMs,
 		Description: "The distribution of latency inside of the xml data codec for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
 	}
 )
 
-type Observed int32
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
 
 const (
-	ReportEncode Observed = iota
-	ReportDecode
+	reportEncode observed = iota
+	reportDecode
 )
 
-func (o Observed) TraceName() string {
+// TraceName implements Observable.TraceName
+func (o observed) TraceName() string {
 	switch o {
-	case ReportEncode:
+	case reportEncode:
 		return "datacodec/xml/encode"
-	case ReportDecode:
+	case reportDecode:
 		return "datacodec/xml/decode"
 	default:
 		return "datacodec/xml/unknown"
 	}
 }
 
-func (o Observed) MethodName() string {
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
 	switch o {
-	case ReportEncode:
+	case reportEncode:
 		return "encode"
-	case ReportDecode:
+	case reportDecode:
 		return "decode"
 	default:
 		return "unknown"
 	}
 }
 
-func (o Observed) LatencyMs() *stats.Float64Measure {
-	return LatencyMs
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return latencyMs
 }

--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -15,22 +15,29 @@ type Event struct {
 	Data    interface{}
 }
 
+// DataAs attempts to populate the provided data object with the event payload.
+// data should be a pointer type.
 func (e Event) DataAs(data interface{}) error {
 	return datacodec.Decode(e.Context.GetDataMediaType(), e.Data, data)
 }
 
+// SpecVersion returns Context.GetSpecVersion()
 func (e Event) SpecVersion() string {
 	return e.Context.GetSpecVersion()
 }
 
+// Type returns Context.GetType()
 func (e Event) Type() string {
 	return e.Context.GetType()
 }
 
+// DataContentType returns Context.getDataContentType()
 func (e Event) DataContentType() string {
 	return e.Context.GetDataContentType()
 }
 
+// Validate performs a spec based validation on this event.
+// Validation is dependent on the spec version specified in the event context.
 func (e Event) Validate() error {
 	if e.Context == nil {
 		return fmt.Errorf("every event conforming to the CloudEvents specification MUST include a context")
@@ -45,6 +52,7 @@ func (e Event) Validate() error {
 	return nil
 }
 
+// String returns a pretty-printed representation of the Event.
 func (e Event) String() string {
 	b := strings.Builder{}
 
@@ -63,6 +71,8 @@ func (e Event) String() string {
 	b.WriteString("Context Attributes,\n")
 
 	var extensions map[string]interface{}
+
+	// TODO: This impl detail should be pushed into the impl structs.
 
 	switch e.SpecVersion() {
 	case CloudEventsVersionV01:

--- a/pkg/cloudevents/event_response.go
+++ b/pkg/cloudevents/event_response.go
@@ -1,13 +1,15 @@
 package cloudevents
 
 // EventResponse represents the canonical representation of a Response to a
-// CloudEvent from a receiver.
+// CloudEvent from a receiver. Response implementation is Transport dependent.
 type EventResponse struct {
 	Status int
 	Event  *Event
 	Reason string
 }
 
+// RespondWith sets up the instance of EventResponse to be set with status and
+// an event. Response implementation is Transport dependent.
 func (e *EventResponse) RespondWith(status int, event *Event) {
 	if e == nil {
 		// if nil, response not supported
@@ -19,6 +21,8 @@ func (e *EventResponse) RespondWith(status int, event *Event) {
 	}
 }
 
+// Error sets the instance of EventResponse to be set with an error code and
+// reason string. Response implementation is Transport dependent.
 func (e *EventResponse) Error(status int, reason string) {
 	if e == nil {
 		// if nil, response not supported

--- a/pkg/cloudevents/eventcontext.go
+++ b/pkg/cloudevents/eventcontext.go
@@ -30,5 +30,7 @@ type EventContext interface {
 	// GetType returns the CloudEvents type from the context.
 	GetType() string
 
+	// Validate the event based on the specifics of the CloudEvents spec version
+	// represented by this event context.
 	Validate() error
 }

--- a/pkg/cloudevents/eventcontext_v01.go
+++ b/pkg/cloudevents/eventcontext_v01.go
@@ -38,8 +38,10 @@ type EventContextV01 struct {
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 
+// Adhere to EventContext
 var _ EventContext = (*EventContextV01)(nil)
 
+// GetSpecVersion implements EventContext.GetSpecVersion
 func (ec EventContextV01) GetSpecVersion() string {
 	if ec.CloudEventsVersion != "" {
 		return ec.CloudEventsVersion
@@ -47,6 +49,7 @@ func (ec EventContextV01) GetSpecVersion() string {
 	return CloudEventsVersionV01
 }
 
+// GetDataContentType implements EventContext.GetDataContentType
 func (ec EventContextV01) GetDataContentType() string {
 	if ec.ContentType != nil {
 		return *ec.ContentType
@@ -54,6 +57,7 @@ func (ec EventContextV01) GetDataContentType() string {
 	return ""
 }
 
+// GetDataMediaType implements EventContext.GetDataMediaType
 func (ec EventContextV01) GetDataMediaType() string {
 	if ec.ContentType != nil {
 		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
@@ -66,15 +70,18 @@ func (ec EventContextV01) GetDataMediaType() string {
 	return ""
 }
 
+// GetType implements EventContext.GetType
 func (ec EventContextV01) GetType() string {
 	return ec.EventType
 }
 
+// AsV01 implements EventContext.AsV01
 func (ec EventContextV01) AsV01() EventContextV01 {
 	ec.CloudEventsVersion = CloudEventsVersionV01
 	return ec
 }
 
+// AsV02 implements EventContext.AsV02
 func (ec EventContextV01) AsV02() EventContextV02 {
 	ret := EventContextV02{
 		SpecVersion: CloudEventsVersionV02,
@@ -102,6 +109,7 @@ func (ec EventContextV01) AsV02() EventContextV02 {
 	return ret
 }
 
+// AsV03 implements EventContext.AsV03
 func (ec EventContextV01) AsV03() EventContextV03 {
 	ecv2 := ec.AsV02()
 	return ecv2.AsV03()

--- a/pkg/cloudevents/eventcontext_v02.go
+++ b/pkg/cloudevents/eventcontext_v02.go
@@ -35,8 +35,10 @@ type EventContextV02 struct {
 	Extensions map[string]interface{} `json:"-,omitempty"` // TODO: decide how we want extensions to be inserted
 }
 
+// Adhere to EventContext
 var _ EventContext = (*EventContextV02)(nil)
 
+// GetSpecVersion implements EventContext.GetSpecVersion
 func (ec EventContextV02) GetSpecVersion() string {
 	if ec.SpecVersion != "" {
 		return ec.SpecVersion
@@ -44,6 +46,7 @@ func (ec EventContextV02) GetSpecVersion() string {
 	return CloudEventsVersionV02
 }
 
+// GetDataContentType implements EventContext.GetDataContentType
 func (ec EventContextV02) GetDataContentType() string {
 	if ec.ContentType != nil {
 		return *ec.ContentType
@@ -51,6 +54,7 @@ func (ec EventContextV02) GetDataContentType() string {
 	return ""
 }
 
+// GetDataMediaType implements EventContext.GetDataMediaType
 func (ec EventContextV02) GetDataMediaType() string {
 	if ec.ContentType != nil {
 		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
@@ -63,10 +67,12 @@ func (ec EventContextV02) GetDataMediaType() string {
 	return ""
 }
 
+// GetType implements EventContext.GetType
 func (ec EventContextV02) GetType() string {
 	return ec.Type
 }
 
+// AsV01 implements EventContext.AsV01
 func (ec EventContextV02) AsV01() EventContextV01 {
 	ret := EventContextV01{
 		CloudEventsVersion: CloudEventsVersionV01,
@@ -96,11 +102,13 @@ func (ec EventContextV02) AsV01() EventContextV01 {
 	return ret
 }
 
+// AsV02 implements EventContext.AsV02
 func (ec EventContextV02) AsV02() EventContextV02 {
 	ec.SpecVersion = CloudEventsVersionV02
 	return ec
 }
 
+// AsV03 implements EventContext.AsV03
 func (ec EventContextV02) AsV03() EventContextV03 {
 	ret := EventContextV03{
 		SpecVersion:     CloudEventsVersionV03,

--- a/pkg/cloudevents/eventcontext_v03.go
+++ b/pkg/cloudevents/eventcontext_v03.go
@@ -37,8 +37,10 @@ type EventContextV03 struct {
 	Extensions map[string]interface{} `json:"-,omitempty"` // TODO: decide how we want extensions to be inserted
 }
 
+// Adhere to EventContext
 var _ EventContext = (*EventContextV03)(nil)
 
+// GetSpecVersion implements EventContext.GetSpecVersion
 func (ec EventContextV03) GetSpecVersion() string {
 	if ec.SpecVersion != "" {
 		return ec.SpecVersion
@@ -46,6 +48,7 @@ func (ec EventContextV03) GetSpecVersion() string {
 	return CloudEventsVersionV03
 }
 
+// GetDataContentType implements EventContext.GetDataContentType
 func (ec EventContextV03) GetDataContentType() string {
 	if ec.DataContentType != nil {
 		return *ec.DataContentType
@@ -53,6 +56,7 @@ func (ec EventContextV03) GetDataContentType() string {
 	return ""
 }
 
+// GetDataMediaType implements EventContext.GetDataMediaType
 func (ec EventContextV03) GetDataMediaType() string {
 	if ec.DataContentType != nil {
 		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
@@ -64,15 +68,19 @@ func (ec EventContextV03) GetDataMediaType() string {
 	}
 	return ""
 }
+
+// GetType implements EventContext.GetType
 func (ec EventContextV03) GetType() string {
 	return ec.Type
 }
 
+// AsV01 implements EventContext.AsV01
 func (ec EventContextV03) AsV01() EventContextV01 {
 	ecv2 := ec.AsV02()
 	return ecv2.AsV01()
 }
 
+// AsV02 implements EventContext.AsV02
 func (ec EventContextV03) AsV02() EventContextV02 {
 	ret := EventContextV02{
 		SpecVersion: CloudEventsVersionV02,
@@ -87,6 +95,7 @@ func (ec EventContextV03) AsV02() EventContextV02 {
 	return ret
 }
 
+// AsV03 implements EventContext.AsV03
 func (ec EventContextV03) AsV03() EventContextV03 {
 	ec.SpecVersion = CloudEventsVersionV03
 	return ec

--- a/pkg/cloudevents/transport/http/codec.go
+++ b/pkg/cloudevents/transport/http/codec.go
@@ -19,6 +19,8 @@ type Codec struct {
 
 var _ transport.Codec = (*Codec)(nil)
 
+// DefaultBinaryEncodingSelectionStrategy implements a selection process for
+// which binary encoding to use based on spec version of the event.
 func DefaultBinaryEncodingSelectionStrategy(e cloudevents.Event) Encoding {
 	switch e.SpecVersion() {
 	case cloudevents.CloudEventsVersionV01:
@@ -32,6 +34,8 @@ func DefaultBinaryEncodingSelectionStrategy(e cloudevents.Event) Encoding {
 	return Default
 }
 
+// DefaultStructuredEncodingSelectionStrategy implements a selection process
+// for which structured encoding to use based on spec version of the event.
 func DefaultStructuredEncodingSelectionStrategy(e cloudevents.Event) Encoding {
 	switch e.SpecVersion() {
 	case cloudevents.CloudEventsVersionV01:
@@ -45,6 +49,7 @@ func DefaultStructuredEncodingSelectionStrategy(e cloudevents.Event) Encoding {
 	return Default
 }
 
+// Encode encodes the provided event into a transport message.
 func (c *Codec) Encode(e cloudevents.Event) (transport.Message, error) {
 	encoding := c.Encoding
 
@@ -81,6 +86,7 @@ func (c *Codec) Encode(e cloudevents.Event) (transport.Message, error) {
 	}
 }
 
+// Decode converts a provided transport message into an Event, or error.
 func (c *Codec) Decode(msg transport.Message) (*cloudevents.Event, error) {
 	switch c.inspectEncoding(msg) {
 	case BinaryV01:

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -23,7 +23,7 @@ var _ transport.Codec = (*CodecV01)(nil)
 
 func (v CodecV01) Encode(e cloudevents.Event) (transport.Message, error) {
 	// TODO: wire context
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportEncode, c: v.Encoding.Codec()})
+	_, r := observability.NewReporter(context.Background(), CodecObserved{o: reportEncode, c: v.Encoding.Codec()})
 	m, err := v.obsEncode(e)
 	if err != nil {
 		r.Error()
@@ -48,7 +48,7 @@ func (v CodecV01) obsEncode(e cloudevents.Event) (transport.Message, error) {
 
 func (v CodecV01) Decode(msg transport.Message) (*cloudevents.Event, error) {
 	// TODO: wire context
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportDecode, c: v.inspectEncoding(msg).Codec()}) // TODO: inspectEncoding is not free.
+	_, r := observability.NewReporter(context.Background(), CodecObserved{o: reportDecode, c: v.inspectEncoding(msg).Codec()}) // TODO: inspectEncoding is not free.
 	e, err := v.obsDecode(msg)
 	if err != nil {
 		r.Error()

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -23,7 +23,7 @@ var _ transport.Codec = (*CodecV02)(nil)
 
 func (v CodecV02) Encode(e cloudevents.Event) (transport.Message, error) {
 	// TODO: wire context
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportEncode, c: v.Encoding.Codec()})
+	_, r := observability.NewReporter(context.Background(), CodecObserved{o: reportEncode, c: v.Encoding.Codec()})
 	m, err := v.obsEncode(e)
 	if err != nil {
 		r.Error()
@@ -48,7 +48,7 @@ func (v CodecV02) obsEncode(e cloudevents.Event) (transport.Message, error) {
 
 func (v CodecV02) Decode(msg transport.Message) (*cloudevents.Event, error) {
 	// TODO: wire context
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportDecode, c: v.inspectEncoding(msg).Codec()}) // TODO: inspectEncoding is not free.
+	_, r := observability.NewReporter(context.Background(), CodecObserved{o: reportDecode, c: v.inspectEncoding(msg).Codec()}) // TODO: inspectEncoding is not free.
 	e, err := v.obsDecode(msg)
 	if err != nil {
 		r.Error()

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -23,7 +23,7 @@ var _ transport.Codec = (*CodecV03)(nil)
 
 func (v CodecV03) Encode(e cloudevents.Event) (transport.Message, error) {
 	// TODO: wire context
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportEncode, c: v.Encoding.Codec()})
+	_, r := observability.NewReporter(context.Background(), CodecObserved{o: reportEncode, c: v.Encoding.Codec()})
 	m, err := v.obsEncode(e)
 	if err != nil {
 		r.Error()
@@ -50,7 +50,7 @@ func (v CodecV03) obsEncode(e cloudevents.Event) (transport.Message, error) {
 
 func (v CodecV03) Decode(msg transport.Message) (*cloudevents.Event, error) {
 	// TODO: wire context
-	_, r := observability.NewReporter(context.Background(), CodecObserved{o: ReportDecode, c: v.inspectEncoding(msg).Codec()}) // TODO: inspectEncoding is not free.
+	_, r := observability.NewReporter(context.Background(), CodecObserved{o: reportDecode, c: v.inspectEncoding(msg).Codec()}) // TODO: inspectEncoding is not free.
 	e, err := v.obsDecode(msg)
 	if err != nil {
 		r.Error()

--- a/pkg/cloudevents/transport/http/message.go
+++ b/pkg/cloudevents/transport/http/message.go
@@ -9,17 +9,21 @@ import (
 // type check that this transport message impl matches the contract
 var _ transport.Message = (*Message)(nil)
 
+// Message is a http transport message.
 type Message struct {
 	Header http.Header
 	Body   []byte
 }
 
+// Response is a http transport response.
 type Response struct {
 	StatusCode int
 	Header     http.Header
 	Body       []byte
 }
 
+// CloudEventsVersion inspects a message and tries to discover and return the
+// CloudEvents spec version.
 func (m Message) CloudEventsVersion() string {
 
 	// TODO: the impl of this method needs to move into the codec.

--- a/pkg/cloudevents/transport/http/message.go
+++ b/pkg/cloudevents/transport/http/message.go
@@ -9,13 +9,13 @@ import (
 // type check that this transport message impl matches the contract
 var _ transport.Message = (*Message)(nil)
 
-// Message is a http transport message.
+// Message is an http transport message.
 type Message struct {
 	Header http.Header
 	Body   []byte
 }
 
-// Response is a http transport response.
+// Response is an http transport response.
 type Response struct {
 	StatusCode int
 	Header     http.Header

--- a/pkg/cloudevents/transport/http/observability.go
+++ b/pkg/cloudevents/transport/http/observability.go
@@ -15,7 +15,7 @@ var (
 )
 
 var (
-	// LatencyView is a OpenCensus view that shows http transport method latency.
+	// LatencyView is an OpenCensus view that shows http transport method latency.
 	LatencyView = &view.View{
 		Name:        "transport/http/latency",
 		Measure:     latencyMs,

--- a/pkg/cloudevents/transport/http/observability.go
+++ b/pkg/cloudevents/transport/http/observability.go
@@ -8,86 +8,99 @@ import (
 )
 
 var (
-	LatencyMs = stats.Float64(
+	latencyMs = stats.Float64(
 		"transport/http/latency",
 		"The latency in milliseconds for the http transport methods for CloudEvents.",
 		"ms")
 )
 
 var (
+	// LatencyView is a OpenCensus view that shows http transport method latency.
 	LatencyView = &view.View{
 		Name:        "transport/http/latency",
-		Measure:     LatencyMs,
+		Measure:     latencyMs,
 		Description: "The distribution of latency inside of http transport for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
 	}
 )
 
-type Observed int32
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
 
 const (
-	ReportSend Observed = iota
-	ReportReceive
-	ReportServeHTTP
-	ReportEncode
-	ReportDecode
+	reportSend observed = iota
+	reportReceive
+	reportServeHTTP
+	reportEncode
+	reportDecode
 )
 
-func (o Observed) TraceName() string {
+// TraceName implements Observable.TraceName
+func (o observed) TraceName() string {
 	switch o {
-	case ReportSend:
+	case reportSend:
 		return "transport/http/send"
-	case ReportReceive:
+	case reportReceive:
 		return "transport/http/receive"
-	case ReportServeHTTP:
+	case reportServeHTTP:
 		return "transport/http/servehttp"
-	case ReportEncode:
+	case reportEncode:
 		return "transport/http/encode"
-	case ReportDecode:
+	case reportDecode:
 		return "transport/http/decode"
 	default:
 		return "transport/http/unknown"
 	}
 }
 
-func (o Observed) MethodName() string {
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
 	switch o {
-	case ReportSend:
+	case reportSend:
 		return "send"
-	case ReportReceive:
+	case reportReceive:
 		return "receive"
-	case ReportServeHTTP:
+	case reportServeHTTP:
 		return "servehttp"
-	case ReportEncode:
+	case reportEncode:
 		return "encode"
-	case ReportDecode:
+	case reportDecode:
 		return "decode"
 	default:
 		return "unknown"
 	}
 }
 
-func (o Observed) LatencyMs() *stats.Float64Measure {
-	return LatencyMs
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return latencyMs
 }
 
-// CodecObserved is a wrapper to append version to Observed.
+// CodecObserved is a wrapper to append version to observed.
 type CodecObserved struct {
 	// Method
-	o Observed
+	o observed
 	// Codec
 	c string
 }
 
+// Adheres to Observable
+var _ observability.Observable = (*CodecObserved)(nil)
+
+// TraceName implements Observable.TraceName
 func (c CodecObserved) TraceName() string {
 	return fmt.Sprintf("%s/%s", c.o.TraceName(), c.c)
 }
 
+// MethodName implements Observable.MethodName
 func (c CodecObserved) MethodName() string {
 	return fmt.Sprintf("%s/%s", c.o.MethodName(), c.c)
 }
 
+// LatencyMs implements Observable.LatencyMs
 func (c CodecObserved) LatencyMs() *stats.Float64Measure {
 	return c.o.LatencyMs()
 }

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -95,7 +95,7 @@ func copyHeaders(from, to http.Header) {
 }
 
 func (t *Transport) Send(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, error) {
-	ctx, r := observability.NewReporter(ctx, ReportSend)
+	ctx, r := observability.NewReporter(ctx, reportSend)
 	resp, err := t.obsSend(ctx, event)
 	if err != nil {
 		r.Error()
@@ -264,7 +264,7 @@ func status(resp *http.Response) string {
 }
 
 func (t *Transport) invokeReceiver(ctx context.Context, event cloudevents.Event) (*Response, error) {
-	ctx, r := observability.NewReporter(ctx, ReportReceive)
+	ctx, r := observability.NewReporter(ctx, reportReceive)
 	resp, err := t.obsInvokeReceiver(ctx, event)
 	if err != nil {
 		r.Error()
@@ -314,7 +314,7 @@ func (t *Transport) obsInvokeReceiver(ctx context.Context, event cloudevents.Eve
 
 // ServeHTTP implements http.Handler
 func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	ctx, r := observability.NewReporter(req.Context(), ReportServeHTTP)
+	ctx, r := observability.NewReporter(req.Context(), reportServeHTTP)
 
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -24,18 +24,33 @@ var _ transport.Transport = (*Transport)(nil)
 
 // Transport acts as both a http client and a http handler.
 type Transport struct {
-	Encoding                   Encoding
+	// The encoding used to select the codec for outbound events.
+	Encoding Encoding
+	// DefaultEncodingSelectionFn allows for other encoding selection strategies to be injected.
 	DefaultEncodingSelectionFn EncodingSelector
 
 	// Sending
+
+	// Client is the http client that will be used to send requests.
+	// If nil, the Transport will create a one.
 	Client *http.Client
-	Req    *http.Request
+	// Req is the base http request that is used for http.Do.
+	// Only .Method, .URL, and .Header is considered.
+	// If not set, Req.Method defaults to POST.
+	// Req.URL or context.WithTarget(url) are required for sending.
+	Req *http.Request
 
 	// Receiving
+
+	// Receiver is invoked target for incoming events.
 	Receiver transport.Receiver
-	Port     *int   // if nil, default 8080
-	Path     string // if "", default "/"
-	Handler  *http.ServeMux
+	// Port is the port to bind the receiver to. Defaults to 8080.
+	Port *int
+	// Path is the path to bind the receiver to. Defaults to "/".
+	Path string
+	// Handler is the handler the http Server will use. Use this to reuse the
+	// http server. If nil, the Transport will create a one.
+	Handler *http.ServeMux
 
 	realPort          int
 	server            *http.Server

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -404,6 +404,9 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.OK()
 }
 
+// GetPort returns the port the transport is active on.
+// .Port can be set to 0, which means the transport selects a port, GetPort
+// allows the transport to report back the selected port.
 func (t *Transport) GetPort() int {
 	if t.Port != nil && *t.Port == 0 && t.realPort != 0 {
 		return t.realPort
@@ -415,6 +418,10 @@ func (t *Transport) GetPort() int {
 	return 8080 // default
 }
 
+// GetPath returns the path the transport is hosted on. If the path is '/',
+// the transport will handle requests on any URI. To discover the true path
+// a request was received on, inspect the context from Receive(cxt, ...) with
+// TransportContextFrom(ctx).
 func (t *Transport) GetPath() string {
 	path := strings.TrimSpace(t.Path)
 	if len(path) > 0 {

--- a/pkg/cloudevents/transport/transport.go
+++ b/pkg/cloudevents/transport/transport.go
@@ -14,6 +14,8 @@ type Transport interface {
 	StartReceiver(context.Context) error
 }
 
+// Receiver is an interface to define how a transport will invoke a listener
+// of incoming events.
 type Receiver interface {
 	Receive(context.Context, cloudevents.Event, *cloudevents.EventResponse) error
 }


### PR DESCRIPTION
Second pass adding godocs to exported methods and variables. Un-exporting metrics helpers.

Fixes https://github.com/cloudevents/sdk-go/issues/70
Fixes https://github.com/cloudevents/sdk-go/issues/49