### PR TITLE
Qualify stat names to avoid collisions

### DIFF
--- a/pkg/cloudevents/client/observability.go
+++ b/pkg/cloudevents/client/observability.go
@@ -7,14 +7,16 @@ import (
 )
 
 var (
-	latencyMs = stats.Float64("client/latency", "The latency in milliseconds for the CloudEvents client methods.", "ms")
+	// LatencyMs measures the latency in milliseconds for the CloudEvents
+	// client methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/client/latency", "The latency in milliseconds for the CloudEvents client methods.", "ms")
 )
 
 var (
 	// LatencyView is an OpenCensus view that shows client method latency.
 	LatencyView = &view.View{
 		Name:        "client/latency",
-		Measure:     latencyMs,
+		Measure:     LatencyMs,
 		Description: "The distribution of latency inside of client for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
@@ -62,5 +64,5 @@ func (o observed) MethodName() string {
 
 // LatencyMs implements Observable.LatencyMs
 func (o observed) LatencyMs() *stats.Float64Measure {
-	return latencyMs
+	return LatencyMs
 }

--- a/pkg/cloudevents/codec/observability.go
+++ b/pkg/cloudevents/codec/observability.go
@@ -2,20 +2,22 @@ package codec
 
 import (
 	"fmt"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 )
 
 var (
-	latencyMs = stats.Float64("codec/json/latency", "The latency in milliseconds for the CloudEvents json codec methods.", "ms")
+	// LatencyMs measures the latency in milliseconds for the CloudEvents json codec methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/codec/json/latency", "The latency in milliseconds for the CloudEvents json codec methods.", "ms")
 )
 
 var (
 	// LatencyView is an OpenCensus view that shows codec/json method latency.
 	LatencyView = &view.View{
 		Name:        "codec/json/latency",
-		Measure:     latencyMs,
+		Measure:     LatencyMs,
 		Description: "The distribution of latency inside of the json codec for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
@@ -58,7 +60,7 @@ func (o observed) MethodName() string {
 
 // LatencyMs implements Observable.LatencyMs
 func (o observed) LatencyMs() *stats.Float64Measure {
-	return latencyMs
+	return LatencyMs
 }
 
 // codecObserved is a wrapper to append version to observed.

--- a/pkg/cloudevents/datacodec/json/observability.go
+++ b/pkg/cloudevents/datacodec/json/observability.go
@@ -7,14 +7,16 @@ import (
 )
 
 var (
-	latencyMs = stats.Float64("datacodec/json/latency", "The latency in milliseconds for the CloudEvents json data codec methods.", "ms")
+	// LatencyMs measures the latency in milliseconds for the CloudEvents json
+	// data codec methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/datacodec/json/latency", "The latency in milliseconds for the CloudEvents json data codec methods.", "ms")
 )
 
 var (
 	// LatencyView is an OpenCensus view that shows data codec json method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/json/latency",
-		Measure:     latencyMs,
+		Measure:     LatencyMs,
 		Description: "The distribution of latency inside of the json data codec for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
@@ -57,5 +59,5 @@ func (o observed) MethodName() string {
 
 // LatencyMs implements Observable.LatencyMs
 func (o observed) LatencyMs() *stats.Float64Measure {
-	return latencyMs
+	return LatencyMs
 }

--- a/pkg/cloudevents/datacodec/observability.go
+++ b/pkg/cloudevents/datacodec/observability.go
@@ -7,14 +7,16 @@ import (
 )
 
 var (
-	latencyMs = stats.Float64("datacodec/latency", "The latency in milliseconds for the CloudEvents generic data codec methods.", "ms")
+	// LatencyMs measures the latency in milliseconds for the CloudEvents generic
+	// codec data methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/datacodec/latency", "The latency in milliseconds for the CloudEvents generic data codec methods.", "ms")
 )
 
 var (
 	// LatencyView is an OpenCensus view that shows data codec method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/latency",
-		Measure:     latencyMs,
+		Measure:     LatencyMs,
 		Description: "The distribution of latency inside of the generic data codec for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
@@ -57,5 +59,5 @@ func (o observed) MethodName() string {
 
 // LatencyMs implements Observable.LatencyMs
 func (o observed) LatencyMs() *stats.Float64Measure {
-	return latencyMs
+	return LatencyMs
 }

--- a/pkg/cloudevents/datacodec/xml/observability.go
+++ b/pkg/cloudevents/datacodec/xml/observability.go
@@ -7,14 +7,16 @@ import (
 )
 
 var (
-	latencyMs = stats.Float64("datacodec/xml/latency", "The latency in milliseconds for the CloudEvents xml data codec methods.", "ms")
+	// LatencyMs measures the latency in milliseconds for the CloudEvents xml data
+	// codec methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/datacodec/xml/latency", "The latency in milliseconds for the CloudEvents xml data codec methods.", "ms")
 )
 
 var (
 	// LatencyView is an OpenCensus view that shows data codec xml method latency.
 	LatencyView = &view.View{
 		Name:        "datacodec/xml/latency",
-		Measure:     latencyMs,
+		Measure:     LatencyMs,
 		Description: "The distribution of latency inside of the xml data codec for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
@@ -57,5 +59,5 @@ func (o observed) MethodName() string {
 
 // LatencyMs implements Observable.LatencyMs
 func (o observed) LatencyMs() *stats.Float64Measure {
-	return latencyMs
+	return LatencyMs
 }

--- a/pkg/cloudevents/transport/http/observability.go
+++ b/pkg/cloudevents/transport/http/observability.go
@@ -2,14 +2,17 @@ package http
 
 import (
 	"fmt"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 )
 
 var (
-	latencyMs = stats.Float64(
-		"transport/http/latency",
+	// LatencyMs measures the latency in milliseconds for the http transport
+	// methods for CloudEvents.
+	LatencyMs = stats.Float64(
+		"cloudevents.io/sdk-go/transport/http/latency",
 		"The latency in milliseconds for the http transport methods for CloudEvents.",
 		"ms")
 )
@@ -18,7 +21,7 @@ var (
 	// LatencyView is an OpenCensus view that shows http transport method latency.
 	LatencyView = &view.View{
 		Name:        "transport/http/latency",
-		Measure:     latencyMs,
+		Measure:     LatencyMs,
 		Description: "The distribution of latency inside of http transport for CloudEvents.",
 		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
 		TagKeys:     observability.LatencyTags(),
@@ -76,7 +79,7 @@ func (o observed) MethodName() string {
 
 // LatencyMs implements Observable.LatencyMs
 func (o observed) LatencyMs() *stats.Float64Measure {
-	return latencyMs
+	return LatencyMs
 }
 
 // CodecObserved is a wrapper to append version to observed.


### PR DESCRIPTION
[Standard practice](https://godoc.org/go.opencensus.io/plugin/ocgrpc) for OpenCensus measure names is to qualify them with project names so the names are unique. Since measure names are never exported (only view names), this is a safe change.

Also the measures are now exported so library users can create custom views with them This is also standard practice.

/cc @n3wscott 