### PR TITLE
found a bug in how header comes from context, fixed.

### DIFF
--- a/pkg/cloudevents/transport/http/context.go
+++ b/pkg/cloudevents/transport/http/context.go
@@ -147,11 +147,12 @@ func ContextWithHeader(ctx context.Context, key, value string) context.Context {
 
 // HeaderFrom extracts the header oject in the given context. Always returns a non-nil Header.
 func HeaderFrom(ctx context.Context) http.Header {
+	ch := http.Header{}
 	header := ctx.Value(headerKey)
 	if header != nil {
 		if h, ok := header.(http.Header); ok {
-			return h
+			copyHeaders(h, ch)
 		}
 	}
-	return http.Header{}
+	return ch
 }

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -163,9 +163,11 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (*clou
 
 	if m, ok := msg.(*Message); ok {
 		copyHeaders(m.Header, req.Header)
+
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(m.Body))
 		req.ContentLength = int64(len(m.Body))
 		req.Close = true
+
 		return httpDo(ctx, t.Client, &req, func(resp *http.Response, err error) (*cloudevents.Event, error) {
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
I was passing headers by ref, not by value and header values were getting duplicated.