### PR TITLE
Adding alias to top level to make http integrations import less.

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -1,0 +1,94 @@
+package cloudevents
+
+// Package cloudevents alias' common functions and types to improve discoverability and reduce
+// the number of imports for simple HTTP clients.
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/context"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+)
+
+// Client
+
+type Client = client.Client
+
+// Event
+
+type Event = cloudevents.Event
+type EventResponse = cloudevents.EventResponse
+
+// Context
+
+type EventContext = cloudevents.EventContext
+type EventContextV01 = cloudevents.EventContextV01
+type EventContextV02 = cloudevents.EventContextV02
+type EventContextV3 = cloudevents.EventContextV03
+
+// Custom Types
+
+type Timestamp = types.Timestamp
+type URLRef = types.URLRef
+
+// HTTP Transport
+
+type HTTPTransport = http.Transport
+type HTTPTransportContext = http.TransportContext
+type HTTPTransportResponseContext = http.TransportResponseContext
+type HTTPEncoding = http.Encoding
+
+var (
+	// Client Creation
+
+	NewClient        = client.New
+	NewDefaultClient = client.NewDefault
+
+	// Client Options
+
+	WithEventDefaulter = client.WithEventDefaulter
+	WithUUIDs          = client.WithUUIDs
+	WithTimeNow        = client.WithTimeNow
+
+	// Context
+
+	ContextWithTarget = context.WithTarget
+	TargetFromContext = context.TargetFrom
+
+	// Custom Types
+
+	ParseTimestamp = types.ParseTimestamp
+	ParseURLRef    = types.ParseURLRef
+
+	// HTTP Transport
+
+	NewHTTPTransport = http.New
+
+	// HTTP Transport Options
+
+	WithTarget             = http.WithTarget
+	WithMethod             = http.WithMethod
+	WitHHeader             = http.WithHeader
+	WithShutdownTimeout    = http.WithShutdownTimeout
+	WithEncoding           = http.WithEncoding
+	WithBinaryEncoding     = http.WithBinaryEncoding
+	WithStructuredEncoding = http.WithStructuredEncoding
+	WithPort               = http.WithPort
+	WithPath               = http.WithPath
+
+	// HTTP Context
+
+	HTTPTransportContextFrom = http.TransportContextFrom
+	ContextWithHeader        = http.ContextWithHeader
+
+	// HTTP Transport Encodings
+
+	HTTPBinaryV01     = http.BinaryV01
+	HTTPStructuredV01 = http.StructuredV01
+	HTTPBinaryV02     = http.BinaryV02
+	HTTPStructuredV02 = http.StructuredV02
+	HTTPBinaryV03     = http.BinaryV03
+	HTTPStructuredV03 = http.StructuredV03
+	HTTPBatchedV03    = http.BatchedV03
+)

--- a/cmd/samples/http/receiver/main.go
+++ b/cmd/samples/http/receiver/main.go
@@ -6,9 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	cloudeventshttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -40,7 +38,7 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 	}
 	fmt.Printf("Got Data: %+v\n", data)
 
-	fmt.Printf("Got Transport Context: %+v\n", cloudeventshttp.TransportContextFrom(ctx))
+	fmt.Printf("Got Transport Context: %+v\n", cloudevents.HTTPTransportContextFrom(ctx))
 
 	fmt.Printf("----------------------------\n")
 	return nil
