### PR TITLE
Stop spewing request data into log stream

### DIFF
--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -187,7 +187,7 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (*clou
 					log.Printf("failed to load codec: %s", err)
 				}
 				if respEvent, err = t.codec.Decode(msg); err != nil {
-					log.Printf("failed to decode message: %s %v", err, resp)
+					log.Printf("failed to decode message: %s", err)
 				}
 			}
 
@@ -293,11 +293,11 @@ func accepted(resp *http.Response) bool {
 // status is a helper method to read the response of the target.
 func status(resp *http.Response) string {
 	status := resp.Status
-	body, err := ioutil.ReadAll(resp.Body)
+	_, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Sprintf("Status[%s] error reading response body: %v", status, err)
+		return fmt.Sprintf("Status[%s] error reading response body", status)
 	}
-	return fmt.Sprintf("Status[%s] %s", status, body)
+	return fmt.Sprintf("Status[%s]", status)
 }
 
 func (t *Transport) invokeReceiver(ctx context.Context, event cloudevents.Event) (*Response, error) {
@@ -368,7 +368,7 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		log.Printf("failed to handle request: %s %v", err, req)
+		log.Printf("failed to handle request: %s", err)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(`{"error":"Invalid request"}`))
 		r.Error()
@@ -389,7 +389,7 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	event, err := t.codec.Decode(msg)
 	if err != nil {
-		log.Printf("failed to decode message: %s %v", err, req)
+		log.Printf("failed to decode message: %s", err)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))
 		r.Error()


### PR DESCRIPTION
In a lot of places, `transport.go` prints the full body of the response. This seems ripe with the possibility for the wrong data to end up in the wrong log stream / log drain 👎

This removes many of them. Thanks!