### PR TITLE
Use Zap Logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,8 @@ require (
 	github.com/nats-io/nkeys v0.0.2 // indirect
 	github.com/nats-io/nuid v1.0.0 // indirect
 	go.opencensus.io v0.19.1
+	go.uber.org/atomic v1.3.2 // indirect
+	go.uber.org/multierr v1.1.0 // indirect
+	go.uber.org/zap v1.9.1
 	golang.org/x/sys v0.0.0-20190219203350-90b0e4468f99 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -46,7 +47,9 @@ github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7
 github.com/nats-io/nuid v1.0.0 h1:44QGdhbiANq8ZCbUkdn6W5bqtg+mHuDE4wOUuxxndFs=
 github.com/nats-io/nuid v1.0.0/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 h1:D+CiwcpGTW6pL6bv6KI3KbyEyCKyS+1JWS2h8PNDnGA=
@@ -62,9 +65,16 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 go.opencensus.io v0.19.1 h1:gPYKQ/GAQYR2ksU+qXNmq3CrOZWT1kkryvW6O0v1acY=
 go.opencensus.io v0.19.1/go.mod h1:gug0GbSHa8Pafr0d2urOSgoXHZ6x/RUlaiT0d9pqb4A=
+go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
+go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
+go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/zap v1.9.1 h1:XCJQEf3W6eZaVwhRBof6ImoYGJSITeKWsyeh3HFu/5o=
+go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/cloudevents/codec/jsoncodec.go
+++ b/pkg/cloudevents/codec/jsoncodec.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
-	"log"
 	"strconv"
 )
 
@@ -88,7 +87,10 @@ func jsonEncode(ctx cloudevents.EventContextReader, data interface{}) ([]byte, e
 		return nil, err
 	}
 