@@ -49,15 +47,15 @@ func gotEvent(ctx context.Context, event cloudevents.Event) error {
 func _main(args []string, env envConfig) int {
 	ctx := context.Background()
 
-	t, err := cloudeventshttp.New(
-		cloudeventshttp.WithPort(env.Port),
-		cloudeventshttp.WithPath(env.Path),
+	t, err := cloudevents.NewHTTPTransport(
+		cloudevents.WithPort(env.Port),
+		cloudevents.WithPath(env.Path),
 	)
 	if err != nil {
 		log.Printf("failed to create transport, %v", err)
 		return 1
 	}
-	c, err := client.New(t)
+	c, err := cloudevents.NewClient(t)
 	if err != nil {
 		log.Printf("failed to create client, %v", err)
 		return 1

--- a/cmd/samples/http/sender/main.go
+++ b/cmd/samples/http/sender/main.go
@@ -8,10 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	cloudeventshttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/cloudevents/sdk-go"
 	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 )
@@ -49,19 +46,19 @@ func _main(args []string, env envConfig) int {
 
 	seq := 0
 	for _, contentType := range []string{"application/json", "application/xml"} {
-		for _, encoding := range []cloudeventshttp.Encoding{cloudeventshttp.BinaryV01, cloudeventshttp.StructuredV01, cloudeventshttp.BinaryV02, cloudeventshttp.StructuredV02} {
+		for _, encoding := range []cloudevents.HTTPEncoding{cloudevents.HTTPBinaryV01, cloudevents.HTTPStructuredV01, cloudevents.HTTPBinaryV02, cloudevents.HTTPStructuredV02} {
 
-			t, err := cloudeventshttp.New(
-				cloudeventshttp.WithTarget(env.Target),
-				cloudeventshttp.WithEncoding(encoding),
+			t, err := cloudevents.NewHTTPTransport(
+				cloudevents.WithTarget(env.Target),
+				cloudevents.WithEncoding(encoding),
 			)
 			if err != nil {
 				log.Printf("failed to create transport, %v", err)
 				return 1
 			}
 
-			c, err := client.New(t,
-				client.WithTimeNow(),
+			c, err := cloudevents.NewClient(t,
+				cloudevents.WithTimeNow(),
 			)
 			if err != nil {
 				log.Printf("failed to create client, %v", err)
@@ -75,7 +72,7 @@ func _main(args []string, env envConfig) int {
 					Context: cloudevents.EventContextV01{
 						EventID:     uuid.New().String(),
 						EventType:   "com.cloudevents.sample.sent",
-						Source:      types.URLRef{URL: *source},
+						Source:      cloudevents.URLRef{URL: *source},
 						ContentType: &contentType,
 					}.AsV01(),
 					Data: &Example{

--- a/cmd/samples/http/sleepy/main.go
+++ b/cmd/samples/http/sleepy/main.go
@@ -7,9 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	cloudeventshttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -45,15 +43,15 @@ func gotEvent(event cloudevents.Event) error {
 }
 
 func _main(args []string, env envConfig) int {
-	t, err := cloudeventshttp.New(
-		cloudeventshttp.WithPort(env.Port),
-		cloudeventshttp.WithPath(env.Path),
+	t, err := cloudevents.NewHTTPTransport(
+		cloudevents.WithPort(env.Port),
+		cloudevents.WithPath(env.Path),
 	)
 	if err != nil {
 		log.Printf("failed to create transport, %v", err)
 		return 1
 	}
-	c, err := client.New(t)
+	c, err := cloudevents.NewClient(t)
 	if err != nil {
 		log.Printf("failed to create client, %v", err)
 		return 1

--- a/cmd/samples/simple/http/receiver/main.go
+++ b/cmd/samples/simple/http/receiver/main.go
@@ -3,16 +3,15 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	"log"
+
+	"github.com/cloudevents/sdk-go"
 )
 
 func main() {
 	ctx := context.Background()
 
-	c, err := client.NewDefault()
+	c, err := cloudevents.NewDefaultClient()
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
@@ -35,5 +34,5 @@ func gotEvent(ctx context.Context, event cloudevents.Event) {
 	}
 
 	fmt.Printf("%s", event)
-	fmt.Printf("%s\n", cehttp.TransportContextFrom(ctx))
+	fmt.Printf("%s\n", cloudevents.HTTPTransportContextFrom(ctx))
 }

--- a/cmd/samples/simple/http/sender/main.go
+++ b/cmd/samples/simple/http/sender/main.go
@@ -3,15 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	cecontext "github.com/cloudevents/sdk-go/pkg/cloudevents/context"
-	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 	"log"
+
+	"github.com/cloudevents/sdk-go"
 )
 
-var source = types.ParseURLRef("https://github.com/cloudevents/sdk-go/cmd/samples/sender")
+var source = cloudevents.ParseURLRef("https://github.com/cloudevents/sdk-go/cmd/samples/sender")
 
 // Basic data struct.
 type Example struct {
@@ -20,11 +17,11 @@ type Example struct {
 }
 
 func main() {
-	ctx := cecontext.WithTarget(context.Background(), "http://localhost:8080/")
+	ctx := cloudevents.ContextWithTarget(context.Background(), "http://localhost:8080/")
 
-	ctx = cehttp.ContextWithHeader(ctx, "demo", "header value")
+	ctx = cloudevents.ContextWithHeader(ctx, "demo", "header value")
 
-	c, err := client.NewDefault()
+	c, err := cloudevents.NewDefaultClient()
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}


### PR DESCRIPTION
Lets us go from:

```go
	"github.com/cloudevents/sdk-go/pkg/cloudevents"
	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
	cloudeventshttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
```

to 

```go
	"github.com/cloudevents/sdk-go"
```

Signed-off-by: Scott Nichols <nicholss@google.com>