### PR TITLE
Adding ExtensionAs and SetExtension methods

### DIFF
--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -31,6 +31,11 @@ func (e Event) Type() string {
 	return e.Context.GetType()
 }
 
+// ExtensionAs returns Context.ExtensionAs(name, obj)
+func (e Event) ExtensionAs(name string, obj interface{}) error {
+	return e.Context.ExtensionAs(name, obj)
+}
+
 // DataContentType returns Context.getDataContentType()
 func (e Event) DataContentType() string {
 	return e.Context.GetDataContentType()

--- a/pkg/cloudevents/eventcontext.go
+++ b/pkg/cloudevents/eventcontext.go
@@ -30,6 +30,11 @@ type EventContext interface {
 	// GetType returns the CloudEvents type from the context.
 	GetType() string
 
+	// ExtensionAs populates 'obj' with the CloudEvents extension 'name' from the context.
+	// It returns an error if the extension 'name' does not exist, the extension's type
+	// does not match the 'obj' type, or if the 'obj' type is not a supported.
+	ExtensionAs(name string, obj interface{}) error
+
 	// Validate the event based on the specifics of the CloudEvents spec version
 	// represented by this event context.
 	Validate() error

--- a/pkg/cloudevents/eventcontext_v01.go
+++ b/pkg/cloudevents/eventcontext_v01.go
@@ -75,6 +75,34 @@ func (ec EventContextV01) GetType() string {
 	return ec.EventType
 }
 
+// ExtensionAs implements EventContext.ExtensionAs
+func (ec EventContextV01) ExtensionAs(name string, obj interface{}) error {
+	value, ok := ec.Extensions[name]
+	if !ok {
+		return fmt.Errorf("extension %q does not exist", name)
+	}
+	// Only support *string for now.
+	switch v := obj.(type) {
+	case *string:
+		if valueAsString, ok := value.(string); ok {
+			*v = valueAsString
+			return nil
+		} else {
+			return fmt.Errorf("invalid type for extension %q", name)
+		}
+	default:
+		return fmt.Errorf("unkown extension type %T", obj)
+	}
+}
+
+// SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
+func (ec *EventContextV01) SetExtension(name string, value interface{}) {
+	if ec.Extensions == nil {
+		ec.Extensions = make(map[string]interface{})
+	}
+	ec.Extensions[name] = value
+}
+
 // AsV01 implements EventContext.AsV01
 func (ec EventContextV01) AsV01() EventContextV01 {
 	ec.CloudEventsVersion = CloudEventsVersionV01

--- a/pkg/cloudevents/eventcontext_v02.go
+++ b/pkg/cloudevents/eventcontext_v02.go
@@ -72,6 +72,34 @@ func (ec EventContextV02) GetType() string {
 	return ec.Type
 }
 
+// ExtensionAs implements EventContext.ExtensionAs
+func (ec EventContextV02) ExtensionAs(name string, obj interface{}) error {
+	value, ok := ec.Extensions[name]
+	if !ok {
+		return fmt.Errorf("extension %q does not exist", name)
+	}
+	// Only support *string for now.
+	switch v := obj.(type) {
+	case *string:
+		if valueAsString, ok := value.(string); ok {
+			*v = valueAsString
+			return nil
+		} else {
+			return fmt.Errorf("invalid type for extension %q", name)
+		}
+	default:
+		return fmt.Errorf("unkown extension type %T", obj)
+	}
+}
+
+// SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
+func (ec *EventContextV02) SetExtension(name string, value interface{}) {
+	if ec.Extensions == nil {
+		ec.Extensions = make(map[string]interface{})
+	}
+	ec.Extensions[name] = value
+}
+
 // AsV01 implements EventContext.AsV01
 func (ec EventContextV02) AsV01() EventContextV01 {
 	ret := EventContextV01{

--- a/pkg/cloudevents/eventcontext_v03.go
+++ b/pkg/cloudevents/eventcontext_v03.go
@@ -74,6 +74,34 @@ func (ec EventContextV03) GetType() string {
 	return ec.Type
 }
 
+// ExtensionAs implements EventContext.ExtensionAs
+func (ec EventContextV03) ExtensionAs(name string, obj interface{}) error {
+	value, ok := ec.Extensions[name]
+	if !ok {
+		return fmt.Errorf("extension %q does not exist", name)
+	}
+	// Only support *string for now.
+	switch v := obj.(type) {
+	case *string:
+		if valueAsString, ok := value.(string); ok {
+			*v = valueAsString
+			return nil
+		} else {
+			return fmt.Errorf("invalid type for extension %q", name)
+		}
+	default:
+		return fmt.Errorf("unkown extension type %T", obj)
+	}
+}
+
+// SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
+func (ec *EventContextV03) SetExtension(name string, value interface{}) {
+	if ec.Extensions == nil {
+		ec.Extensions = make(map[string]interface{})
+	}
+	ec.Extensions[name] = value
+}
+
 // AsV01 implements EventContext.AsV01
 func (ec EventContextV03) AsV01() EventContextV01 {
 	ecv2 := ec.AsV02()


### PR DESCRIPTION
**Proposed Changes**

* Adding an ExtensionAs(string, interface{}) function as part of EventContext interface to easily read extension attributes. Only supports decoding string extensions. Might need to use something like DataAs decoding functionality to avoid duplicating code, and better support multiple extension types.
* Adding a SetExtension(string, interface{}) function to every EventContextV* struct. As it mutates the underlying map, we need a pointer receiver, thus I couldn't add it as part of the EventContext interface.