-	mediaType := ctx.GetDataMediaType()
+	mediaType, err := ctx.GetDataMediaType()
+	if err != nil {
+		return nil, err
+	}
 	datab, err := marshalEventData(mediaType, data)
 	if err != nil {
 		return nil, err
@@ -222,10 +224,6 @@ func obsJsonDecodeV03(body []byte) (*cloudevents.Event, error) {
 }
 
 func marshalEvent(event interface{}) ([]byte, error) {
-	if b, ok := event.([]byte); ok {
-		log.Printf("json.marshalEvent asked to encode bytes... wrong? %s", string(b))
-	}
-
 	b, err := json.Marshal(event)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudevents/context/logger.go
+++ b/pkg/cloudevents/context/logger.go
@@ -1,0 +1,42 @@
+package context
+
+import (
+	"context"
+	"go.uber.org/zap"
+)
+
+// Opaque key type used to store logger
+type loggerKeyType struct{}
+
+var loggerKey = loggerKeyType{}
+
+// fallbackLogger is the logger is used when there is no logger attached to the context.
+var fallbackLogger *zap.SugaredLogger
+
+func init() {
+	if logger, err := zap.NewProduction(); err != nil {
+		// We failed to create a fallback logger.
+		fallbackLogger = zap.NewNop().Sugar()
+	} else {
+		fallbackLogger = logger.Named("fallback").Sugar()
+	}
+}
+
+// WithLogger returns a new context with the logger injected into the given context.
+func WithLogger(ctx context.Context, logger *zap.SugaredLogger) context.Context {
+	if logger == nil {
+		return context.WithValue(ctx, loggerKey, fallbackLogger)
+	}
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// LoggerFrom returns the logger stored in context.
+func LoggerFrom(ctx context.Context) *zap.SugaredLogger {
+	l := ctx.Value(loggerKey)
+	if l != nil {
+		if logger, ok := l.(*zap.SugaredLogger); ok {
+			return logger
+		}
+	}
+	return fallbackLogger
+}

--- a/pkg/cloudevents/context/logger_test.go
+++ b/pkg/cloudevents/context/logger_test.go
@@ -1,0 +1,55 @@
+package context
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.uber.org/zap"
+	"testing"
+)
+
+func TestLoggerContext(t *testing.T) {
+	var namedLogger *zap.SugaredLogger
+	if logger, err := zap.NewProduction(); err != nil {
+		t.Fatal(err)
+	} else {
+		namedLogger = logger.Named("unittest").Sugar()
+	}
+
+	nopLogger := zap.NewNop().Sugar()
+
+	testCases := map[string]struct {
+		logger *zap.SugaredLogger
+		ctx    context.Context
+		want   *zap.SugaredLogger
+	}{
+		"nil context": {
+			want: fallbackLogger,
+		},
+		"nil context, set nop logger": {
+			logger: nopLogger,
+			want:   nopLogger,
+		},
+		"todo context, set logger": {
+			ctx:    context.TODO(),
+			logger: namedLogger,
+			want:   namedLogger,
+		},
+		"already set logger": {
+			ctx:    WithLogger(context.TODO(), nopLogger),
+			logger: namedLogger,
+			want:   namedLogger,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			ctx := WithLogger(tc.ctx, tc.logger)
+			got := LoggerFrom(ctx)
+
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreUnexported(zap.SugaredLogger{})); diff != "" {
+				t.Errorf("unexpected (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -34,7 +34,11 @@ func New(version ...string) Event {
 // DataAs attempts to populate the provided data object with the event payload.
 // data should be a pointer type.
 func (e Event) DataAs(data interface{}) error {
-	return datacodec.Decode(e.Context.GetDataMediaType(), e.Data, data)
+	mediaType, err := e.Context.GetDataMediaType()
+	if err != nil {
+		return err
+	}
+	return datacodec.Decode(mediaType, e.Data, data)
 }
 
 // ExtensionAs returns Context.ExtensionAs(name, obj)

--- a/pkg/cloudevents/event_reader.go
+++ b/pkg/cloudevents/event_reader.go
@@ -48,7 +48,8 @@ func (e Event) DataContentType() string {
 
 // DataMediaType implements EventReader.DataMediaType
 func (e Event) DataMediaType() string {
-	return e.Context.GetDataMediaType()
+	mediaType, _ := e.Context.GetDataMediaType()
+	return mediaType
 }
 
 // DataContentEncoding implements EventReader.DataContentEncoding

--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -59,7 +59,7 @@ func TestGetDataContentType(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 
-			got := tc.event.Context.GetDataMediaType()
+			got, _ := tc.event.Context.GetDataMediaType()
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected (-want, +got) = %v", diff)

--- a/pkg/cloudevents/eventcontext.go
+++ b/pkg/cloudevents/eventcontext.go
@@ -23,11 +23,13 @@ type EventContextReader interface {
 	GetSchemaURL() string
 	// GetDataContentType returns content type on the context.
 	GetDataContentType() string
-	// GetDataMediaType returns the MIME media type for encoded data, which is
-	// needed by both encoding and decoding.
-	GetDataMediaType() string
 	// GetDataContentEncoding returns content encoding on the context.
 	GetDataContentEncoding() string
+
+	// GetDataMediaType returns the MIME media type for encoded data, which is
+	// needed by both encoding and decoding. This is a processed form of
+	// GetDataContentType and it may return an error.
+	GetDataMediaType() (string, error)
 
 	// ExtensionAs populates the given interface with the CloudEvents extension
 	// of the given name from the extension attributes. It returns an error if

--- a/pkg/cloudevents/eventcontext_v01_reader.go
+++ b/pkg/cloudevents/eventcontext_v01_reader.go
@@ -1,7 +1,6 @@
 package cloudevents
 
 import (
-	"log"
 	"mime"
 	"time"
 )
@@ -26,16 +25,15 @@ func (ec EventContextV01) GetDataContentType() string {
 }
 
 // GetDataMediaType implements EventContextReader.GetDataMediaType
-func (ec EventContextV01) GetDataMediaType() string {
+func (ec EventContextV01) GetDataMediaType() (string, error) {
 	if ec.ContentType != nil {
 		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
 		if err != nil {
-			log.Printf("failed to parse media type from ContentType: %s", err)
-			return ""
+			return "", err
 		}
-		return mediaType
+		return mediaType, nil
 	}
-	return ""
+	return "", nil
 }
 
 // GetType implements EventContextReader.GetType

--- a/pkg/cloudevents/eventcontext_v01_test.go
+++ b/pkg/cloudevents/eventcontext_v01_test.go
@@ -194,7 +194,7 @@ func TestGetMediaTypeV01(t *testing.T) {
 			if tc.t != "" {
 				ec.ContentType = &tc.t
 			}
-			got := ec.GetDataMediaType()
+			got, _ := ec.GetDataMediaType()
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected  (-want, +got) = %v", diff)

--- a/pkg/cloudevents/eventcontext_v02_reader.go
+++ b/pkg/cloudevents/eventcontext_v02_reader.go
@@ -1,7 +1,6 @@
 package cloudevents
 
 import (
-	"log"
 	"mime"
 	"time"
 )
@@ -66,16 +65,15 @@ func (ec EventContextV02) GetDataContentType() string {
 }
 
 // GetDataMediaType implements EventContextReader.GetDataMediaType
-func (ec EventContextV02) GetDataMediaType() string {
+func (ec EventContextV02) GetDataMediaType() (string, error) {
 	if ec.ContentType != nil {
 		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
 		if err != nil {
-			log.Printf("failed to parse media type from ContentType: %s", err)
-			return ""
+			return "", err
 		}
-		return mediaType
+		return mediaType, nil
 	}
-	return ""
+	return "", nil
 }
 
 // GetDataContentEncoding implements EventContextReader.GetDataContentEncoding

--- a/pkg/cloudevents/eventcontext_v02_test.go
+++ b/pkg/cloudevents/eventcontext_v02_test.go
@@ -181,7 +181,7 @@ func TestGetMediaTypeV02(t *testing.T) {
 			if tc.t != "" {
 				ec.ContentType = &tc.t
 			}
-			got := ec.GetDataMediaType()
+			got, _ := ec.GetDataMediaType()
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected  (-want, +got) = %v", diff)

--- a/pkg/cloudevents/eventcontext_v03_reader.go
+++ b/pkg/cloudevents/eventcontext_v03_reader.go
@@ -1,7 +1,6 @@
 package cloudevents
 
 import (
-	"log"
 	"mime"
 	"time"
 )
@@ -23,16 +22,15 @@ func (ec EventContextV03) GetDataContentType() string {
 }
 
 // GetDataMediaType implements EventContextReader.GetDataMediaType
-func (ec EventContextV03) GetDataMediaType() string {
+func (ec EventContextV03) GetDataMediaType() (string, error) {
 	if ec.DataContentType != nil {
 		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
 		if err != nil {
-			log.Printf("failed to parse media type from DataContentType: %s", err)
-			return ""
+			return "", err
 		}
-		return mediaType
+		return mediaType, nil
 	}
-	return ""
+	return "", nil
 }
 
 // GetType implements EventContextReader.GetType

--- a/pkg/cloudevents/eventcontext_v03_test.go
+++ b/pkg/cloudevents/eventcontext_v03_test.go
@@ -216,7 +216,7 @@ func TestGetMediaTypeV03(t *testing.T) {
 			if tc.t != "" {
 				ec.DataContentType = &tc.t
 			}
-			got := ec.GetDataMediaType()
+			got, _ := ec.GetDataMediaType()
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected  (-want, +got) = %v", diff)

--- a/pkg/cloudevents/transport/http/codec.go
+++ b/pkg/cloudevents/transport/http/codec.go
@@ -131,7 +131,7 @@ func (c *Codec) Decode(msg transport.Message) (*cloudevents.Event, error) {
 			return c.convertEvent(event), nil
 		}
 	default:
-		return nil, fmt.Errorf("unknown encoding for message %v", msg)
+		return nil, fmt.Errorf("unknown encoding")
 	}
 }
 

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -68,7 +68,7 @@ func (v CodecV01) obsDecode(msg transport.Message) (*cloudevents.Event, error) {
 	case StructuredV01:
 		return v.decodeStructured(msg)
 	default:
-		return nil, fmt.Errorf("unknown encoding for message %v", msg)
+		return nil, fmt.Errorf("unknown encoding")
 	}
 }
 
@@ -180,18 +180,25 @@ func (v CodecV01) fromHeaders(h http.Header) (cloudevents.EventContextV01, error
 
 	ec := cloudevents.EventContextV01{}
 	ec.CloudEventsVersion = h.Get("CE-CloudEventsVersion")
+	h.Del("CE-CloudEventsVersion")
 	ec.EventID = h.Get("CE-EventID")
+	h.Del("CE-EventID")
 	ec.EventType = h.Get("CE-EventType")
+	h.Del("CE-EventType")
 	source := types.ParseURLRef(h.Get("CE-Source"))
+	h.Del("CE-Source")
 	if source != nil {
 		ec.Source = *source
 	}
 	ec.EventTime = types.ParseTimestamp(h.Get("CE-EventTime"))
+	h.Del("CE-EventTime")
 	etv := h.Get("CE-EventTypeVersion")
+	h.Del("CE-EventTypeVersion")
 	if etv != "" {
 		ec.EventTypeVersion = &etv
 	}
 	ec.SchemaURL = types.ParseURLRef(h.Get("CE-SchemaURL"))
+	h.Del("CE-SchemaURL")
 	et := h.Get("Content-Type")
 	ec.ContentType = &et
 
@@ -206,6 +213,7 @@ func (v CodecV01) fromHeaders(h http.Header) (cloudevents.EventContextV01, error
 				// If we can't unmarshal the data, treat it as a string.
 				extensions[key] = v[0]
 			}
+			h.Del(k)
 		}
 	}
 	if len(extensions) > 0 {

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"log"
 	"net/http"
 	"net/textproto"
 	"strings"
@@ -79,7 +78,11 @@ func (v CodecV01) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 		return nil, err
 	}
 
-	body, err := marshalEventData(e.Context.GetDataMediaType(), e.Data)
+	mediaType, err := e.Context.GetDataMediaType()
+	if err != nil {
+		return nil, err
+	}
+	body, err := marshalEventData(mediaType, e.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +174,6 @@ func (v CodecV01) fromHeaders(h http.Header) (cloudevents.EventContextV01, error
 	for k, v := range h {
 		ck := textproto.CanonicalMIMEHeaderKey(k)
 		if k != ck {
-			log.Printf("[warn] received header with non-canonical form; canonical: %q, got %q", ck, k)
 			h[ck] = v
 		}
 	}

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"log"
 	"net/http"
 	"net/textproto"
 	"strings"
@@ -79,7 +78,11 @@ func (v CodecV02) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 		return nil, err
 	}
 
-	body, err := marshalEventData(e.Context.GetDataMediaType(), e.Data)
+	mediaType, err := e.Context.GetDataMediaType()
+	if err != nil {
+		return nil, err
+	}
+	body, err := marshalEventData(mediaType, e.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +179,6 @@ func (v CodecV02) fromHeaders(h http.Header) (cloudevents.EventContextV02, error
 	for k, v := range h {
 		ck := textproto.CanonicalMIMEHeaderKey(k)
 		if k != ck {
-			log.Printf("[warn] received header with non-canonical form; canonical: %q, got %q", ck, k)
 			delete(h, k)
 			h[ck] = v
 		}

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -68,7 +68,7 @@ func (v CodecV02) obsDecode(msg transport.Message) (*cloudevents.Event, error) {
 	case StructuredV02:
 		return v.decodeStructured(msg)
 	default:
-		return nil, fmt.Errorf("unknown encoding for message %v", msg)
+		return nil, fmt.Errorf("unknown encoding")
 	}
 }
 

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -73,7 +73,7 @@ func (v CodecV03) obsDecode(msg transport.Message) (*cloudevents.Event, error) {
 	case BatchedV03:
 		return nil, fmt.Errorf("not implemented")
 	default:
-		return nil, fmt.Errorf("unknown encoding for message %v", msg)
+		return nil, fmt.Errorf("unknown encoding")
 	}
 }
 

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"log"
 	"net/http"
 	"net/textproto"
 	"strings"
@@ -84,7 +83,11 @@ func (v CodecV03) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 		return nil, err
 	}
 
-	body, err := marshalEventData(e.Context.GetDataMediaType(), e.Data)
+	mediaType, err := e.Context.GetDataMediaType()
+	if err != nil {
+		return nil, err
+	}
+	body, err := marshalEventData(mediaType, e.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +206,6 @@ func (v CodecV03) fromHeaders(h http.Header) (cloudevents.EventContextV03, error
 	for k, v := range h {
 		ck := textproto.CanonicalMIMEHeaderKey(k)
 		if k != ck {
-			log.Printf("[warn] received header with non-canonical form; canonical: %q, got %q", ck, k)
 			delete(h, k)
 			h[ck] = v
 		}


### PR DESCRIPTION
As a follow-up to https://github.com/cloudevents/sdk-go/pull/107, this moves the SDK to use Zap for logging and cleans up some more logging messages that, while useful for debugging, are not wanted in production. 😺 

