### PR TITLE
Adding event interface

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -59,6 +59,13 @@ var (
 	WithUUIDs          = client.WithUUIDs
 	WithTimeNow        = client.WithTimeNow
 
+	// Event Creation
+
+	NewEvent   = cloudevents.New
+	VersionV01 = cloudevents.CloudEventsVersionV01
+	VersionV02 = cloudevents.CloudEventsVersionV02
+	VersionV03 = cloudevents.CloudEventsVersionV03
+
 	// Context
 
 	ContextWithTarget = context.WithTarget

--- a/cmd/samples/simple/http/sender/main.go
+++ b/cmd/samples/simple/http/sender/main.go
@@ -8,8 +8,6 @@ import (
 	"github.com/cloudevents/sdk-go"
 )
 
-var source = cloudevents.ParseURLRef("https://github.com/cloudevents/sdk-go/cmd/samples/sender")
-
 // Basic data struct.
 type Example struct {
 	Sequence int    `json:"id"`
@@ -31,13 +29,21 @@ func main() {
 			Sequence: i,
 			Message:  "Hello, World!",
 		}
-		event := cloudevents.Event{
-			Context: cloudevents.EventContextV02{
-				Type:   "com.cloudevents.sample.sent",
-				Source: *source,
-			}.AsV02(),
-			Data: data,
+
+		var version string
+		switch i % 3 {
+		case 0:
+			version = cloudevents.VersionV01
+		case 1:
+			version = cloudevents.VersionV02
+		case 2:
+			version = cloudevents.VersionV03
 		}
+
+		event := cloudevents.NewEvent(version)
+		event.SetType("com.cloudevents.sample.sent")
+		event.SetSource("https://github.com/cloudevents/sdk-go/cmd/samples/sender")
+		event.Data = data
 
 		if resp, err := c.Send(ctx, event); err != nil {
 			log.Printf("failed to send: %v", err)

--- a/cmd/samples/simple/http/sender/v03/main_v03.go
+++ b/cmd/samples/simple/http/sender/v03/main_v03.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/cloudevents/sdk-go"
+)
+
+var source = cloudevents.ParseURLRef("https://github.com/cloudevents/sdk-go/cmd/samples/sender")
+
+// Basic data struct.
+type Example struct {
+	Sequence int    `json:"id"`
+	Message  string `json:"message"`
+}
+
+var subject = "this_thing"
+
+func main() {
+	ctx := cloudevents.ContextWithTarget(context.Background(), "http://localhost:8080/")
+
+	ctx = cloudevents.ContextWithHeader(ctx, "demo", "header value")
+
+	c, err := cloudevents.NewDefaultClient()
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		data := &Example{
+			Sequence: i,
+			Message:  "Hello, World!",
+		}
+		event := cloudevents.Event{
+			Context: cloudevents.EventContextV03{
+				Type:    "com.cloudevents.sample.sent",
+				Source:  *source,
+				Subject: &subject,
+			}.AsV03(),
+			Data: data,
+		}
+
+		if resp, err := c.Send(ctx, event); err != nil {
+			log.Printf("failed to send: %v", err)
+		} else if resp != nil {
+			fmt.Printf("got back a response: \n%s", resp)
+		} else {
+			log.Printf("%s: %d - %s", event.Context.GetType(), data.Sequence, data.Message)
+		}
+	}
+}

--- a/pkg/cloudevents/client/defaulters.go
+++ b/pkg/cloudevents/client/defaulters.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 	"github.com/google/uuid"
 	"time"
 )
@@ -15,25 +14,9 @@ type EventDefaulter func(event cloudevents.Event) cloudevents.Event
 // context.ID if it is found to be empty.
 func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {
-		switch event.Context.GetSpecVersion() {
-		case cloudevents.CloudEventsVersionV01:
-			ec := event.Context.AsV01()
-			if ec.EventID == "" {
-				ec.EventID = uuid.New().String()
-				event.Context = ec
-			}
-		case cloudevents.CloudEventsVersionV02:
-			ec := event.Context.AsV02()
-			if ec.ID == "" {
-				ec.ID = uuid.New().String()
-				event.Context = ec
-			}
-		case cloudevents.CloudEventsVersionV03:
-			ec := event.Context.AsV03()
-			if ec.ID == "" {
-				ec.ID = uuid.New().String()
-				event.Context = ec
-			}
+		if event.ID() == "" {
+			event.Context = event.Context.Clone()
+			_ = event.SetID(uuid.New().String())
 		}
 	}
 	return event
@@ -43,25 +26,9 @@ func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 // Timestamp to context.Time if it is found to be nil or zero.
 func DefaultTimeToNowIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {
-		switch event.Context.GetSpecVersion() {
-		case cloudevents.CloudEventsVersionV01:
-			ec := event.Context.AsV01()
-			if ec.EventTime == nil || ec.EventTime.IsZero() {
-				ec.EventTime = &types.Timestamp{Time: time.Now()}
-				event.Context = ec
-			}
-		case cloudevents.CloudEventsVersionV02:
-			ec := event.Context.AsV02()
-			if ec.Time == nil || ec.Time.IsZero() {
-				ec.Time = &types.Timestamp{Time: time.Now()}
-				event.Context = ec
-			}
-		case cloudevents.CloudEventsVersionV03:
-			ec := event.Context.AsV03()
-			if ec.Time == nil || ec.Time.IsZero() {
-				ec.Time = &types.Timestamp{Time: time.Now()}
-				event.Context = ec
-			}
+		if event.Time().IsZero() {
+			event.Context = event.Context.Clone()
+			_ = event.SetTime(time.Now())
 		}
 	}
 	return event

--- a/pkg/cloudevents/client/defaulters.go
+++ b/pkg/cloudevents/client/defaulters.go
@@ -16,7 +16,7 @@ func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {
 		if event.ID() == "" {
 			event.Context = event.Context.Clone()
-			_ = event.SetID(uuid.New().String())
+			event.SetID(uuid.New().String())
 		}
 	}
 	return event
@@ -28,7 +28,7 @@ func DefaultTimeToNowIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {
 		if event.Time().IsZero() {
 			event.Context = event.Context.Clone()
-			_ = event.SetTime(time.Now())
+			event.SetTime(time.Now())
 		}
 	}
 	return event

--- a/pkg/cloudevents/client/defaulters_test.go
+++ b/pkg/cloudevents/client/defaulters_test.go
@@ -17,17 +17,17 @@ func TestDefaultIDToUUIDIfNotSet(t *testing.T) {
 		},
 		"v0.1 empty": {
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{},
+				Context: &cloudevents.EventContextV01{},
 			},
 		},
 		"v0.2 empty": {
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{},
+				Context: &cloudevents.EventContextV02{},
 			},
 		},
 		"v0.3 empty": {
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{},
+				Context: &cloudevents.EventContextV03{},
 			},
 		},
 		"v0.1 no change": {
@@ -60,7 +60,7 @@ func TestDefaultIDToUUIDIfNotSet(t *testing.T) {
 
 func TestDefaultIDToUUIDIfNotSetImmutable(t *testing.T) {
 	event := cloudevents.Event{
-		Context: cloudevents.EventContextV01{},
+		Context: &cloudevents.EventContextV01{},
 	}
 
 	got := DefaultIDToUUIDIfNotSet(event)
@@ -89,17 +89,17 @@ func TestDefaultTimeToNowIfNotSet(t *testing.T) {
 		},
 		"v0.1 empty": {
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{},
+				Context: &cloudevents.EventContextV01{},
 			},
 		},
 		"v0.2 empty": {
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{},
+				Context: &cloudevents.EventContextV02{},
 			},
 		},
 		"v0.3 empty": {
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{},
+				Context: &cloudevents.EventContextV03{},
 			},
 		},
 		"v0.1 no change": {
@@ -132,7 +132,7 @@ func TestDefaultTimeToNowIfNotSet(t *testing.T) {
 
 func TestDefaultTimeToNowIfNotSetImmutable(t *testing.T) {
 	event := cloudevents.Event{
-		Context: cloudevents.EventContextV01{},
+		Context: &cloudevents.EventContextV01{},
 	}
 
 	got := DefaultTimeToNowIfNotSet(event)

--- a/pkg/cloudevents/client/receiver_test.go
+++ b/pkg/cloudevents/client/receiver_test.go
@@ -67,7 +67,7 @@ func TestReceiverFnInvoke_1(t *testing.T) {
 	key := struct{}{}
 	wantCtx := context.WithValue(context.TODO(), key, "UNIT TEST")
 	wantEvent := cloudevents.Event{
-		Context: cloudevents.EventContextV02{
+		Context: &cloudevents.EventContextV02{
 			ID: "UNIT TEST",
 		},
 	}
@@ -103,7 +103,7 @@ func TestReceiverFnInvoke_2(t *testing.T) {
 	key := struct{}{}
 	ctx := context.WithValue(context.TODO(), key, "UNIT TEST")
 	wantEvent := cloudevents.Event{
-		Context: cloudevents.EventContextV02{
+		Context: &cloudevents.EventContextV02{
 			ID: "UNIT TEST",
 		},
 	}
@@ -134,7 +134,7 @@ func TestReceiverFnInvoke_3(t *testing.T) {
 	key := struct{}{}
 	ctx := context.WithValue(context.TODO(), key, "UNIT TEST")
 	wantEvent := cloudevents.Event{
-		Context: cloudevents.EventContextV02{
+		Context: &cloudevents.EventContextV02{
 			ID: "UNIT TEST",
 		},
 	}
@@ -165,7 +165,7 @@ func TestReceiverFnInvoke_4(t *testing.T) {
 	key := struct{}{}
 	ctx := context.WithValue(context.TODO(), key, "UNIT TEST")
 	event := cloudevents.Event{
-		Context: cloudevents.EventContextV02{
+		Context: &cloudevents.EventContextV02{
 			ID: "UNIT TEST",
 		},
 	}
@@ -193,7 +193,7 @@ func TestReceiverFnInvoke_5(t *testing.T) {
 	key := struct{}{}
 	ctx := context.WithValue(context.TODO(), key, "UNIT TEST")
 	event := cloudevents.Event{
-		Context: cloudevents.EventContextV02{
+		Context: &cloudevents.EventContextV02{
 			ID: "UNIT TEST",
 		},
 	}
@@ -217,7 +217,7 @@ func TestReceiverFnInvoke_6(t *testing.T) {
 	key := struct{}{}
 	ctx := context.WithValue(context.TODO(), key, "UNIT TEST")
 	event := cloudevents.Event{
-		Context: cloudevents.EventContextV02{
+		Context: &cloudevents.EventContextV02{
 			ID: "UNIT TEST",
 		},
 	}

--- a/pkg/cloudevents/codec/jsoncodec.go
+++ b/pkg/cloudevents/codec/jsoncodec.go
@@ -75,7 +75,7 @@ func obsJsonEncodeV03(e cloudevents.Event) ([]byte, error) {
 	return jsonEncode(ctx, e.Data)
 }
 
-func jsonEncode(ctx cloudevents.EventContext, data interface{}) ([]byte, error) {
+func jsonEncode(ctx cloudevents.EventContextReader, data interface{}) ([]byte, error) {
 	ctxb, err := marshalEvent(ctx)
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func obsJsonDecodeV01(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: ec,
+		Context: &ec,
 		Data:    data,
 	}, nil
 }
@@ -181,7 +181,7 @@ func obsJsonDecodeV02(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: ec,
+		Context: &ec,
 		Data:    data,
 	}, nil
 }
@@ -216,7 +216,7 @@ func obsJsonDecodeV03(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: ec,
+		Context: &ec,
 		Data:    data,
 	}, nil
 }

--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
-	"sort"
 	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
 )
 
 // Event represents the canonical representation of a CloudEvent.
@@ -15,40 +15,21 @@ type Event struct {
 	Data    interface{}
 }
 
+func New(specVersion string) Event {
+	e := &Event{}
+	_ = e.SetSpecVersion(specVersion)
+	return *e
+}
+
 // DataAs attempts to populate the provided data object with the event payload.
 // data should be a pointer type.
 func (e Event) DataAs(data interface{}) error {
 	return datacodec.Decode(e.Context.GetDataMediaType(), e.Data, data)
 }
 
-// SpecVersion returns Context.GetSpecVersion()
-func (e Event) SpecVersion() string {
-	return e.Context.GetSpecVersion()
-}
-
-// Type returns Context.GetType()
-func (e Event) Type() string {
-	return e.Context.GetType()
-}
-
-// Source returns Context.GetSource()
-func (e Event) Source() string {
-	return e.Context.GetSource()
-}
-
-// SchemaURL returns Context.GetSchemaURL()
-func (e Event) SchemaURL() string {
-	return e.Context.GetSchemaURL()
-}
-
 // ExtensionAs returns Context.ExtensionAs(name, obj)
 func (e Event) ExtensionAs(name string, obj interface{}) error {
 	return e.Context.ExtensionAs(name, obj)
-}
-
-// DataContentType returns Context.getDataContentType()
-func (e Event) DataContentType() string {
-	return e.Context.GetDataContentType()
 }
 
 // Validate performs a spec based validation on this event.
@@ -83,90 +64,7 @@ func (e Event) String() string {
 		b.WriteString(fmt.Sprintf("Validation Error: \n%s\n", valid.Error()))
 	}
 
-	b.WriteString("Context Attributes,\n")
-
-	var extensions map[string]interface{}
-
-	// TODO: This impl detail should be pushed into the impl structs.
-
-	switch e.SpecVersion() {
-	case CloudEventsVersionV01:
-		if ec, ok := e.Context.(EventContextV01); ok {
-			b.WriteString("  cloudEventsVersion: " + ec.CloudEventsVersion + "\n")
-			b.WriteString("  eventType: " + ec.EventType + "\n")
-			if ec.EventTypeVersion != nil {
-				b.WriteString("  eventTypeVersion: " + *ec.EventTypeVersion + "\n")
-			}
-			b.WriteString("  source: " + ec.Source.String() + "\n")
-			b.WriteString("  eventID: " + ec.EventID + "\n")
-			if ec.EventTime != nil {
-				b.WriteString("  eventTime: " + ec.EventTime.String() + "\n")
-			}
-			if ec.SchemaURL != nil {
-				b.WriteString("  schemaURL: " + ec.SchemaURL.String() + "\n")
-			}
-			if ec.ContentType != nil {
-				b.WriteString("  contentType: " + *ec.ContentType + "\n")
-			}
-			extensions = ec.Extensions
-		}
-
-	case CloudEventsVersionV02:
-		if ec, ok := e.Context.(EventContextV02); ok {
-			b.WriteString("  specversion: " + ec.SpecVersion + "\n")
-			b.WriteString("  type: " + ec.Type + "\n")
-			b.WriteString("  source: " + ec.Source.String() + "\n")
-			b.WriteString("  id: " + ec.ID + "\n")
-			if ec.Time != nil {
-				b.WriteString("  time: " + ec.Time.String() + "\n")
-			}
-			if ec.SchemaURL != nil {
-				b.WriteString("  schemaurl: " + ec.SchemaURL.String() + "\n")
-			}
-			if ec.ContentType != nil {
-				b.WriteString("  contenttype: " + *ec.ContentType + "\n")
-			}
-			extensions = ec.Extensions
-		}
-
-	case CloudEventsVersionV03:
-		if ec, ok := e.Context.(EventContextV03); ok {
-			b.WriteString("  specversion: " + ec.SpecVersion + "\n")
-			b.WriteString("  type: " + ec.Type + "\n")
-			b.WriteString("  source: " + ec.Source.String() + "\n")
-			if ec.Subject != nil {
-				b.WriteString("  subject: " + *ec.Subject + "\n")
-			}
-			b.WriteString("  id: " + ec.ID + "\n")
-			if ec.Time != nil {
-				b.WriteString("  time: " + ec.Time.String() + "\n")
-			}
-			if ec.SchemaURL != nil {
-				b.WriteString("  schemaurl: " + ec.SchemaURL.String() + "\n")
-			}
-			if ec.DataContentType != nil {
-				b.WriteString("  datacontenttype: " + *ec.DataContentType + "\n")
-			}
-			if ec.DataContentEncoding != nil {
-				b.WriteString("  datacontentencoding: " + *ec.DataContentEncoding + "\n")
-			}
-			extensions = ec.Extensions
-		}
-	default:
-		b.WriteString(e.String() + "\n")
-	}
-
-	if extensions != nil && len(extensions) > 0 {
-		b.WriteString("Extensions,\n")
-		keys := make([]string, 0, len(extensions))
-		for k := range extensions {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			b.WriteString(fmt.Sprintf("  %s: %v\n", key, extensions[key]))
-		}
-	}
+	b.WriteString(e.Context.String())
 
 	if e.Data != nil {
 		b.WriteString("Data,\n  ")

--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -15,9 +15,19 @@ type Event struct {
 	Data    interface{}
 }
 
-func New(specVersion string) Event {
+const (
+	defaultEventVersion = CloudEventsVersionV02
+)
+
+// New returns a new Event, an optional version can be passed to change the
+// default spec version from 0.2 to the provided version.
+func New(version ...string) Event {
+	specVersion := defaultEventVersion // TODO: should there be a default? or set a default?
+	if len(version) >= 1 {
+		specVersion = version[0]
+	}
 	e := &Event{}
-	_ = e.SetSpecVersion(specVersion)
+	e.SetSpecVersion(specVersion)
 	return *e
 }
 

--- a/pkg/cloudevents/event_interface.go
+++ b/pkg/cloudevents/event_interface.go
@@ -5,43 +5,67 @@ import (
 )
 
 type EventReader interface {
-	// Context Attributes
-
+	// SpecVersion returns event.Context.GetSpecVersion().
 	SpecVersion() string
+	// Type returns event.Context.GetType().
 	Type() string
+	// Source returns event.Context.GetSource().
 	Source() string
+	// Subject returns event.Context.GetSubject().
+	Subject() string
+	// ID returns event.Context.GetID().
 	ID() string
+	// Time returns event.Context.GetTime().
 	Time() time.Time
+	// SchemaURL returns event.Context.GetSchemaURL().
 	SchemaURL() string
+	// DataContentType returns event.Context.GetDataContentType().
 	DataContentType() string
+	// DataMediaType returns event.Context.GetDataMediaType().
+	DataMediaType() string
+	// DataContentEncoding returns event.Context.GetDataContentEncoding().
 	DataContentEncoding() string
 
 	// Extension Attributes
 
+	// ExtensionAs returns event.Context.ExtensionAs(name, obj).
 	ExtensionAs(string, interface{}) error
 
 	// Data Attribute
 
+	// ExtensionAs returns event.Context.ExtensionAs(name, obj).
 	DataAs(interface{}) error
 }
 
 type EventWriter interface {
 	// Context Attributes
 
+	// SetSpecVersion performs event.Context.SetSpecVersion.
 	SetSpecVersion(string) error
+	// SetType performs event.Context.SetType.
 	SetType(string) error
+	// SetSource performs event.Context.SetSource.
 	SetSource(string) error
+	// SetSubject( performs event.Context.SetSubject.
+	SetSubject(string) error
+	// SetID performs event.Context.SetID.
 	SetID(string) error
-	SetTime(time time.Time) error
+	// SetTime performs event.Context.SetTime.
+	SetTime(time.Time) error
+	// SetSchemaURL performs event.Context.SetSchemaURL.
 	SetSchemaURL(string) error
+	// SetDataContentType performs event.Context.SetDataContentType.
 	SetDataContentType(string) error
+	// SetDataContentEncoding performs event.Context.SetDataContentEncoding.
 	SetDataContentEncoding(string) error
 
 	// Extension Attributes
 
+	// SetExtension performs event.Context.SetExtension.
 	SetExtension(string, interface{}) error
 
 	// Data Attribute
 
-	SetData(data interface{}) error
+	// SetData sets the data attribute.
+	SetData(interface{}) error
 }

--- a/pkg/cloudevents/event_interface.go
+++ b/pkg/cloudevents/event_interface.go
@@ -4,6 +4,7 @@ import (
 	"time"
 )
 
+// EventWriter is the interface for reading through an event from attributes.
 type EventReader interface {
 	// SpecVersion returns event.Context.GetSpecVersion().
 	SpecVersion() string
@@ -37,35 +38,32 @@ type EventReader interface {
 	DataAs(interface{}) error
 }
 
+// EventWriter is the interface for writing through an event onto attributes.
+// If an error is thrown by a sub-component, EventWriter panics.
 type EventWriter interface {
 	// Context Attributes
 
 	// SetSpecVersion performs event.Context.SetSpecVersion.
-	SetSpecVersion(string) error
+	SetSpecVersion(string)
 	// SetType performs event.Context.SetType.
-	SetType(string) error
+	SetType(string)
 	// SetSource performs event.Context.SetSource.
-	SetSource(string) error
+	SetSource(string)
 	// SetSubject( performs event.Context.SetSubject.
-	SetSubject(string) error
+	SetSubject(string)
 	// SetID performs event.Context.SetID.
-	SetID(string) error
+	SetID(string)
 	// SetTime performs event.Context.SetTime.
-	SetTime(time.Time) error
+	SetTime(time.Time)
 	// SetSchemaURL performs event.Context.SetSchemaURL.
-	SetSchemaURL(string) error
+	SetSchemaURL(string)
 	// SetDataContentType performs event.Context.SetDataContentType.
-	SetDataContentType(string) error
+	SetDataContentType(string)
 	// SetDataContentEncoding performs event.Context.SetDataContentEncoding.
-	SetDataContentEncoding(string) error
+	SetDataContentEncoding(string)
 
 	// Extension Attributes
 
 	// SetExtension performs event.Context.SetExtension.
-	SetExtension(string, interface{}) error
-
-	// Data Attribute
-
-	// SetData sets the data attribute.
-	SetData(interface{}) error
+	SetExtension(string, interface{})
 }

--- a/pkg/cloudevents/event_interface.go
+++ b/pkg/cloudevents/event_interface.go
@@ -1,0 +1,47 @@
+package cloudevents
+
+import (
+	"time"
+)
+
+type EventReader interface {
+	// Context Attributes
+
+	SpecVersion() string
+	Type() string
+	Source() string
+	ID() string
+	Time() time.Time
+	SchemaURL() string
+	DataContentType() string
+	DataContentEncoding() string
+
+	// Extension Attributes
+
+	ExtensionAs(string, interface{}) error
+
+	// Data Attribute
+
+	DataAs(interface{}) error
+}
+
+type EventWriter interface {
+	// Context Attributes
+
+	SetSpecVersion(string) error
+	SetType(string) error
+	SetSource(string) error
+	SetID(string) error
+	SetTime(time time.Time) error
+	SetSchemaURL(string) error
+	SetDataContentType(string) error
+	SetDataContentEncoding(string) error
+
+	// Extension Attributes
+
+	SetExtension(string, interface{}) error
+
+	// Data Attribute
+
+	SetData(data interface{}) error
+}

--- a/pkg/cloudevents/event_reader.go
+++ b/pkg/cloudevents/event_reader.go
@@ -1,0 +1,57 @@
+package cloudevents
+
+import (
+	"time"
+)
+
+var _ EventReader = (*Event)(nil)
+
+// SpecVersion implements EventReader.SpecVersion
+func (e Event) SpecVersion() string {
+	return e.Context.GetSpecVersion()
+}
+
+// Type implements EventReader.Type
+func (e Event) Type() string {
+	return e.Context.GetType()
+}
+
+// Source implements EventReader.Source
+func (e Event) Source() string {
+	return e.Context.GetSource()
+}
+
+// Subject implements EventReader.Subject
+func (e Event) Subject() string {
+	return e.Context.GetSubject()
+}
+
+// ID implements EventReader.ID
+func (e Event) ID() string {
+	return e.Context.GetID()
+}
+
+// Time implements EventReader.Time
+func (e Event) Time() time.Time {
+	return e.Context.GetTime()
+}
+
+// SchemaURL implements EventReader.SchemaURL
+func (e Event) SchemaURL() string {
+	return e.Context.GetSchemaURL()
+}
+
+// DataContentType implements EventReader.DataContentType
+func (e Event) DataContentType() string {
+	return e.Context.GetDataContentType()
+}
+
+// DataMediaType implements EventReader.DataMediaType
+func (e Event) DataMediaType() string {
+	return e.Context.GetDataMediaType()
+}
+
+// DataContentEncoding implements EventReader.DataContentEncoding
+func (e Event) DataContentEncoding() string {
+	return e.Context.GetDataContentEncoding()
+}

--- a/pkg/cloudevents/event_reader_writer_test.go
+++ b/pkg/cloudevents/event_reader_writer_test.go
@@ -1,0 +1,581 @@
+package cloudevents_test
+
+import (
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/google/go-cmp/cmp"
+	"strings"
+	"testing"
+	"time"
+)
+
+type ReadWriteTest struct {
+	event   ce.Event
+	set     string
+	want    interface{}
+	wantErr string
+}
+
+func TestEventRW_SpecVersion(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"empty v01": {
+			event: ce.New(""),
+			set:   "0.1",
+			want:  "0.1",
+		},
+		"empty v02": {
+			event: ce.New(""),
+			set:   "0.2",
+			want:  "0.2",
+		},
+		"empty v03": {
+			event: ce.New(""),
+			set:   "0.3",
+			want:  "0.3",
+		},
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "0.1",
+			want:  "0.1",
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "0.2",
+			want:  "0.2",
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "0.3",
+			want:  "0.3",
+		},
+		"invalid v01": {
+			event:   ce.New("0.1"),
+			set:     "1.1",
+			want:    "0.1",
+			wantErr: "invalid version",
+		},
+		"invalid v02": {
+			event:   ce.New("0.2"),
+			set:     "1.2",
+			want:    "0.2",
+			wantErr: "invalid version",
+		},
+		"invalid v03": {
+			event:   ce.New("0.3"),
+			set:     "1.3",
+			want:    "0.3",
+			wantErr: "invalid version",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.event.SetSpecVersion(tc.set)
+			got := tc.event.SpecVersion()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func TestEventRW_Type(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "type.0.1",
+			want:  "type.0.1",
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "type.0.2",
+			want:  "type.0.2",
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "type.0.3",
+			want:  "type.0.3",
+		},
+		"spaced v01": {
+			event: ce.New("0.1"),
+			set:   "  type.0.1  ",
+			want:  "type.0.1",
+		},
+		"spaced v02": {
+			event: ce.New("0.2"),
+			set:   "  type.0.2  ",
+			want:  "type.0.2",
+		},
+		"spaced v03": {
+			event: ce.New("0.3"),
+			set:   "   type.0.3   ",
+			want:  "type.0.3",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.event.SetType(tc.set)
+			got := tc.event.Type()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func TestEventRW_ID(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "id.0.1",
+			want:  "id.0.1",
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "id.0.2",
+			want:  "id.0.2",
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "id.0.3",
+			want:  "id.0.3",
+		},
+		"spaced v01": {
+			event: ce.New("0.1"),
+			set:   "  id.0.1  ",
+			want:  "id.0.1",
+		},
+		"spaced v02": {
+			event: ce.New("0.2"),
+			set:   "  id.0.2  ",
+			want:  "id.0.2",
+		},
+		"spaced v03": {
+			event: ce.New("0.3"),
+			set:   "   id.0.3   ",
+			want:  "id.0.3",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.event.SetID(tc.set)
+			got := tc.event.ID()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func TestEventRW_Source(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "http://example/",
+			want:  "http://example/",
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "http://example/",
+			want:  "http://example/",
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "http://example/",
+			want:  "http://example/",
+		},
+		"invalid v01": {
+			event:   ce.New("0.1"),
+			set:     "%",
+			want:    "",
+			wantErr: "invalid URL escape",
+		},
+		"invalid v02": {
+			event:   ce.New("0.2"),
+			set:     "%",
+			want:    "",
+			wantErr: "invalid URL escape",
+		},
+		"invalid v03": {
+			event:   ce.New("0.3"),
+			set:     "%",
+			want:    "",
+			wantErr: "invalid URL escape",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.event.SetSource(tc.set)
+			got := tc.event.Source()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func TestEventRW_Subject(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "subject.0.1",
+			want:  "subject.0.1",
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "subject.0.2",
+			want:  "subject.0.2",
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "subject.0.3",
+			want:  "subject.0.3",
+		},
+		"spaced v01": {
+			event: ce.New("0.1"),
+			set:   "  subject.0.1  ",
+			want:  "subject.0.1",
+		},
+		"spaced v02": {
+			event: ce.New("0.2"),
+			set:   "  subject.0.2  ",
+			want:  "subject.0.2",
+		},
+		"spaced v03": {
+			event: ce.New("0.3"),
+			set:   "   subject.0.3   ",
+			want:  "subject.0.3",
+		},
+		"nilled v01": {
+			event: func() ce.Event {
+				e := ce.New("0.1")
+				_ = e.SetSource("should nil")
+				return e
+			}(),
+			want: "",
+		},
+		"nilled v02": {
+			event: func() ce.Event {
+				e := ce.New("0.2")
+				_ = e.SetSource("should nil")
+				return e
+			}(),
+			want: "",
+		},
+		"nilled v03": {
+			event: func() ce.Event {
+				e := ce.New("0.3")
+				_ = e.SetSource("should nil")
+				return e
+			}(),
+			want: "",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.event.SetSubject(tc.set)
+			got := tc.event.Subject()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func TestEventRW_Time(t *testing.T) {
+	now := time.Now()
+
+	testCases := map[string]ReadWriteTest{
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "now", // hack
+			want:  now,
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "now", // hack
+			want:  now,
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "now", // hack
+			want:  now,
+		},
+		"nilled v01": {
+			event: func() ce.Event {
+				e := ce.New("0.1")
+				_ = e.SetTime(now)
+				return e
+			}(),
+			want: time.Time{},
+		},
+		"nilled v02": {
+			event: func() ce.Event {
+				e := ce.New("0.2")
+				_ = e.SetTime(now)
+				return e
+			}(),
+			want: time.Time{},
+		},
+		"nilled v03": {
+			event: func() ce.Event {
+				e := ce.New("0.3")
+				_ = e.SetTime(now)
+				return e
+			}(),
+			want: time.Time{},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			var err error
+			if tc.set == "now" {
+				err = tc.event.SetTime(now) // pull now from outer test.
+			} else {
+				err = tc.event.SetTime(time.Time{}) // pull now from outer test.
+			}
+			got := tc.event.Time()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func TestEventRW_SchemaURL(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "http://example/",
+			want:  "http://example/",
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "http://example/",
+			want:  "http://example/",
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "http://example/",
+			want:  "http://example/",
+		},
+		"invalid v01": {
+			event:   ce.New("0.1"),
+			set:     "%",
+			want:    "",
+			wantErr: "invalid URL escape",
+		},
+		"invalid v02": {
+			event:   ce.New("0.2"),
+			set:     "%",
+			want:    "",
+			wantErr: "invalid URL escape",
+		},
+		"invalid v03": {
+			event:   ce.New("0.3"),
+			set:     "%",
+			want:    "",
+			wantErr: "invalid URL escape",
+		},
+		"nilled v01": {
+			event: func() ce.Event {
+				e := ce.New("0.1")
+				_ = e.SetSchemaURL("should nil")
+				return e
+			}(),
+			want: "",
+		},
+		"nilled v02": {
+			event: func() ce.Event {
+				e := ce.New("0.2")
+				_ = e.SetSchemaURL("should nil")
+				return e
+			}(),
+			want: "",
+		},
+		"nilled v03": {
+			event: func() ce.Event {
+				e := ce.New("0.3")
+				_ = e.SetSchemaURL("should nil")
+				return e
+			}(),
+			want: "",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.event.SetSchemaURL(tc.set)
+			got := tc.event.SchemaURL()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func TestEventRW_DataContentType(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "application/json",
+			want:  "application/json",
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "application/json",
+			want:  "application/json",
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "application/json",
+			want:  "application/json",
+		},
+		"spaced v01": {
+			event: ce.New("0.1"),
+			set:   "  application/json  ",
+			want:  "application/json",
+		},
+		"spaced v02": {
+			event: ce.New("0.2"),
+			set:   "  application/json  ",
+			want:  "application/json",
+		},
+		"spaced v03": {
+			event: ce.New("0.3"),
+			set:   "   application/json   ",
+			want:  "application/json",
+		},
+		"nilled v01": {
+			event: func() ce.Event {
+				e := ce.New("0.1")
+				_ = e.SetDataContentType("application/json")
+				return e
+			}(),
+			want: "",
+		},
+		"nilled v02": {
+			event: func() ce.Event {
+				e := ce.New("0.2")
+				_ = e.SetDataContentType("application/json")
+				return e
+			}(),
+			want: "",
+		},
+		"nilled v03": {
+			event: func() ce.Event {
+				e := ce.New("0.3")
+				_ = e.SetDataContentType("application/json")
+				return e
+			}(),
+			want: "",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.event.SetDataContentType(tc.set)
+			got := tc.event.DataContentType()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func TestEventRW_DataContentEncoding(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"v01": {
+			event: ce.New("0.1"),
+			set:   "base64",
+			want:  "base64",
+		},
+		"v02": {
+			event: ce.New("0.2"),
+			set:   "base64",
+			want:  "base64",
+		},
+		"v03": {
+			event: ce.New("0.3"),
+			set:   "base64",
+			want:  "base64",
+		},
+		"spaced v01": {
+			event: ce.New("0.1"),
+			set:   "  base64  ",
+			want:  "base64",
+		},
+		"spaced v02": {
+			event: ce.New("0.2"),
+			set:   "  base64  ",
+			want:  "base64",
+		},
+		"spaced v03": {
+			event: ce.New("0.3"),
+			set:   "   base64   ",
+			want:  "base64",
+		},
+		"cased v01": {
+			event: ce.New("0.1"),
+			set:   "  BaSe64  ",
+			want:  "base64",
+		},
+		"cased v02": {
+			event: ce.New("0.2"),
+			set:   "  BaSe64  ",
+			want:  "base64",
+		},
+		"cased v03": {
+			event: ce.New("0.3"),
+			set:   "   BaSe64   ",
+			want:  "base64",
+		},
+		"nilled v01": {
+			event: func() ce.Event {
+				e := ce.New("0.1")
+				_ = e.SetDataContentEncoding("base64")
+				return e
+			}(),
+			want: "",
+		},
+		"nilled v02": {
+			event: func() ce.Event {
+				e := ce.New("0.2")
+				_ = e.SetDataContentEncoding("base64")
+				return e
+			}(),
+			want: "",
+		},
+		"nilled v03": {
+			event: func() ce.Event {
+				e := ce.New("0.3")
+				_ = e.SetDataContentEncoding("base64")
+				return e
+			}(),
+			want: "",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			err := tc.event.SetDataContentEncoding(tc.set)
+			got := tc.event.DataContentEncoding()
+
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+func validateReaderWriter(t *testing.T, tc ReadWriteTest, got interface{}, err error) {
+	var gotErr string
+	if err != nil {
+		gotErr = err.Error()
+		if tc.wantErr == "" {
+			t.Errorf("unexpected no error, got %q", gotErr)
+		}
+	}
+	if tc.wantErr != "" {
+		if !strings.Contains(gotErr, tc.wantErr) {
+			t.Errorf("unexpected error, expected to contain %q, got: %q ", tc.wantErr, gotErr)
+		}
+	}
+	if diff := cmp.Diff(tc.want, got); diff != "" {
+		t.Errorf("unexpected (-want, +got) = %v", diff)
+	}
+}

--- a/pkg/cloudevents/event_reader_writer_test.go
+++ b/pkg/cloudevents/event_reader_writer_test.go
@@ -18,19 +18,19 @@ type ReadWriteTest struct {
 func TestEventRW_SpecVersion(t *testing.T) {
 	testCases := map[string]ReadWriteTest{
 		"empty v01": {
-			event: ce.New(""),
-			set:   "0.1",
-			want:  "0.1",
+			event:   ce.New(),
+			set:     "0.1",
+			wantErr: "invalid version",
 		},
 		"empty v02": {
-			event: ce.New(""),
+			event: ce.New(),
 			set:   "0.2",
 			want:  "0.2",
 		},
 		"empty v03": {
-			event: ce.New(""),
-			set:   "0.3",
-			want:  "0.3",
+			event:   ce.New(),
+			set:     "0.3",
+			wantErr: "invalid version",
 		},
 		"v01": {
 			event: ce.New("0.1"),
@@ -50,29 +50,34 @@ func TestEventRW_SpecVersion(t *testing.T) {
 		"invalid v01": {
 			event:   ce.New("0.1"),
 			set:     "1.1",
-			want:    "0.1",
 			wantErr: "invalid version",
 		},
 		"invalid v02": {
 			event:   ce.New("0.2"),
 			set:     "1.2",
-			want:    "0.2",
 			wantErr: "invalid version",
 		},
 		"invalid v03": {
 			event:   ce.New("0.3"),
 			set:     "1.3",
-			want:    "0.3",
 			wantErr: "invalid version",
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 
-			err := tc.event.SetSpecVersion(tc.set)
-			got := tc.event.SpecVersion()
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			validateReaderWriter(t, tc, got, err)
+			tc.event.SetSpecVersion(tc.set)
+			got = tc.event.SpecVersion()
 		})
 	}
 }
@@ -112,11 +117,18 @@ func TestEventRW_Type(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			err := tc.event.SetType(tc.set)
-			got := tc.event.Type()
-
-			validateReaderWriter(t, tc, got, err)
+			tc.event.SetType(tc.set)
+			got = tc.event.Type()
 		})
 	}
 }
@@ -156,11 +168,18 @@ func TestEventRW_ID(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			err := tc.event.SetID(tc.set)
-			got := tc.event.ID()
-
-			validateReaderWriter(t, tc, got, err)
+			tc.event.SetID(tc.set)
+			got = tc.event.ID()
 		})
 	}
 }
@@ -185,29 +204,33 @@ func TestEventRW_Source(t *testing.T) {
 		"invalid v01": {
 			event:   ce.New("0.1"),
 			set:     "%",
-			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"invalid v02": {
 			event:   ce.New("0.2"),
 			set:     "%",
-			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"invalid v03": {
 			event:   ce.New("0.3"),
 			set:     "%",
-			want:    "",
 			wantErr: "invalid URL escape",
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			err := tc.event.SetSource(tc.set)
-			got := tc.event.Source()
-
-			validateReaderWriter(t, tc, got, err)
+			tc.event.SetSource(tc.set)
+			got = tc.event.Source()
 		})
 	}
 }
@@ -247,7 +270,7 @@ func TestEventRW_Subject(t *testing.T) {
 		"nilled v01": {
 			event: func() ce.Event {
 				e := ce.New("0.1")
-				_ = e.SetSource("should nil")
+				e.SetSource("should nil")
 				return e
 			}(),
 			want: "",
@@ -255,7 +278,7 @@ func TestEventRW_Subject(t *testing.T) {
 		"nilled v02": {
 			event: func() ce.Event {
 				e := ce.New("0.2")
-				_ = e.SetSource("should nil")
+				e.SetSource("should nil")
 				return e
 			}(),
 			want: "",
@@ -263,7 +286,7 @@ func TestEventRW_Subject(t *testing.T) {
 		"nilled v03": {
 			event: func() ce.Event {
 				e := ce.New("0.3")
-				_ = e.SetSource("should nil")
+				e.SetSource("should nil")
 				return e
 			}(),
 			want: "",
@@ -271,11 +294,18 @@ func TestEventRW_Subject(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			err := tc.event.SetSubject(tc.set)
-			got := tc.event.Subject()
-
-			validateReaderWriter(t, tc, got, err)
+			tc.event.SetSubject(tc.set)
+			got = tc.event.Subject()
 		})
 	}
 }
@@ -302,7 +332,7 @@ func TestEventRW_Time(t *testing.T) {
 		"nilled v01": {
 			event: func() ce.Event {
 				e := ce.New("0.1")
-				_ = e.SetTime(now)
+				e.SetTime(now)
 				return e
 			}(),
 			want: time.Time{},
@@ -310,7 +340,7 @@ func TestEventRW_Time(t *testing.T) {
 		"nilled v02": {
 			event: func() ce.Event {
 				e := ce.New("0.2")
-				_ = e.SetTime(now)
+				e.SetTime(now)
 				return e
 			}(),
 			want: time.Time{},
@@ -318,7 +348,7 @@ func TestEventRW_Time(t *testing.T) {
 		"nilled v03": {
 			event: func() ce.Event {
 				e := ce.New("0.3")
-				_ = e.SetTime(now)
+				e.SetTime(now)
 				return e
 			}(),
 			want: time.Time{},
@@ -326,16 +356,22 @@ func TestEventRW_Time(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			var err error
 			if tc.set == "now" {
-				err = tc.event.SetTime(now) // pull now from outer test.
+				tc.event.SetTime(now) // pull now from outer test.
 			} else {
-				err = tc.event.SetTime(time.Time{}) // pull now from outer test.
+				tc.event.SetTime(time.Time{}) // pull now from outer test.
 			}
-			got := tc.event.Time()
-
-			validateReaderWriter(t, tc, got, err)
+			got = tc.event.Time()
 		})
 	}
 }
@@ -360,25 +396,22 @@ func TestEventRW_SchemaURL(t *testing.T) {
 		"invalid v01": {
 			event:   ce.New("0.1"),
 			set:     "%",
-			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"invalid v02": {
 			event:   ce.New("0.2"),
 			set:     "%",
-			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"invalid v03": {
 			event:   ce.New("0.3"),
 			set:     "%",
-			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"nilled v01": {
 			event: func() ce.Event {
 				e := ce.New("0.1")
-				_ = e.SetSchemaURL("should nil")
+				e.SetSchemaURL("should nil")
 				return e
 			}(),
 			want: "",
@@ -386,7 +419,7 @@ func TestEventRW_SchemaURL(t *testing.T) {
 		"nilled v02": {
 			event: func() ce.Event {
 				e := ce.New("0.2")
-				_ = e.SetSchemaURL("should nil")
+				e.SetSchemaURL("should nil")
 				return e
 			}(),
 			want: "",
@@ -394,7 +427,7 @@ func TestEventRW_SchemaURL(t *testing.T) {
 		"nilled v03": {
 			event: func() ce.Event {
 				e := ce.New("0.3")
-				_ = e.SetSchemaURL("should nil")
+				e.SetSchemaURL("should nil")
 				return e
 			}(),
 			want: "",
@@ -402,11 +435,18 @@ func TestEventRW_SchemaURL(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			err := tc.event.SetSchemaURL(tc.set)
-			got := tc.event.SchemaURL()
-
-			validateReaderWriter(t, tc, got, err)
+			tc.event.SetSchemaURL(tc.set)
+			got = tc.event.SchemaURL()
 		})
 	}
 }
@@ -446,7 +486,7 @@ func TestEventRW_DataContentType(t *testing.T) {
 		"nilled v01": {
 			event: func() ce.Event {
 				e := ce.New("0.1")
-				_ = e.SetDataContentType("application/json")
+				e.SetDataContentType("application/json")
 				return e
 			}(),
 			want: "",
@@ -454,7 +494,7 @@ func TestEventRW_DataContentType(t *testing.T) {
 		"nilled v02": {
 			event: func() ce.Event {
 				e := ce.New("0.2")
-				_ = e.SetDataContentType("application/json")
+				e.SetDataContentType("application/json")
 				return e
 			}(),
 			want: "",
@@ -462,7 +502,7 @@ func TestEventRW_DataContentType(t *testing.T) {
 		"nilled v03": {
 			event: func() ce.Event {
 				e := ce.New("0.3")
-				_ = e.SetDataContentType("application/json")
+				e.SetDataContentType("application/json")
 				return e
 			}(),
 			want: "",
@@ -470,11 +510,18 @@ func TestEventRW_DataContentType(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			err := tc.event.SetDataContentType(tc.set)
-			got := tc.event.DataContentType()
-
-			validateReaderWriter(t, tc, got, err)
+			tc.event.SetDataContentType(tc.set)
+			got = tc.event.DataContentType()
 		})
 	}
 }
@@ -529,7 +576,7 @@ func TestEventRW_DataContentEncoding(t *testing.T) {
 		"nilled v01": {
 			event: func() ce.Event {
 				e := ce.New("0.1")
-				_ = e.SetDataContentEncoding("base64")
+				e.SetDataContentEncoding("base64")
 				return e
 			}(),
 			want: "",
@@ -537,7 +584,7 @@ func TestEventRW_DataContentEncoding(t *testing.T) {
 		"nilled v02": {
 			event: func() ce.Event {
 				e := ce.New("0.2")
-				_ = e.SetDataContentEncoding("base64")
+				e.SetDataContentEncoding("base64")
 				return e
 			}(),
 			want: "",
@@ -545,7 +592,7 @@ func TestEventRW_DataContentEncoding(t *testing.T) {
 		"nilled v03": {
 			event: func() ce.Event {
 				e := ce.New("0.3")
-				_ = e.SetDataContentEncoding("base64")
+				e.SetDataContentEncoding("base64")
 				return e
 			}(),
 			want: "",
@@ -553,11 +600,18 @@ func TestEventRW_DataContentEncoding(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			defer func() {
+				var err error
+				r := recover()
+				if r != nil {
+					err = r.(error)
+				}
+				validateReaderWriter(t, tc, got, err)
+			}()
 
-			err := tc.event.SetDataContentEncoding(tc.set)
-			got := tc.event.DataContentEncoding()
-
-			validateReaderWriter(t, tc, got, err)
+			tc.event.SetDataContentEncoding(tc.set)
+			got = tc.event.DataContentEncoding()
 		})
 	}
 }

--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -350,7 +350,7 @@ func TestString(t *testing.T) {
 	}{
 		"empty v0.1": {
 			event: ce.Event{
-				Context: ce.EventContextV01{},
+				Context: &ce.EventContextV01{},
 			},
 			want: `Validation: invalid
 Validation Error: 
@@ -367,7 +367,7 @@ Context Attributes,
 		},
 		"empty v0.2": {
 			event: ce.Event{
-				Context: ce.EventContextV02{},
+				Context: &ce.EventContextV02{},
 			},
 			want: `Validation: invalid
 Validation Error: 
@@ -384,7 +384,7 @@ Context Attributes,
 		},
 		"empty v0.3": {
 			event: ce.Event{
-				Context: ce.EventContextV03{},
+				Context: &ce.EventContextV03{},
 			},
 			want: `Validation: invalid
 Validation Error: 
@@ -637,7 +637,7 @@ func strptr(s string) *string {
 	return &s
 }
 
-func MinEventContextV01() ce.EventContextV01 {
+func MinEventContextV01() *ce.EventContextV01 {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
 
@@ -648,7 +648,7 @@ func MinEventContextV01() ce.EventContextV01 {
 	}.AsV01()
 }
 
-func MinEventContextV02() ce.EventContextV02 {
+func MinEventContextV02() *ce.EventContextV02 {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
 
@@ -659,7 +659,7 @@ func MinEventContextV02() ce.EventContextV02 {
 	}.AsV02()
 }
 
-func MinEventContextV03() ce.EventContextV03 {
+func MinEventContextV03() *ce.EventContextV03 {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
 
@@ -670,7 +670,7 @@ func MinEventContextV03() ce.EventContextV03 {
 	}.AsV03()
 }
 
-func FullEventContextV01(now types.Timestamp) ce.EventContextV01 {
+func FullEventContextV01(now types.Timestamp) *ce.EventContextV01 {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
 
@@ -693,7 +693,7 @@ func FullEventContextV01(now types.Timestamp) ce.EventContextV01 {
 	return eventContextV01.AsV01()
 }
 
-func FullEventContextV02(now types.Timestamp) ce.EventContextV02 {
+func FullEventContextV02(now types.Timestamp) *ce.EventContextV02 {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
 
@@ -719,7 +719,7 @@ func FullEventContextV02(now types.Timestamp) ce.EventContextV02 {
 	return eventContextV02.AsV02()
 }
 
-func FullEventContextV03(now types.Timestamp) ce.EventContextV03 {
+func FullEventContextV03(now types.Timestamp) *ce.EventContextV03 {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
 

--- a/pkg/cloudevents/event_writer.go
+++ b/pkg/cloudevents/event_writer.go
@@ -8,7 +8,7 @@ import (
 var _ EventWriter = (*Event)(nil)
 
 // SetSpecVersion implements EventWriter.SetSpecVersion
-func (e *Event) SetSpecVersion(v string) error {
+func (e *Event) SetSpecVersion(v string) {
 	if e.Context == nil {
 		switch v {
 		case CloudEventsVersionV01:
@@ -18,61 +18,75 @@ func (e *Event) SetSpecVersion(v string) error {
 		case CloudEventsVersionV03:
 			e.Context = EventContextV03{}.AsV03()
 		default:
-			return fmt.Errorf("a valid spec version is required: [%s, %s, %s]",
-				CloudEventsVersionV01, CloudEventsVersionV02, CloudEventsVersionV03)
+			panic(fmt.Errorf("a valid spec version is required: [%s, %s, %s]",
+				CloudEventsVersionV01, CloudEventsVersionV02, CloudEventsVersionV03))
 		}
-		return nil
+		return
 	}
-	return e.Context.SetSpecVersion(v)
+	if err := e.Context.SetSpecVersion(v); err != nil {
+		panic(err)
+	}
 }
 
 // SetType implements EventWriter.SetType
-func (e *Event) SetType(t string) error {
-	return e.Context.SetType(t)
+func (e *Event) SetType(t string) {
+	if err := e.Context.SetType(t); err != nil {
+		panic(err)
+	}
 }
 
 // SetSource implements EventWriter.SetSource
-func (e *Event) SetSource(s string) error {
-	return e.Context.SetSource(s)
+func (e *Event) SetSource(s string) {
+	if err := e.Context.SetSource(s); err != nil {
+		panic(err)
+	}
 }
 
 // SetSubject implements EventWriter.SetSubject
-func (e *Event) SetSubject(s string) error {
-	return e.Context.SetSubject(s)
+func (e *Event) SetSubject(s string) {
+	if err := e.Context.SetSubject(s); err != nil {
+		panic(err)
+	}
 }
 
 // SetID implements EventWriter.SetID
-func (e *Event) SetID(id string) error {
-	return e.Context.SetID(id)
+func (e *Event) SetID(id string) {
+	if err := e.Context.SetID(id); err != nil {
+		panic(err)
+	}
 }
 
 // SetTime implements EventWriter.SetTime
-func (e *Event) SetTime(t time.Time) error {
-	return e.Context.SetTime(t)
+func (e *Event) SetTime(t time.Time) {
+	if err := e.Context.SetTime(t); err != nil {
+		panic(err)
+	}
 }
 
 // SetSchemaURL implements EventWriter.SetSchemaURL
-func (e *Event) SetSchemaURL(s string) error {
-	return e.Context.SetSchemaURL(s)
+func (e *Event) SetSchemaURL(s string) {
+	if err := e.Context.SetSchemaURL(s); err != nil {
+		panic(err)
+	}
 }
 
 // SetDataContentType implements EventWriter.SetDataContentType
-func (e *Event) SetDataContentType(ct string) error {
-	return e.Context.SetDataContentType(ct)
+func (e *Event) SetDataContentType(ct string) {
+	if err := e.Context.SetDataContentType(ct); err != nil {
+		panic(err)
+	}
 }
 
 // SetDataContentEncoding implements EventWriter.SetDataContentEncoding
-func (e *Event) SetDataContentEncoding(enc string) error {
-	return e.Context.SetDataContentEncoding(enc)
+func (e *Event) SetDataContentEncoding(enc string) {
+	if err := e.Context.SetDataContentEncoding(enc); err != nil {
+		panic(err)
+	}
 }
 
 // SetDataContentEncoding implements EventWriter.SetDataContentEncoding
-func (e *Event) SetExtension(name string, obj interface{}) error {
-	return e.Context.SetExtension(name, obj)
-}
-
-// SetData implements EventWriter.SetData
-func (e *Event) SetData(obj interface{}) error {
-	e.Data = obj
-	return nil
+func (e *Event) SetExtension(name string, obj interface{}) {
+	if err := e.Context.SetExtension(name, obj); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/cloudevents/event_writer.go
+++ b/pkg/cloudevents/event_writer.go
@@ -1,0 +1,78 @@
+package cloudevents
+
+import (
+	"fmt"
+	"time"
+)
+
+var _ EventWriter = (*Event)(nil)
+
+// SetSpecVersion implements EventWriter.SetSpecVersion
+func (e *Event) SetSpecVersion(v string) error {
+	if e.Context == nil {
+		switch v {
+		case CloudEventsVersionV01:
+			e.Context = EventContextV01{}.AsV01()
+		case CloudEventsVersionV02:
+			e.Context = EventContextV02{}.AsV02()
+		case CloudEventsVersionV03:
+			e.Context = EventContextV03{}.AsV03()
+		default:
+			return fmt.Errorf("a valid spec version is required: [%s, %s, %s]",
+				CloudEventsVersionV01, CloudEventsVersionV02, CloudEventsVersionV03)
+		}
+		return nil
+	}
+	return e.Context.SetSpecVersion(v)
+}
+
+// SetType implements EventWriter.SetType
+func (e *Event) SetType(t string) error {
+	return e.Context.SetType(t)
+}
+
+// SetSource implements EventWriter.SetSource
+func (e *Event) SetSource(s string) error {
+	return e.Context.SetSource(s)
+}
+
+// SetSubject implements EventWriter.SetSubject
+func (e *Event) SetSubject(s string) error {
+	return e.Context.SetSubject(s)
+}
+
+// SetID implements EventWriter.SetID
+func (e *Event) SetID(id string) error {
+	return e.Context.SetID(id)
+}
+
+// SetTime implements EventWriter.SetTime
+func (e *Event) SetTime(t time.Time) error {
+	return e.Context.SetTime(t)
+}
+
+// SetSchemaURL implements EventWriter.SetSchemaURL
+func (e *Event) SetSchemaURL(s string) error {
+	return e.Context.SetSchemaURL(s)
+}
+
+// SetDataContentType implements EventWriter.SetDataContentType
+func (e *Event) SetDataContentType(ct string) error {
+	return e.Context.SetDataContentType(ct)
+}
+
+// SetDataContentEncoding implements EventWriter.SetDataContentEncoding
+func (e *Event) SetDataContentEncoding(enc string) error {
+	return e.Context.SetDataContentEncoding(enc)
+}
+
+// SetDataContentEncoding implements EventWriter.SetDataContentEncoding
+func (e *Event) SetExtension(name string, obj interface{}) error {
+	return e.Context.SetExtension(name, obj)
+}
+
+// SetData implements EventWriter.SetData
+func (e *Event) SetData(obj interface{}) error {
+	e.Data = obj
+	return nil
+}

--- a/pkg/cloudevents/eventcontext.go
+++ b/pkg/cloudevents/eventcontext.go
@@ -1,54 +1,103 @@
 package cloudevents
 
-// EventContext is conical interface for a CloudEvents Context.
-type EventContext interface {
+import "time"
+
+// EventContextReader are the methods required to be a reader of context
+// attributes.
+type EventContextReader interface {
+	// GetSpecVersion returns the native CloudEvents Spec version of the event
+	// context.
+	GetSpecVersion() string
+	// GetType returns the CloudEvents type from the context.
+	GetType() string
+	// GetSource returns the CloudEvents source from the context.
+	GetSource() string
+	// GetSubject returns the CloudEvents subject from the context.
+	GetSubject() string
+	// GetID returns the CloudEvents ID from the context.
+	GetID() string
+	// GetTime returns the CloudEvents creation time from the context.
+	GetTime() time.Time
+	// GetSchemaURL returns the CloudEvents schema URL (if any) from the
+	// context.
+	GetSchemaURL() string
+	// GetDataContentType returns content type on the context.
+	GetDataContentType() string
+	// GetDataMediaType returns the MIME media type for encoded data, which is
+	// needed by both encoding and decoding.
+	GetDataMediaType() string
+	// GetDataContentEncoding returns content encoding on the context.
+	GetDataContentEncoding() string
+
+	// ExtensionAs populates the given interface with the CloudEvents extension
+	// of the given name from the extension attributes. It returns an error if
+	// the extension does not exist, the extension's type does not match the
+	// provided type, or if the type is not a supported.
+	ExtensionAs(string, interface{}) error
+}
+
+// EventContextWriter are the methods required to be a writer of context
+// attributes.
+type EventContextWriter interface {
+	// SetSpecVersion sets the spec version of the context.
+	SetSpecVersion(string) error
+	// SetType sets the type of the context.
+	SetType(string) error
+	// SetSource sets the source of the context.
+	SetSource(string) error
+	// SetSubject sets the subject of the context.
+	SetSubject(string) error
+	// SetID sets the ID of the context.
+	SetID(string) error
+	// SetTime sets the time of the context.
+	SetTime(time time.Time) error
+	// SetSchemaURL sets the schema url of the context.
+	SetSchemaURL(string) error
+	// SetDataContentType sets the data content type of the context.
+	SetDataContentType(string) error
+	// SetDataContentEncoding sets the data context encoding of the context.
+	SetDataContentEncoding(string) error
+
+	// SetExtension sets the given interface onto the extension attributes
+	// determined by the provided name.
+	SetExtension(string, interface{}) error
+}
+
+type EventContextConverter interface {
 	// AsV01 provides a translation from whatever the "native" encoding of the
 	// CloudEvent was to the equivalent in v0.1 field names, moving fields to or
 	// from extensions as necessary.
-	AsV01() EventContextV01
+	AsV01() *EventContextV01
 
 	// AsV02 provides a translation from whatever the "native" encoding of the
 	// CloudEvent was to the equivalent in v0.2 field names, moving fields to or
 	// from extensions as necessary.
-	AsV02() EventContextV02
+	AsV02() *EventContextV02
 
 	// AsV03 provides a translation from whatever the "native" encoding of the
 	// CloudEvent was to the equivalent in v0.3 field names, moving fields to or
 	// from extensions as necessary.
-	AsV03() EventContextV03
+	AsV03() *EventContextV03
+}
 
-	// GetDataContentType returns content type on the context.
-	GetDataContentType() string
+// EventContext is conical interface for a CloudEvents Context.
+type EventContext interface {
+	// EventContextConverter allows for conversion between versions.
+	EventContextConverter
 
-	// GetDataContentEncoding returns content encoding on the context.
-	GetDataContentEncoding() string
+	// EventContextReader adds methods for reading context.
+	EventContextReader
 
-	// GetDataMediaType returns the MIME media type for encoded data, which is
-	// needed by both encoding and decoding.
-	GetDataMediaType() string
-
-	// GetSpecVersion returns the native CloudEvents Spec version of the event
-	// context.
-	GetSpecVersion() string
-
-	// GetType returns the CloudEvents type from the context.
-	GetType() string
-
-	// GetSource returns the CloudEvents source from the context.
-	GetSource() string
-
-	// GetSubject returns the CloudEvents subject from the context.
-	GetSubject() string
-
-	// GetSchemaURL returns the CloudEvents schema URL (if any) from the context.
-	GetSchemaURL() string
-
-	// ExtensionAs populates 'obj' with the CloudEvents extension 'name' from the context.
-	// It returns an error if the extension 'name' does not exist, the extension's type
-	// does not match the 'obj' type, or if the 'obj' type is not a supported.
-	ExtensionAs(name string, obj interface{}) error
+	// EventContextWriter adds methods for writing to context.
+	EventContextWriter
 
 	// Validate the event based on the specifics of the CloudEvents spec version
 	// represented by this event context.
 	Validate() error
+
+	// Clone clones the event context.
+	Clone() EventContext
+
+	// String returns a pretty-printed representation of the EventContext.
+	String() string
 }

--- a/pkg/cloudevents/eventcontext_test.go
+++ b/pkg/cloudevents/eventcontext_test.go
@@ -13,13 +13,13 @@ func TestContextAsV01(t *testing.T) {
 
 	testCases := map[string]struct {
 		event ce.Event
-		want  ce.EventContextV01
+		want  *ce.EventContextV01
 	}{
 		"empty, no conversion": {
 			event: ce.Event{
-				Context: ce.EventContextV01{},
+				Context: &ce.EventContextV01{},
 			},
-			want: ce.EventContextV01{
+			want: &ce.EventContextV01{
 				CloudEventsVersion: "0.1",
 			},
 		},
@@ -77,13 +77,13 @@ func TestContextAsV02(t *testing.T) {
 
 	testCases := map[string]struct {
 		event ce.Event
-		want  ce.EventContextV02
+		want  *ce.EventContextV02
 	}{
 		"empty, no conversion": {
 			event: ce.Event{
-				Context: ce.EventContextV02{},
+				Context: &ce.EventContextV02{},
 			},
-			want: ce.EventContextV02{
+			want: &ce.EventContextV02{
 				SpecVersion: "0.2",
 			},
 		},
@@ -141,13 +141,13 @@ func TestContextAsV03(t *testing.T) {
 
 	testCases := map[string]struct {
 		event ce.Event
-		want  ce.EventContextV03
+		want  *ce.EventContextV03
 	}{
 		"empty, no conversion": {
 			event: ce.Event{
-				Context: ce.EventContextV02{},
+				Context: &ce.EventContextV02{},
 			},
-			want: ce.EventContextV03{
+			want: &ce.EventContextV03{
 				SpecVersion: "0.3",
 			},
 		},

--- a/pkg/cloudevents/eventcontext_v01.go
+++ b/pkg/cloudevents/eventcontext_v01.go
@@ -3,8 +3,7 @@ package cloudevents
 import (
 	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"log"
-	"mime"
+	"sort"
 	"strings"
 )
 
@@ -41,72 +40,7 @@ type EventContextV01 struct {
 // Adhere to EventContext
 var _ EventContext = (*EventContextV01)(nil)
 
-// GetSpecVersion implements EventContext.GetSpecVersion
-func (ec EventContextV01) GetSpecVersion() string {
-	if ec.CloudEventsVersion != "" {
-		return ec.CloudEventsVersion
-	}
-	return CloudEventsVersionV01
-}
-
-// GetDataContentType implements EventContext.GetDataContentType
-func (ec EventContextV01) GetDataContentType() string {
-	if ec.ContentType != nil {
-		return *ec.ContentType
-	}
-	return ""
-}
-
-// GetDataMediaType implements EventContext.GetDataMediaType
-func (ec EventContextV01) GetDataMediaType() string {
-	if ec.ContentType != nil {
-		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
-		if err != nil {
-			log.Printf("failed to parse media type from ContentType: %s", err)
-			return ""
-		}
-		return mediaType
-	}
-	return ""
-}
-
-// GetType implements EventContext.GetType
-func (ec EventContextV01) GetType() string {
-	return ec.EventType
-}
-
-// GetSource implements EventContext.GetSource
-func (ec EventContextV01) GetSource() string {
-	return ec.Source.String()
-}
-
-// GetSubject implements EventContext.GetSubject
-func (ec EventContextV01) GetSubject() string {
-	var sub string
-	if err := ec.ExtensionAs(SubjectKey, &sub); err != nil {
-		return ""
-	}
-	return sub
-}
-
-// GetSchemaURL implements EventContext.GetSchemaURL
-func (ec EventContextV01) GetSchemaURL() string {
-	if ec.SchemaURL != nil {
-		return ec.SchemaURL.String()
-	}
-	return ""
-}
-
-// GetDataContentEncoding implements EventContext.GetDataContentEncoding
-func (ec EventContextV01) GetDataContentEncoding() string {
-	var enc string
-	if err := ec.ExtensionAs(DataContentEncodingKey, &enc); err != nil {
-		return ""
-	}
-	return enc
-}
-
-// ExtensionAs implements EventContext.ExtensionAs
+// ExtensionAs implements EventContextReader.ExtensionAs
 func (ec EventContextV01) ExtensionAs(name string, obj interface{}) error {
 	value, ok := ec.Extensions[name]
 	if !ok {
@@ -127,21 +61,31 @@ func (ec EventContextV01) ExtensionAs(name string, obj interface{}) error {
 }
 
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
-func (ec *EventContextV01) SetExtension(name string, value interface{}) {
+func (ec *EventContextV01) SetExtension(name string, value interface{}) error {
 	if ec.Extensions == nil {
 		ec.Extensions = make(map[string]interface{})
 	}
-	ec.Extensions[name] = value
+	if value == nil {
+		delete(ec.Extensions, name)
+	} else {
+		ec.Extensions[name] = value
+	}
+	return nil
 }
 
-// AsV01 implements EventContext.AsV01
-func (ec EventContextV01) AsV01() EventContextV01 {
+// Clone implements EventContextConverter.Clone
+func (ec EventContextV01) Clone() EventContext {
+	return ec.AsV01()
+}
+
+// AsV01 implements EventContextConverter.AsV01
+func (ec EventContextV01) AsV01() *EventContextV01 {
 	ec.CloudEventsVersion = CloudEventsVersionV01
-	return ec
+	return &ec
 }
 
-// AsV02 implements EventContext.AsV02
-func (ec EventContextV01) AsV02() EventContextV02 {
+// AsV02 implements EventContextConverter.AsV02
+func (ec EventContextV01) AsV02() *EventContextV02 {
 	ret := EventContextV02{
 		SpecVersion: CloudEventsVersionV02,
 		Type:        ec.EventType,
@@ -165,11 +109,11 @@ func (ec EventContextV01) AsV02() EventContextV02 {
 	if len(ret.Extensions) == 0 {
 		ret.Extensions = nil
 	}
-	return ret
+	return &ret
 }
 
-// AsV03 implements EventContext.AsV03
-func (ec EventContextV01) AsV03() EventContextV03 {
+// AsV03 implements EventContextConverter.AsV03
+func (ec EventContextV01) AsV03() *EventContextV03 {
 	ecv2 := ec.AsV02()
 	return ecv2.AsV03()
 }
@@ -282,4 +226,42 @@ func (ec EventContextV01) Validate() error {
 		return fmt.Errorf(strings.Join(errors, "\n"))
 	}
 	return nil
+}
+
+// String returns a pretty-printed representation of the EventContext.
+func (ec EventContextV01) String() string {
+	b := strings.Builder{}
+
+	b.WriteString("Context Attributes,\n")
+
+	b.WriteString("  cloudEventsVersion: " + ec.CloudEventsVersion + "\n")
+	b.WriteString("  eventType: " + ec.EventType + "\n")
+	if ec.EventTypeVersion != nil {
+		b.WriteString("  eventTypeVersion: " + *ec.EventTypeVersion + "\n")
+	}
+	b.WriteString("  source: " + ec.Source.String() + "\n")
+	b.WriteString("  eventID: " + ec.EventID + "\n")
+	if ec.EventTime != nil {
+		b.WriteString("  eventTime: " + ec.EventTime.String() + "\n")
+	}
+	if ec.SchemaURL != nil {
+		b.WriteString("  schemaURL: " + ec.SchemaURL.String() + "\n")
+	}
+	if ec.ContentType != nil {
+		b.WriteString("  contentType: " + *ec.ContentType + "\n")
+	}
+
+	if ec.Extensions != nil && len(ec.Extensions) > 0 {
+		b.WriteString("Extensions,\n")
+		keys := make([]string, 0, len(ec.Extensions))
+		for k := range ec.Extensions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			b.WriteString(fmt.Sprintf("  %s: %v\n", key, ec.Extensions[key]))
+		}
+	}
+
+	return b.String()
 }

--- a/pkg/cloudevents/eventcontext_v01_reader.go
+++ b/pkg/cloudevents/eventcontext_v01_reader.go
@@ -1,0 +1,88 @@
+package cloudevents
+
+import (
+	"log"
+	"mime"
+	"time"
+)
+
+// Adhere to EventContextReader
+var _ EventContextReader = (*EventContextV01)(nil)
+
+// GetSpecVersion implements EventContextReader.GetSpecVersion
+func (ec EventContextV01) GetSpecVersion() string {
+	if ec.CloudEventsVersion != "" {
+		return ec.CloudEventsVersion
+	}
+	return CloudEventsVersionV01
+}
+
+// GetDataContentType implements EventContextReader.GetDataContentType
+func (ec EventContextV01) GetDataContentType() string {
+	if ec.ContentType != nil {
+		return *ec.ContentType
+	}
+	return ""
+}
+
+// GetDataMediaType implements EventContextReader.GetDataMediaType
+func (ec EventContextV01) GetDataMediaType() string {
+	if ec.ContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
+		if err != nil {
+			log.Printf("failed to parse media type from ContentType: %s", err)
+			return ""
+		}
+		return mediaType
+	}
+	return ""
+}
+
+// GetType implements EventContextReader.GetType
+func (ec EventContextV01) GetType() string {
+	return ec.EventType
+}
+
+// GetSource implements EventContextReader.GetSource
+func (ec EventContextV01) GetSource() string {
+	return ec.Source.String()
+}
+
+// GetSubject implements EventContextReader.GetSubject
+func (ec EventContextV01) GetSubject() string {
+	var sub string
+	if err := ec.ExtensionAs(SubjectKey, &sub); err != nil {
+		return ""
+	}
+	return sub
+}
+
+// GetID implements EventContextReader.GetID
+func (ec EventContextV01) GetID() string {
+	return ec.EventID
+}
+
+// GetTime implements EventContextReader.GetTime
+func (ec EventContextV01) GetTime() time.Time {
+	if ec.EventTime != nil {
+		return ec.EventTime.Time
+	}
+	return time.Time{}
+}
+
+// GetSchemaURL implements EventContextReader.GetSchemaURL
+func (ec EventContextV01) GetSchemaURL() string {
+	if ec.SchemaURL != nil {
+		return ec.SchemaURL.String()
+	}
+	return ""
+}
+
+// GetDataContentEncoding implements EventContextReader.GetDataContentEncoding
+func (ec EventContextV01) GetDataContentEncoding() string {
+	var enc string
+	if err := ec.ExtensionAs(DataContentEncodingKey, &enc); err != nil {
+		return ""
+	}
+	return enc
+}

--- a/pkg/cloudevents/eventcontext_v01_writer.go
+++ b/pkg/cloudevents/eventcontext_v01_writer.go
@@ -1,0 +1,103 @@
+package cloudevents
+
+import (
+	"errors"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Adhere to EventContextWriter
+var _ EventContextWriter = (*EventContextV01)(nil)
+
+// SetSpecVersion implements EventContextWriter.SetSpecVersion
+func (ec *EventContextV01) SetSpecVersion(v string) error {
+	if v != CloudEventsVersionV01 {
+		return fmt.Errorf("invalid version %q, expecting %q", v, CloudEventsVersionV01)
+	}
+	ec.CloudEventsVersion = CloudEventsVersionV01
+	return nil
+}
+
+// SetDataContentType implements EventContextWriter.SetDataContentType
+func (ec *EventContextV01) SetDataContentType(ct string) error {
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		ec.ContentType = nil
+	} else {
+		ec.ContentType = &ct
+	}
+	return nil
+}
+
+// SetType implements EventContextWriter.SetType
+func (ec *EventContextV01) SetType(t string) error {
+	t = strings.TrimSpace(t)
+	ec.EventType = t
+	return nil
+}
+
+// SetSource implements EventContextWriter.SetSource
+func (ec *EventContextV01) SetSource(u string) error {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.Source = types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetSubject implements EventContextWriter.SetSubject
+func (ec *EventContextV01) SetSubject(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ec.SetExtension(SubjectKey, nil)
+	}
+	return ec.SetExtension(SubjectKey, s)
+}
+
+// SetID implements EventContextWriter.SetID
+func (ec *EventContextV01) SetID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("event id is required to be a non-empty string")
+	}
+	ec.EventID = id
+	return nil
+}
+
+// SetTime implements EventContextWriter.SetTime
+func (ec *EventContextV01) SetTime(t time.Time) error {
+	if t.IsZero() {
+		ec.EventTime = nil
+	} else {
+		ec.EventTime = &types.Timestamp{Time: t}
+	}
+	return nil
+}
+
+// SetSchemaURL implements EventContextWriter.SetSchemaURL
+func (ec *EventContextV01) SetSchemaURL(u string) error {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		ec.SchemaURL = nil
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.SchemaURL = &types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetDataContentEncoding implements EventContextWriter.SetDataContentEncoding
+func (ec *EventContextV01) SetDataContentEncoding(e string) error {
+	e = strings.ToLower(strings.TrimSpace(e))
+	if e == "" {
+		return ec.SetExtension(DataContentEncodingKey, nil)
+	}
+	return ec.SetExtension(DataContentEncodingKey, e)
+}

--- a/pkg/cloudevents/eventcontext_v02.go
+++ b/pkg/cloudevents/eventcontext_v02.go
@@ -3,8 +3,7 @@ package cloudevents
 import (
 	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"log"
-	"mime"
+	"sort"
 	"strings"
 )
 
@@ -38,71 +37,6 @@ type EventContextV02 struct {
 // Adhere to EventContext
 var _ EventContext = (*EventContextV02)(nil)
 
-// GetSpecVersion implements EventContext.GetSpecVersion
-func (ec EventContextV02) GetSpecVersion() string {
-	if ec.SpecVersion != "" {
-		return ec.SpecVersion
-	}
-	return CloudEventsVersionV02
-}
-
-// GetDataContentType implements EventContext.GetDataContentType
-func (ec EventContextV02) GetDataContentType() string {
-	if ec.ContentType != nil {
-		return *ec.ContentType
-	}
-	return ""
-}
-
-// GetDataMediaType implements EventContext.GetDataMediaType
-func (ec EventContextV02) GetDataMediaType() string {
-	if ec.ContentType != nil {
-		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
-		if err != nil {
-			log.Printf("failed to parse media type from ContentType: %s", err)
-			return ""
-		}
-		return mediaType
-	}
-	return ""
-}
-
-// GetDataContentEncoding implements EventContext.GetDataContentEncoding
-func (ec EventContextV02) GetDataContentEncoding() string {
-	var enc string
-	if err := ec.ExtensionAs(DataContentEncodingKey, &enc); err != nil {
-		return ""
-	}
-	return enc
-}
-
-// GetType implements EventContext.GetType
-func (ec EventContextV02) GetType() string {
-	return ec.Type
-}
-
-// GetSource implements EventContext.GetSource
-func (ec EventContextV02) GetSource() string {
-	return ec.Source.String()
-}
-
-// GetSubject implements EventContext.GetSubject
-func (ec EventContextV02) GetSubject() string {
-	var sub string
-	if err := ec.ExtensionAs(SubjectKey, &sub); err != nil {
-		return ""
-	}
-	return sub
-}
-
-// GetSchemaURL implements EventContext.GetSchemaURL
-func (ec EventContextV02) GetSchemaURL() string {
-	if ec.SchemaURL != nil {
-		return ec.SchemaURL.String()
-	}
-	return ""
-}
-
 // ExtensionAs implements EventContext.ExtensionAs
 func (ec EventContextV02) ExtensionAs(name string, obj interface{}) error {
 	value, ok := ec.Extensions[name]
@@ -124,15 +58,25 @@ func (ec EventContextV02) ExtensionAs(name string, obj interface{}) error {
 }
 
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
-func (ec *EventContextV02) SetExtension(name string, value interface{}) {
+func (ec *EventContextV02) SetExtension(name string, value interface{}) error {
 	if ec.Extensions == nil {
 		ec.Extensions = make(map[string]interface{})
 	}
-	ec.Extensions[name] = value
+	if value == nil {
+		delete(ec.Extensions, name)
+	} else {
+		ec.Extensions[name] = value
+	}
+	return nil
 }
 
-// AsV01 implements EventContext.AsV01
-func (ec EventContextV02) AsV01() EventContextV01 {
+// Clone implements EventContextConverter.Clone
+func (ec EventContextV02) Clone() EventContext {
+	return ec.AsV02()
+}
+
+// AsV01 implements EventContextConverter.AsV01
+func (ec EventContextV02) AsV01() *EventContextV01 {
 	ret := EventContextV01{
 		CloudEventsVersion: CloudEventsVersionV01,
 		EventID:            ec.ID,
@@ -158,17 +102,17 @@ func (ec EventContextV02) AsV01() EventContextV01 {
 	if len(ret.Extensions) == 0 {
 		ret.Extensions = nil
 	}
-	return ret
+	return &ret
 }
 
-// AsV02 implements EventContext.AsV02
-func (ec EventContextV02) AsV02() EventContextV02 {
+// AsV02 implements EventContextConverter.AsV02
+func (ec EventContextV02) AsV02() *EventContextV02 {
 	ec.SpecVersion = CloudEventsVersionV02
-	return ec
+	return &ec
 }
 
-// AsV03 implements EventContext.AsV03
-func (ec EventContextV02) AsV03() EventContextV03 {
+// AsV03 implements EventContextConverter.AsV03
+func (ec EventContextV02) AsV03() *EventContextV03 {
 	ret := EventContextV03{
 		SpecVersion:     CloudEventsVersionV03,
 		ID:              ec.ID,
@@ -203,7 +147,7 @@ func (ec EventContextV02) AsV03() EventContextV03 {
 		ret.Extensions = nil
 	}
 
-	return ret
+	return &ret
 }
 
 // Validate returns errors based on requirements from the CloudEvents spec.
@@ -291,4 +235,39 @@ func (ec EventContextV02) Validate() error {
 		return fmt.Errorf(strings.Join(errors, "\n"))
 	}
 	return nil
+}
+
+// String returns a pretty-printed representation of the EventContext.
+func (ec EventContextV02) String() string {
+	b := strings.Builder{}
+
+	b.WriteString("Context Attributes,\n")
+
+	b.WriteString("  specversion: " + ec.SpecVersion + "\n")
+	b.WriteString("  type: " + ec.Type + "\n")
+	b.WriteString("  source: " + ec.Source.String() + "\n")
+	b.WriteString("  id: " + ec.ID + "\n")
+	if ec.Time != nil {
+		b.WriteString("  time: " + ec.Time.String() + "\n")
+	}
+	if ec.SchemaURL != nil {
+		b.WriteString("  schemaurl: " + ec.SchemaURL.String() + "\n")
+	}
+	if ec.ContentType != nil {
+		b.WriteString("  contenttype: " + *ec.ContentType + "\n")
+	}
+
+	if ec.Extensions != nil && len(ec.Extensions) > 0 {
+		b.WriteString("Extensions,\n")
+		keys := make([]string, 0, len(ec.Extensions))
+		for k := range ec.Extensions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			b.WriteString(fmt.Sprintf("  %s: %v\n", key, ec.Extensions[key]))
+		}
+	}
+
+	return b.String()
 }

--- a/pkg/cloudevents/eventcontext_v02_reader.go
+++ b/pkg/cloudevents/eventcontext_v02_reader.go
@@ -1,0 +1,88 @@
+package cloudevents
+
+import (
+	"log"
+	"mime"
+	"time"
+)
+
+// Adhere to EventContextReader
+var _ EventContextReader = (*EventContextV02)(nil)
+
+// GetSpecVersion implements EventContextReader.GetSpecVersion
+func (ec EventContextV02) GetSpecVersion() string {
+	if ec.SpecVersion != "" {
+		return ec.SpecVersion
+	}
+	return CloudEventsVersionV02
+}
+
+// GetType implements EventContextReader.GetType
+func (ec EventContextV02) GetType() string {
+	return ec.Type
+}
+
+// GetSource implements EventContextReader.GetSource
+func (ec EventContextV02) GetSource() string {
+	return ec.Source.String()
+}
+
+// GetSubject implements EventContextReader.GetSubject
+func (ec EventContextV02) GetSubject() string {
+	var sub string
+	if err := ec.ExtensionAs(SubjectKey, &sub); err != nil {
+		return ""
+	}
+	return sub
+}
+
+// GetID implements EventContextReader.GetID
+func (ec EventContextV02) GetID() string {
+	return ec.ID
+}
+
+// GetTime implements EventContextReader.GetTime
+func (ec EventContextV02) GetTime() time.Time {
+	if ec.Time != nil {
+		return ec.Time.Time
+	}
+	return time.Time{}
+}
+
+// GetSchemaURL implements EventContextReader.GetSchemaURL
+func (ec EventContextV02) GetSchemaURL() string {
+	if ec.SchemaURL != nil {
+		return ec.SchemaURL.String()
+	}
+	return ""
+}
+
+// GetDataContentType implements EventContextReader.GetDataContentType
+func (ec EventContextV02) GetDataContentType() string {
+	if ec.ContentType != nil {
+		return *ec.ContentType
+	}
+	return ""
+}
+
+// GetDataMediaType implements EventContextReader.GetDataMediaType
+func (ec EventContextV02) GetDataMediaType() string {
+	if ec.ContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
+		if err != nil {
+			log.Printf("failed to parse media type from ContentType: %s", err)
+			return ""
+		}
+		return mediaType
+	}
+	return ""
+}
+
+// GetDataContentEncoding implements EventContextReader.GetDataContentEncoding
+func (ec EventContextV02) GetDataContentEncoding() string {
+	var enc string
+	if err := ec.ExtensionAs(DataContentEncodingKey, &enc); err != nil {
+		return ""
+	}
+	return enc
+}

--- a/pkg/cloudevents/eventcontext_v02_writer.go
+++ b/pkg/cloudevents/eventcontext_v02_writer.go
@@ -1,0 +1,103 @@
+package cloudevents
+
+import (
+	"errors"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Adhere to EventContextWriter
+var _ EventContextWriter = (*EventContextV02)(nil)
+
+// SetSpecVersion implements EventContextWriter.SetSpecVersion
+func (ec *EventContextV02) SetSpecVersion(v string) error {
+	if v != CloudEventsVersionV02 {
+		return fmt.Errorf("invalid version %q, expecting %q", v, CloudEventsVersionV02)
+	}
+	ec.SpecVersion = CloudEventsVersionV02
+	return nil
+}
+
+// SetDataContentType implements EventContextWriter.SetDataContentType
+func (ec *EventContextV02) SetDataContentType(ct string) error {
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		ec.ContentType = nil
+	} else {
+		ec.ContentType = &ct
+	}
+	return nil
+}
+
+// SetType implements EventContextWriter.SetType
+func (ec *EventContextV02) SetType(t string) error {
+	t = strings.TrimSpace(t)
+	ec.Type = t
+	return nil
+}
+
+// SetSource implements EventContextWriter.SetSource
+func (ec *EventContextV02) SetSource(u string) error {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.Source = types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetSubject implements EventContextWriter.SetSubject
+func (ec *EventContextV02) SetSubject(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ec.SetExtension(SubjectKey, nil)
+	}
+	return ec.SetExtension(SubjectKey, s)
+}
+
+// SetID implements EventContextWriter.SetID
+func (ec *EventContextV02) SetID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("id is required to be a non-empty string")
+	}
+	ec.ID = id
+	return nil
+}
+
+// SetTime implements EventContextWriter.SetTime
+func (ec *EventContextV02) SetTime(t time.Time) error {
+	if t.IsZero() {
+		ec.Time = nil
+	} else {
+		ec.Time = &types.Timestamp{Time: t}
+	}
+	return nil
+}
+
+// SetSchemaURL implements EventContextWriter.SetSchemaURL
+func (ec *EventContextV02) SetSchemaURL(u string) error {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		ec.SchemaURL = nil
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.SchemaURL = &types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetDataContentEncoding implements EventContextWriter.SetDataContentEncoding
+func (ec *EventContextV02) SetDataContentEncoding(e string) error {
+	e = strings.ToLower(strings.TrimSpace(e))
+	if e == "" {
+		return ec.SetExtension(DataContentEncodingKey, nil)
+	}
+	return ec.SetExtension(DataContentEncodingKey, e)
+}

--- a/pkg/cloudevents/eventcontext_v03_reader.go
+++ b/pkg/cloudevents/eventcontext_v03_reader.go
@@ -1,0 +1,83 @@
+package cloudevents
+
+import (
+	"log"
+	"mime"
+	"time"
+)
+
+// GetSpecVersion implements EventContextReader.GetSpecVersion
+func (ec EventContextV03) GetSpecVersion() string {
+	if ec.SpecVersion != "" {
+		return ec.SpecVersion
+	}
+	return CloudEventsVersionV03
+}
+
+// GetDataContentType implements EventContextReader.GetDataContentType
+func (ec EventContextV03) GetDataContentType() string {
+	if ec.DataContentType != nil {
+		return *ec.DataContentType
+	}
+	return ""
+}
+
+// GetDataMediaType implements EventContextReader.GetDataMediaType
+func (ec EventContextV03) GetDataMediaType() string {
+	if ec.DataContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
+		if err != nil {
+			log.Printf("failed to parse media type from DataContentType: %s", err)
+			return ""
+		}
+		return mediaType
+	}
+	return ""
+}
+
+// GetType implements EventContextReader.GetType
+func (ec EventContextV03) GetType() string {
+	return ec.Type
+}
+
+// GetSource implements EventContextReader.GetSource
+func (ec EventContextV03) GetSource() string {
+	return ec.Source.String()
+}
+
+// GetSubject implements EventContextReader.GetSubject
+func (ec EventContextV03) GetSubject() string {
+	if ec.Subject != nil {
+		return *ec.Subject
+	}
+	return ""
+}
+
+// GetTime implements EventContextReader.GetTime
+func (ec EventContextV03) GetTime() time.Time {
+	if ec.Time != nil {
+		return ec.Time.Time
+	}
+	return time.Time{}
+}
+
+// GetID implements EventContextReader.GetID
+func (ec EventContextV03) GetID() string {
+	return ec.ID
+}
+
+// GetSchemaURL implements EventContextReader.GetSchemaURL
+func (ec EventContextV03) GetSchemaURL() string {
+	if ec.SchemaURL != nil {
+		return ec.SchemaURL.String()
+	}
+	return ""
+}
+
+// GetDataContentEncoding implements EventContextReader.GetDataContentEncoding
+func (ec EventContextV03) GetDataContentEncoding() string {
+	if ec.DataContentEncoding != nil {
+		return *ec.DataContentEncoding
+	}
+	return ""
+}

--- a/pkg/cloudevents/eventcontext_v03_writer.go
+++ b/pkg/cloudevents/eventcontext_v03_writer.go
@@ -1,0 +1,107 @@
+package cloudevents
+
+import (
+	"errors"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Adhere to EventContextWriter
+var _ EventContextWriter = (*EventContextV03)(nil)
+
+// SetSpecVersion implements EventContextWriter.SetSpecVersion
+func (ec *EventContextV03) SetSpecVersion(v string) error {
+	if v != CloudEventsVersionV03 {
+		return fmt.Errorf("invalid version %q, expecting %q", v, CloudEventsVersionV03)
+	}
+	ec.SpecVersion = CloudEventsVersionV03
+	return nil
+}
+
+// SetDataContentType implements EventContextWriter.SetDataContentType
+func (ec *EventContextV03) SetDataContentType(ct string) error {
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		ec.DataContentType = nil
+	} else {
+		ec.DataContentType = &ct
+	}
+	return nil
+}
+
+// SetType implements EventContextWriter.SetType
+func (ec *EventContextV03) SetType(t string) error {
+	t = strings.TrimSpace(t)
+	ec.Type = t
+	return nil
+}
+
+// SetSource implements EventContextWriter.SetSource
+func (ec *EventContextV03) SetSource(u string) error {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.Source = types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetSubject implements EventContextWriter.SetSubject
+func (ec *EventContextV03) SetSubject(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		ec.Subject = nil
+	} else {
+		ec.Subject = &s
+	}
+	return nil
+}
+
+// SetID implements EventContextWriter.SetID
+func (ec *EventContextV03) SetID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("id is required to be a non-empty string")
+	}
+	ec.ID = id
+	return nil
+}
+
+// SetTime implements EventContextWriter.SetTime
+func (ec *EventContextV03) SetTime(t time.Time) error {
+	if t.IsZero() {
+		ec.Time = nil
+	} else {
+		ec.Time = &types.Timestamp{Time: t}
+	}
+	return nil
+}
+
+// SetSchemaURL implements EventContextWriter.SetSchemaURL
+func (ec *EventContextV03) SetSchemaURL(u string) error {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		ec.SchemaURL = nil
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.SchemaURL = &types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetDataContentEncoding implements EventContextWriter.SetDataContentEncoding
+func (ec *EventContextV03) SetDataContentEncoding(e string) error {
+	e = strings.ToLower(strings.TrimSpace(e))
+	if e == "" {
+		ec.DataContentEncoding = nil
+	} else {
+		ec.DataContentEncoding = &e
+	}
+	return nil
+}

--- a/pkg/cloudevents/transport/http/codec_test.go
+++ b/pkg/cloudevents/transport/http/codec_test.go
@@ -23,7 +23,7 @@ func TestDefaultBinaryEncodingSelectionStrategy(t *testing.T) {
 	}{
 		"default, unknown version": {
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: "unknown",
 				},
 			},
@@ -67,7 +67,7 @@ func TestDefaultStructuredEncodingSelectionStrategy(t *testing.T) {
 	}{
 		"default, unknown version": {
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: "unknown",
 				},
 			},
@@ -119,7 +119,7 @@ func TestCodecEncode(t *testing.T) {
 				DefaultEncodingSelectionFn: http.DefaultBinaryEncodingSelectionStrategy,
 			},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventType: "com.example.test",
 					Source:    *source,
 					EventID:   "ABC-123",
@@ -140,7 +140,7 @@ func TestCodecEncode(t *testing.T) {
 				DefaultEncodingSelectionFn: http.DefaultStructuredEncodingSelectionStrategy,
 			},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventType: "com.example.test",
 					Source:    *source,
 					EventID:   "ABC-123",
@@ -167,7 +167,7 @@ func TestCodecEncode(t *testing.T) {
 				DefaultEncodingSelectionFn: http.DefaultBinaryEncodingSelectionStrategy,
 			},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -188,7 +188,7 @@ func TestCodecEncode(t *testing.T) {
 				DefaultEncodingSelectionFn: http.DefaultStructuredEncodingSelectionStrategy,
 			},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -215,7 +215,7 @@ func TestCodecEncode(t *testing.T) {
 				DefaultEncodingSelectionFn: http.DefaultBinaryEncodingSelectionStrategy,
 			},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -236,7 +236,7 @@ func TestCodecEncode(t *testing.T) {
 				DefaultEncodingSelectionFn: http.DefaultStructuredEncodingSelectionStrategy,
 			},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -261,7 +261,7 @@ func TestCodecEncode(t *testing.T) {
 		"simple v0.1 binary": {
 			codec: http.Codec{Encoding: http.BinaryV01},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventType: "com.example.test",
 					Source:    *source,
 					EventID:   "ABC-123",
@@ -280,7 +280,7 @@ func TestCodecEncode(t *testing.T) {
 		"simple v0.1 structured": {
 			codec: http.Codec{Encoding: http.StructuredV01},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventType: "com.example.test",
 					Source:    *source,
 					EventID:   "ABC-123",
@@ -305,7 +305,7 @@ func TestCodecEncode(t *testing.T) {
 		"simple v0.2 binary": {
 			codec: http.Codec{Encoding: http.BinaryV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -324,7 +324,7 @@ func TestCodecEncode(t *testing.T) {
 		"simple v0.2 structured": {
 			codec: http.Codec{Encoding: http.StructuredV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -349,7 +349,7 @@ func TestCodecEncode(t *testing.T) {
 		"simple v0.3 binary": {
 			codec: http.Codec{Encoding: http.BinaryV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -368,7 +368,7 @@ func TestCodecEncode(t *testing.T) {
 		"simple v0.3 structured": {
 			codec: http.Codec{Encoding: http.StructuredV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -442,7 +442,7 @@ func TestCodecDecode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventType:          "com.example.test",
 					Source:             *source,
@@ -468,7 +468,7 @@ func TestCodecDecode(t *testing.T) {
 				}(),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventType:          "com.example.test",
 					Source:             *source,
@@ -488,7 +488,7 @@ func TestCodecDecode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -514,7 +514,7 @@ func TestCodecDecode(t *testing.T) {
 				}(),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -535,7 +535,7 @@ func TestCodecDecode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion:     cloudevents.CloudEventsVersionV03,
 					Type:            "com.example.test",
 					Source:          *source,
@@ -561,7 +561,7 @@ func TestCodecDecode(t *testing.T) {
 				}(),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion: cloudevents.CloudEventsVersionV03,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -584,7 +584,7 @@ func TestCodecDecode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -610,7 +610,7 @@ func TestCodecDecode(t *testing.T) {
 				}(),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -630,7 +630,7 @@ func TestCodecDecode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventType:          "com.example.test",
 					Source:             *source,
@@ -656,7 +656,7 @@ func TestCodecDecode(t *testing.T) {
 				}(),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventType:          "com.example.test",
 					Source:             *source,
@@ -708,7 +708,7 @@ func TestCodecRoundTrip(t *testing.T) {
 			"simple data v0.1": {
 				codec: http.Codec{Encoding: encoding},
 				event: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						EventType: "com.example.test",
 						Source:    *source,
 						EventID:   "ABC-123",
@@ -719,7 +719,7 @@ func TestCodecRoundTrip(t *testing.T) {
 					},
 				},
 				want: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 						EventType:          "com.example.test",
 						Source:             *source,
@@ -735,7 +735,7 @@ func TestCodecRoundTrip(t *testing.T) {
 			"struct data v0.1": {
 				codec: http.Codec{Encoding: encoding},
 				event: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						EventType: "com.example.test",
 						Source:    *source,
 						EventID:   "ABC-123",
@@ -746,7 +746,7 @@ func TestCodecRoundTrip(t *testing.T) {
 					},
 				},
 				want: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 						EventType:          "com.example.test",
 						Source:             *source,
@@ -832,7 +832,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 				//"simple data": {
 				//	codec: http.Codec{Encoding: encoding},
 				//	event: cloudevents.Event{
-				//		Context: cloudevents.EventContextV01{
+				//		Context: &cloudevents.EventContextV01{
 				//			EventType:   "com.example.test",
 				//			Source:      *source,
 				//			EventID:     "ABC-123",
@@ -844,7 +844,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 				//		},
 				//	},
 				//	want: cloudevents.Event{
-				//		Context: cloudevents.EventContextV01{
+				//		Context: &cloudevents.EventContextV01{
 				//			CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 				//			EventType:          "com.example.test",
 				//			Source:             *source,
@@ -860,7 +860,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 				"struct data": {
 					codec: http.Codec{Encoding: encoding},
 					event: cloudevents.Event{
-						Context: cloudevents.EventContextV01{
+						Context: &cloudevents.EventContextV01{
 							EventType:   "com.example.test",
 							Source:      *source,
 							EventID:     "ABC-123",
@@ -872,7 +872,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 						},
 					},
 					want: cloudevents.Event{
-						Context: cloudevents.EventContextV01{
+						Context: &cloudevents.EventContextV01{
 							CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 							EventType:          "com.example.test",
 							Source:             *source,

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -92,7 +92,7 @@ func (v CodecV01) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 	return msg, nil
 }
 
-func (v CodecV01) toHeaders(ec cloudevents.EventContextV01) (http.Header, error) {
+func (v CodecV01) toHeaders(ec *cloudevents.EventContextV01) (http.Header, error) {
 	// Preserve case in v0.1, even though HTTP headers are case-insensitive.
 	h := http.Header{}
 	h["CE-CloudEventsVersion"] = []string{ec.CloudEventsVersion}
@@ -161,7 +161,7 @@ func (v CodecV01) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 		body = m.Body
 	}
 	return &cloudevents.Event{
-		Context: ctx,
+		Context: &ctx,
 		Data:    body,
 	}, nil
 }

--- a/pkg/cloudevents/transport/http/codec_v01_test.go
+++ b/pkg/cloudevents/transport/http/codec_v01_test.go
@@ -27,7 +27,7 @@ func TestCodecV01_Encode(t *testing.T) {
 		"simple v0.1 default": {
 			codec: http.CodecV01{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: "TestIfDefaulted",
 					EventType:          "com.example.test",
 					Source:             *source,
@@ -47,7 +47,7 @@ func TestCodecV01_Encode(t *testing.T) {
 		"full v0.1 default": {
 			codec: http.CodecV01{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventID:          "ABC-123",
 					EventTime:        &now,
 					EventType:        "com.example.full",
@@ -81,7 +81,7 @@ func TestCodecV01_Encode(t *testing.T) {
 		"simple v0.1 binary": {
 			codec: http.CodecV01{Encoding: http.BinaryV01},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventType: "com.example.test",
 					Source:    *source,
 					EventID:   "ABC-123",
@@ -100,7 +100,7 @@ func TestCodecV01_Encode(t *testing.T) {
 		"full v0.1 binary": {
 			codec: http.CodecV01{Encoding: http.BinaryV01},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventID:          "ABC-123",
 					EventTime:        &now,
 					EventType:        "com.example.full",
@@ -134,7 +134,7 @@ func TestCodecV01_Encode(t *testing.T) {
 		"simple v0.1 structured": {
 			codec: http.CodecV01{Encoding: http.StructuredV01},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventType: "com.example.test",
 					Source:    *source,
 					EventID:   "ABC-123",
@@ -159,7 +159,7 @@ func TestCodecV01_Encode(t *testing.T) {
 		"full v0.1 structured": {
 			codec: http.CodecV01{Encoding: http.StructuredV01},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					EventID:          "ABC-123",
 					EventTime:        &now,
 					EventType:        "com.example.full",
@@ -256,7 +256,7 @@ func TestCodecV01_Decode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventType:          "com.example.test",
 					Source:             *source,
@@ -284,7 +284,7 @@ func TestCodecV01_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventID:            "ABC-123",
 					EventTime:          &now,
@@ -316,7 +316,7 @@ func TestCodecV01_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventType:          "com.example.test",
 					Source:             *source,
@@ -348,7 +348,7 @@ func TestCodecV01_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventID:            "ABC-123",
 					EventTime:          &now,
@@ -379,7 +379,7 @@ func TestCodecV01_Decode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV01{
+				Context: &cloudevents.EventContextV01{
 					CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 					EventType:          "com.example.test",
 					Source:             *source,

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -92,7 +92,7 @@ func (v CodecV02) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 	return msg, nil
 }
 
-func (v CodecV02) toHeaders(ec cloudevents.EventContextV02) (http.Header, error) {
+func (v CodecV02) toHeaders(ec *cloudevents.EventContextV02) (http.Header, error) {
 	h := http.Header{}
 	h.Set("ce-specversion", ec.SpecVersion)
 	h.Set("ce-type", ec.Type)
@@ -166,7 +166,7 @@ func (v CodecV02) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 		body = m.Body
 	}
 	return &cloudevents.Event{
-		Context: ctx,
+		Context: &ctx,
 		Data:    body,
 	}, nil
 }
@@ -274,7 +274,7 @@ func (v CodecV02) decodeStructured(msg transport.Message) (*cloudevents.Event, e
 	}
 
 	return &cloudevents.Event{
-		Context: ec,
+		Context: &ec,
 		Data:    data,
 	}, nil
 }

--- a/pkg/cloudevents/transport/http/codec_v02_test.go
+++ b/pkg/cloudevents/transport/http/codec_v02_test.go
@@ -27,7 +27,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"simple v0.2 default": {
 			codec: http.CodecV02{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -46,7 +46,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"full v0.2 default": {
 			codec: http.CodecV02{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					ID:          "ABC-123",
 					Time:        &now,
 					Type:        "com.example.test",
@@ -78,7 +78,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"simple v0.2 binary": {
 			codec: http.CodecV02{Encoding: http.BinaryV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -97,7 +97,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"full v0.2 binary": {
 			codec: http.CodecV02{Encoding: http.BinaryV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					ID:          "ABC-123",
 					Time:        &now,
 					Type:        "com.example.test",
@@ -140,7 +140,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"simple v0.2 structured": {
 			codec: http.CodecV02{Encoding: http.StructuredV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -165,7 +165,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"full v0.2 structured": {
 			codec: http.CodecV02{Encoding: http.StructuredV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					ID:          "ABC-123",
 					Time:        &now,
 					Type:        "com.example.test",
@@ -263,7 +263,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					ContentType: cloudevents.StringOfApplicationJSON(),
 					Type:        "com.example.test",
@@ -293,7 +293,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					ID:          "ABC-123",
 					Time:        &now,
@@ -329,7 +329,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -360,7 +360,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					ID:          "ABC-123",
 					Time:        &now,
@@ -390,7 +390,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					ContentType: cloudevents.StringOfApplicationJSON(),
 					Type:        "com.example.test",

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -103,7 +103,7 @@ func (v CodecV03) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 	return msg, nil
 }
 
-func (v CodecV03) toHeaders(ec cloudevents.EventContextV03) (http.Header, error) {
+func (v CodecV03) toHeaders(ec *cloudevents.EventContextV03) (http.Header, error) {
 	h := http.Header{}
 	h.Set("ce-specversion", ec.SpecVersion)
 	h.Set("ce-type", ec.Type)
@@ -193,7 +193,7 @@ func (v CodecV03) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 		}
 	}
 	return &cloudevents.Event{
-		Context: ctx,
+		Context: &ctx,
 		Data:    body,
 	}, nil
 }
@@ -327,7 +327,7 @@ func (v CodecV03) decodeStructured(msg transport.Message) (*cloudevents.Event, e
 	}
 
 	return &cloudevents.Event{
-		Context: ec,
+		Context: &ec,
 		Data:    data,
 	}, nil
 }

--- a/pkg/cloudevents/transport/http/codec_v03_test.go
+++ b/pkg/cloudevents/transport/http/codec_v03_test.go
@@ -29,7 +29,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"simple v0.3 default": {
 			codec: http.CodecV03{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -48,7 +48,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"full v0.3 default": {
 			codec: http.CodecV03{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					ID:              "ABC-123",
 					Time:            &now,
 					Type:            "com.example.test",
@@ -82,7 +82,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"simple v0.3 binary": {
 			codec: http.CodecV03{Encoding: http.BinaryV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -101,7 +101,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"full v0.3 binary": {
 			codec: http.CodecV03{Encoding: http.BinaryV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					ID:              "ABC-123",
 					Time:            &now,
 					Type:            "com.example.test",
@@ -146,7 +146,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"full v0.3 binary base64": {
 			codec: http.CodecV03{Encoding: http.BinaryV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					ID:                  "ABC-123",
 					Time:                &now,
 					Type:                "com.example.test",
@@ -193,7 +193,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"simple v0.3 structured": {
 			codec: http.CodecV03{Encoding: http.StructuredV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -218,7 +218,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"full v0.3 structured": {
 			codec: http.CodecV03{Encoding: http.StructuredV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					ID:              "ABC-123",
 					Time:            &now,
 					Type:            "com.example.test",
@@ -262,7 +262,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"full v0.3 structured base64": {
 			codec: http.CodecV03{Encoding: http.StructuredV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					ID:                  "ABC-123",
 					Time:                &now,
 					Type:                "com.example.test",
@@ -364,7 +364,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion:     cloudevents.CloudEventsVersionV03,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
 					Type:            "com.example.test",
@@ -395,7 +395,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion:     cloudevents.CloudEventsVersionV03,
 					ID:              "ABC-123",
 					Time:            &now,
@@ -439,7 +439,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				Body: []byte("eyJoZWxsbyI6IndvcmxkIn0="),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion:         cloudevents.CloudEventsVersionV03,
 					ID:                  "ABC-123",
 					Time:                &now,
@@ -475,7 +475,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion: cloudevents.CloudEventsVersionV03,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -507,7 +507,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion:     cloudevents.CloudEventsVersionV03,
 					ID:              "ABC-123",
 					Time:            &now,
@@ -548,7 +548,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion:         cloudevents.CloudEventsVersionV03,
 					ID:                  "ABC-123",
 					Time:                &now,
@@ -578,7 +578,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				},
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion:     cloudevents.CloudEventsVersionV03,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
 					Type:            "com.example.test",

--- a/pkg/cloudevents/transport/nats/codec_test.go
+++ b/pkg/cloudevents/transport/nats/codec_test.go
@@ -29,7 +29,7 @@ func TestCodecEncode(t *testing.T) {
 		"simple v02 structured binary": {
 			codec: nats.Codec{Encoding: nats.StructuredV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -101,7 +101,7 @@ func TestCodecDecode(t *testing.T) {
 				}(),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -152,7 +152,7 @@ func TestCodecRoundTrip(t *testing.T) {
 			"simple data": {
 				codec: nats.Codec{Encoding: encoding},
 				event: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						EventType: "com.example.test",
 						Source:    *source,
 						EventID:   "ABC-123",
@@ -163,7 +163,7 @@ func TestCodecRoundTrip(t *testing.T) {
 					},
 				},
 				want: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 						EventType:          "com.example.test",
 						Source:             *source,
@@ -179,7 +179,7 @@ func TestCodecRoundTrip(t *testing.T) {
 			"struct data": {
 				codec: nats.Codec{Encoding: encoding},
 				event: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						EventType: "com.example.test",
 						Source:    *source,
 						EventID:   "ABC-123",
@@ -190,7 +190,7 @@ func TestCodecRoundTrip(t *testing.T) {
 					},
 				},
 				want: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 						EventType:          "com.example.test",
 						Source:             *source,
@@ -272,7 +272,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 			"simple data": {
 				codec: nats.Codec{Encoding: encoding},
 				event: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						EventType: "com.example.test",
 						Source:    *source,
 						EventID:   "ABC-123",
@@ -283,7 +283,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 					},
 				},
 				want: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 						EventType:          "com.example.test",
 						Source:             *source,
@@ -299,7 +299,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 			"struct data": {
 				codec: nats.Codec{Encoding: encoding},
 				event: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						EventType: "com.example.test",
 						Source:    *source,
 						EventID:   "ABC-123",
@@ -310,7 +310,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 					},
 				},
 				want: cloudevents.Event{
-					Context: cloudevents.EventContextV01{
+					Context: &cloudevents.EventContextV01{
 						CloudEventsVersion: cloudevents.CloudEventsVersionV01,
 						EventType:          "com.example.test",
 						Source:             *source,

--- a/pkg/cloudevents/transport/nats/codec_v02_test.go
+++ b/pkg/cloudevents/transport/nats/codec_v02_test.go
@@ -27,7 +27,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"simple v2 default": {
 			codec: nats.CodecV02{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -49,7 +49,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"full v2 default": {
 			codec: nats.CodecV02{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					ID:          "ABC-123",
 					Time:        &now,
 					Type:        "com.example.test",
@@ -88,7 +88,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"simple v2 structured": {
 			codec: nats.CodecV02{Encoding: nats.StructuredV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -110,7 +110,7 @@ func TestCodecV02_Encode(t *testing.T) {
 		"full v2 structured": {
 			codec: nats.CodecV02{Encoding: nats.StructuredV02},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					ID:          "ABC-123",
 					Time:        &now,
 					Type:        "com.example.test",
@@ -204,7 +204,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -232,7 +232,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: &cloudevents.EventContextV02{
 					SpecVersion: cloudevents.CloudEventsVersionV02,
 					ID:          "ABC-123",
 					Time:        &now,

--- a/pkg/cloudevents/transport/nats/codec_v03_test.go
+++ b/pkg/cloudevents/transport/nats/codec_v03_test.go
@@ -27,7 +27,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"simple v0.3 default": {
 			codec: nats.CodecV03{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -49,7 +49,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"full v0.3 default": {
 			codec: nats.CodecV03{},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					ID:              "ABC-123",
 					Time:            &now,
 					Type:            "com.example.test",
@@ -88,7 +88,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"simple v0.3 structured": {
 			codec: nats.CodecV03{Encoding: nats.StructuredV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					Type:   "com.example.test",
 					Source: *source,
 					ID:     "ABC-123",
@@ -110,7 +110,7 @@ func TestCodecV03_Encode(t *testing.T) {
 		"full v0.3 structured": {
 			codec: nats.CodecV03{Encoding: nats.StructuredV03},
 			event: cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					ID:              "ABC-123",
 					Time:            &now,
 					Type:            "com.example.test",
@@ -204,7 +204,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion: cloudevents.CloudEventsVersionV03,
 					Type:        "com.example.test",
 					Source:      *source,
@@ -232,7 +232,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				}),
 			},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: &cloudevents.EventContextV03{
 					SpecVersion:     cloudevents.CloudEventsVersionV03,
 					ID:              "ABC-123",
 					Time:            &now,

--- a/test/http/validation.go
+++ b/test/http/validation.go
@@ -23,6 +23,9 @@ func assertEventEquality(t *testing.T, ctx string, expected, actual *cloudevents
 	if diff := cmp.Diff(expected, actual, cmpopts.IgnoreFields(cloudevents.Event{}, "Data")); diff != "" {
 		t.Errorf("Unexpected difference in %s (-want, +got): %v", ctx, diff)
 	}
+	if expected == nil || actual == nil {
+		return
+	}
 	data := make(map[string]string, 0)
 	err := actual.DataAs(&data)
 	if err != nil {


### PR DESCRIPTION
With this change I am starting to move away from concrete for the consumer of the SDK. There has been requests to be able to setup the event without ever needing to know the impl details of the context versions.

Both of these work and are equivalent:

```go
event := cloudevents.Event{
	Context: cloudevents.EventContextV02{
		Type:   "com.cloudevents.sample.sent",
		Source: *source,
	}.AsV02(),
	Data: data,
}
```

```go
event := cloudevents.NewEvent()
event.SetType("com.cloudevents.sample.sent")
event.SetSource("https://github.com/cloudevents/sdk-go/cmd/samples/sender")
event.Data = data
```
