### PR TITLE
Encoding cleanup, adding event.DataEncoded flag, adding event.SetData

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -48,6 +48,8 @@ var (
 	StringOfApplicationCloudEventsBatchJSON = cloudevents.StringOfApplicationCloudEventsBatchJSON
 	StringOfBase64                          = cloudevents.StringOfBase64
 
+	Base64 = cloudevents.Base64
+
 	// Client Creation
 
 	NewClient        = client.New

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# Development
+
+This is a collection of topics related to development of the SDK.
+
+## Transcoding
+
+One of the goals of this sdk is to decouple the encoding from the transport as
+much as possible. This is done by the integrating interacting with the
+[Event][cloudevents.event] object. The [Transport][transport.transport]
+implementation interacts with a [Message][transport.message]. The
+[Codec][transport.codec] is responsible for converting Event to Message for the
+the transport implementation. And this process works in reverse when a transport
+is used to receive an event.
+
+Sending:
+
+```
+ Event -[via Codec]-> Message -> Transport
+```
+
+Receiving:
+
+```
+(Transport) -> Message -[via Codec]-> Event
+```
+
+The CloudEvents spec outlines the various ways encoding is allowed, and there
+are two levels of encoding.
+
+1. Encoding of the context and extension attributes of the event.
+1. Encoding of the data payload of the event.
+
+For this reason there is also a [DataCodec][datacodec.codec] that is responsible
+for converting an encoded data payload into the intended format. These formats
+tend to be `application/xml`, `text/xml`, `application/json`, and `text/json`.
+
+The DataCodec is invoked (as of this writing) when converting Event to Message,
+or when `event.DataAs` is called when receiving.
+
+^ This should be rewritten so that it is invoked only on Data() and SetData()
+
+[cloudevents.event]: ../pkg/cloudevents/event.go
+[transport.transport]: ../pkg/cloudevents/transport/transport.go
+[transport.message]: ../pkg/cloudevents/transport/message.go
+[transport.codec]: ../pkg/cloudevents/transport/codec.go
+[datacodec.codec]: ../pkg/cloudevents/datacodec/codec.go

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,10 +34,8 @@ For this reason there is also a [DataCodec][datacodec.codec] that is responsible
 for converting an encoded data payload into the intended format. These formats
 tend to be `application/xml`, `text/xml`, `application/json`, and `text/json`.
 
-The DataCodec is invoked (as of this writing) when converting Event to Message,
-or when `event.DataAs` is called when receiving.
-
-^ This should be rewritten so that it is invoked only on Data() and SetData()
+The DataCodec is invoked (as of this writing) when `event.SetData` is called, or
+when `event.DataAs` is called when receiving.
 
 [cloudevents.event]: ../pkg/cloudevents/event.go
 [transport.transport]: ../pkg/cloudevents/transport/transport.go

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,12 @@ This is a collection of topics related to development of the SDK.
 ## Transcoding
 
 One of the goals of this sdk is to decouple the encoding from the transport as
-much as possible. This is done by the integrating interacting with the
-[Event][cloudevents.event] object. The [Transport][transport.transport]
-implementation interacts with a [Message][transport.message]. The
-[Codec][transport.codec] is responsible for converting Event to Message for the
-the transport implementation. And this process works in reverse when a transport
-is used to receive an event.
+much as possible. This is done by the sdk integrator interacting primarily with
+the [Event][cloudevents.event] object. The [Transport][transport.transport]
+implementation interacts with a [Message][transport.message] object. The
+[Codec][transport.codec] is responsible for converting `Event` to `Message` for
+the the transport implementation. And this process works in reverse when a
+transport is used to receive an event.
 
 Sending:
 

--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -102,6 +102,7 @@ func (c *ceClient) obsSend(ctx context.Context, event cloudevents.Event) (*cloud
 			event = fn(event)
 		}
 	}
+
 	// Validate the event conforms to the CloudEvents Spec.
 	if err := event.Validate(); err != nil {
 		return nil, err

--- a/pkg/cloudevents/codec/jsoncodec.go
+++ b/pkg/cloudevents/codec/jsoncodec.go
@@ -169,8 +169,9 @@ func obsJsonDecodeV01(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: &ec,
-		Data:    data,
+		Context:     &ec,
+		Data:        data,
+		DataEncoded: true,
 	}, nil
 }
 
@@ -204,8 +205,9 @@ func obsJsonDecodeV02(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: &ec,
-		Data:    data,
+		Context:     &ec,
+		Data:        data,
+		DataEncoded: true,
 	}, nil
 }
 
@@ -239,8 +241,9 @@ func obsJsonDecodeV03(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: &ec,
-		Data:    data,
+		Context:     &ec,
+		Data:        data,
+		DataEncoded: true,
 	}, nil
 }
 

--- a/pkg/cloudevents/codec/jsoncodec.go
+++ b/pkg/cloudevents/codec/jsoncodec.go
@@ -2,7 +2,6 @@ package codec
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
@@ -28,7 +27,11 @@ func obsJsonEncodeV01(e cloudevents.Event) ([]byte, error) {
 	if ctx.ContentType == nil {
 		ctx.ContentType = cloudevents.StringOfApplicationJSON()
 	}
-	return jsonEncode(ctx, e.Data)
+	data, err := e.DataBytes()
+	if err != nil {
+		return nil, err
+	}
+	return jsonEncode(ctx, data)
 }
 
 // JsonEncodeV02 takes in a cloudevent.Event and outputs the byte representation of that event using CloudEvents
@@ -49,7 +52,11 @@ func obsJsonEncodeV02(e cloudevents.Event) ([]byte, error) {
 	if ctx.ContentType == nil {
 		ctx.ContentType = cloudevents.StringOfApplicationJSON()
 	}
-	return jsonEncode(ctx, e.Data)
+	data, err := e.DataBytes()
+	if err != nil {
+		return nil, err
+	}
+	return jsonEncode(ctx, data)
 }
 
 // JsonEncodeV03 takes in a cloudevent.Event and outputs the byte representation of that event using CloudEvents
@@ -71,10 +78,14 @@ func obsJsonEncodeV03(e cloudevents.Event) ([]byte, error) {
 		ctx.DataContentType = cloudevents.StringOfApplicationJSON()
 	}
 
-	return jsonEncode(ctx, e.Data)
+	data, err := e.DataBytes()
+	if err != nil {
+		return nil, err
+	}
+	return jsonEncode(ctx, data)
 }
 
-func jsonEncode(ctx cloudevents.EventContextReader, data interface{}) ([]byte, error) {
+func jsonEncode(ctx cloudevents.EventContextReader, data []byte) ([]byte, error) {
 	ctxb, err := marshalEvent(ctx)
 	if err != nil {
 		return nil, err
@@ -86,27 +97,37 @@ func jsonEncode(ctx cloudevents.EventContextReader, data interface{}) ([]byte, e
 	if err := json.Unmarshal(ctxb, &b); err != nil {
 		return nil, err
 	}
-
+	//
 	mediaType, err := ctx.GetDataMediaType()
 	if err != nil {
 		return nil, err
 	}
-	datab, err := marshalEventData(mediaType, data)
-	if err != nil {
-		return nil, err
-	}
+	encoding := ctx.GetDataContentEncoding()
+	//datab, err := marshalEventData(mediaType, data)
+	//if err != nil {
+	//	return nil, err
+	//}
 	if data != nil {
-		if ctx.GetDataContentEncoding() == cloudevents.Base64 {
-			buf := make([]byte, base64.StdEncoding.EncodedLen(len(datab)))
-			base64.StdEncoding.Encode(buf, datab)
-			b["data"] = []byte(strconv.QuoteToASCII(string(buf)))
+		//if ctx.GetDataContentEncoding() == cloudevents.Base64 {
+		//	buf := make([]byte, base64.StdEncoding.EncodedLen(len(datab)))
+		//	base64.StdEncoding.Encode(buf, datab)
+		//	b["data"] = []byte(strconv.QuoteToASCII(string(buf)))
+		//} else
+
+		if encoding == cloudevents.Base64 {
+			if data[0] != byte('"') {
+				b["data"] = []byte(strconv.QuoteToASCII(string(data)))
+			} else {
+				// already quoted
+				b["data"] = data
+			}
 		} else if mediaType == "" || mediaType == cloudevents.ApplicationJSON {
-			b["data"] = datab
-		} else if datab[0] != byte('"') {
-			b["data"] = []byte(strconv.QuoteToASCII(string(datab)))
+			b["data"] = data
+		} else if data[0] != byte('"') {
+			b["data"] = []byte(strconv.QuoteToASCII(string(data)))
 		} else {
 			// already quoted
-			b["data"] = datab
+			b["data"] = data
 		}
 	}
 

--- a/pkg/cloudevents/codec/jsoncodec.go
+++ b/pkg/cloudevents/codec/jsoncodec.go
@@ -97,31 +97,15 @@ func jsonEncode(ctx cloudevents.EventContextReader, data []byte) ([]byte, error)
 	if err := json.Unmarshal(ctxb, &b); err != nil {
 		return nil, err
 	}
-	//
-	mediaType, err := ctx.GetDataMediaType()
-	if err != nil {
-		return nil, err
-	}
-	encoding := ctx.GetDataContentEncoding()
-	//datab, err := marshalEventData(mediaType, data)
-	//if err != nil {
-	//	return nil, err
-	//}
-	if data != nil {
-		//if ctx.GetDataContentEncoding() == cloudevents.Base64 {
-		//	buf := make([]byte, base64.StdEncoding.EncodedLen(len(datab)))
-		//	base64.StdEncoding.Encode(buf, datab)
-		//	b["data"] = []byte(strconv.QuoteToASCII(string(buf)))
-		//} else
 
-		if encoding == cloudevents.Base64 {
-			if data[0] != byte('"') {
-				b["data"] = []byte(strconv.QuoteToASCII(string(data)))
-			} else {
-				// already quoted
-				b["data"] = data
-			}
-		} else if mediaType == "" || mediaType == cloudevents.ApplicationJSON {
+	if data != nil {
+		mediaType, err := ctx.GetDataMediaType()
+		if err != nil {
+			return nil, err
+		}
+		isBase64 := ctx.GetDataContentEncoding() == cloudevents.Base64
+		isJson := mediaType == "" || mediaType == cloudevents.ApplicationJSON || mediaType == cloudevents.TextJSON
+		if isJson && !isBase64 {
 			b["data"] = data
 		} else if data[0] != byte('"') {
 			b["data"] = []byte(strconv.QuoteToASCII(string(data)))

--- a/pkg/cloudevents/codec/jsoncodec.go
+++ b/pkg/cloudevents/codec/jsoncodec.go
@@ -99,12 +99,18 @@ func jsonEncode(ctx cloudevents.EventContextReader, data []byte) ([]byte, error)
 	}
 
 	if data != nil {
+		// data is passed in as an encoded []byte. That slice might be any
+		// number of things but for json encoding of the envelope all we care
+		// is if the payload is either a string or a json object. If it is a
+		// json object, it can be inserted into the body without modification.
+		// Otherwise we need to quote it if not already quoted.
 		mediaType, err := ctx.GetDataMediaType()
 		if err != nil {
 			return nil, err
 		}
 		isBase64 := ctx.GetDataContentEncoding() == cloudevents.Base64
 		isJson := mediaType == "" || mediaType == cloudevents.ApplicationJSON || mediaType == cloudevents.TextJSON
+		// TODO(#60): we do not support json values at the moment, only objects and lists.
 		if isJson && !isBase64 {
 			b["data"] = data
 		} else if data[0] != byte('"') {

--- a/pkg/cloudevents/content_type.go
+++ b/pkg/cloudevents/content_type.go
@@ -1,6 +1,7 @@
 package cloudevents
 
 const (
+	TextJSON                        = "text/json"
 	ApplicationJSON                 = "application/json"
 	ApplicationXML                  = "application/xml"
 	ApplicationCloudEventsJSON      = "application/cloudevents+json"

--- a/pkg/cloudevents/datacodec/codec.go
+++ b/pkg/cloudevents/datacodec/codec.go
@@ -26,11 +26,15 @@ func init() {
 
 	AddDecoder("", json.Decode)
 	AddDecoder("application/json", json.Decode)
+	AddDecoder("text/json", json.Decode)
 	AddDecoder("application/xml", xml.Decode)
+	AddDecoder("text/xml", xml.Decode)
 
 	AddEncoder("", json.Encode)
 	AddEncoder("application/json", json.Encode)
+	AddEncoder("text/json", json.Encode)
 	AddEncoder("application/xml", xml.Encode)
+	AddEncoder("text/xml", xml.Encode)
 }
 
 // AddDecoder registers a decoder for a given content type. The codecs will use

--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -5,14 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
 )
 
 // Event represents the canonical representation of a CloudEvent.
 type Event struct {
-	Context EventContext
-	Data    interface{}
+	Context     EventContext
+	Data        interface{}
+	DataEncoded bool
 }
 
 const (
@@ -29,16 +28,6 @@ func New(version ...string) Event {
 	e := &Event{}
 	e.SetSpecVersion(specVersion)
 	return *e
-}
-
-// DataAs attempts to populate the provided data object with the event payload.
-// data should be a pointer type.
-func (e Event) DataAs(data interface{}) error {
-	mediaType, err := e.Context.GetDataMediaType()
-	if err != nil {
-		return err
-	}
-	return datacodec.Decode(mediaType, e.Data, data)
 }
 
 // ExtensionAs returns Context.ExtensionAs(name, obj)

--- a/pkg/cloudevents/event_data.go
+++ b/pkg/cloudevents/event_data.go
@@ -1,0 +1,92 @@
+package cloudevents
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
+	"strconv"
+)
+
+// Data is special. Break it out into it's own file.
+
+// SetData implements EventWriter.SetData
+func (e *Event) SetData(obj interface{}) error {
+	data, err := datacodec.Encode(e.DataMediaType(), obj)
+	if err != nil {
+		return err
+	}
+	if e.DataContentEncoding() == Base64 {
+		buf := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+		base64.StdEncoding.Encode(buf, data)
+		e.Data = string(buf)
+	} else {
+		e.Data = data
+	}
+	e.DataEncoded = true
+	return nil
+}
+
+func (e *Event) DataBytes() ([]byte, error) {
+	if !e.DataEncoded {
+		if err := e.SetData(e.Data); err != nil {
+			return nil, err
+		}
+	}
+
+	b, ok := e.Data.([]byte)
+	if !ok {
+		if s, ok := e.Data.(string); ok {
+			b = []byte(s)
+		} else {
+			panic("idk")
+		}
+	}
+	return b, nil
+}
+
+const (
+	quotes = `"'`
+)
+
+// DataAs attempts to populate the provided data object with the event payload.
+// data should be a pointer type.
+func (e Event) DataAs(data interface{}) error { // TODO: Clean this function up
+	obj, ok := e.Data.([]byte)
+	if !ok {
+		if s, ok := e.Data.(string); ok {
+			obj = []byte(s)
+		} else {
+			panic("idk")
+		}
+	}
+	if len(obj) == 0 {
+		// no data.
+		return nil
+	}
+	if e.Context.GetDataContentEncoding() == Base64 {
+		var bs []byte
+		// test to see if we need to unquote the data.
+		if obj[0] == quotes[0] || obj[0] == quotes[1] {
+			str, err := strconv.Unquote(string(obj))
+			if err != nil {
+				return err
+			}
+			bs = []byte(str)
+		} else {
+			bs = obj
+		}
+
+		buf := make([]byte, base64.StdEncoding.DecodedLen(len(bs)))
+		n, err := base64.StdEncoding.Decode(buf, bs)
+		if err != nil {
+			return fmt.Errorf("failed to decode data from base64: %s", err.Error())
+		}
+		obj = buf[:n]
+	}
+
+	mediaType, err := e.Context.GetDataMediaType()
+	if err != nil {
+		return err
+	}
+	return datacodec.Decode(mediaType, obj, data)
+}

--- a/pkg/cloudevents/event_data.go
+++ b/pkg/cloudevents/event_data.go
@@ -51,6 +51,9 @@ const (
 // DataAs attempts to populate the provided data object with the event payload.
 // data should be a pointer type.
 func (e Event) DataAs(data interface{}) error { // TODO: Clean this function up
+	if e.Data == nil {
+		return nil
+	}
 	obj, ok := e.Data.([]byte)
 	if !ok {
 		if s, ok := e.Data.(string); ok {

--- a/pkg/cloudevents/event_data.go
+++ b/pkg/cloudevents/event_data.go
@@ -2,6 +2,7 @@ package cloudevents
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
 	"strconv"
@@ -38,7 +39,7 @@ func (e *Event) DataBytes() ([]byte, error) {
 		if s, ok := e.Data.(string); ok {
 			b = []byte(s)
 		} else {
-			panic("idk")
+			return nil, errors.New("data was not a byte slice or string")
 		}
 	}
 	return b, nil
@@ -59,7 +60,7 @@ func (e Event) DataAs(data interface{}) error { // TODO: Clean this function up
 		if s, ok := e.Data.(string); ok {
 			obj = []byte(s)
 		} else {
-			panic("idk")
+			return errors.New("data was not a byte slice or string")
 		}
 	}
 	if len(obj) == 0 {

--- a/pkg/cloudevents/event_data_test.go
+++ b/pkg/cloudevents/event_data_test.go
@@ -1,0 +1,176 @@
+package cloudevents_test
+
+import (
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/google/go-cmp/cmp"
+	"strings"
+	"testing"
+)
+
+type DataTest struct {
+	event   func(string) ce.Event
+	set     interface{}
+	want    interface{}
+	wantErr string
+}
+
+func TestEventSetData_Json(t *testing.T) {
+	// All version should be the same, so run through them all.
+
+	versions := []string{ce.CloudEventsVersionV01, ce.CloudEventsVersionV02, ce.CloudEventsVersionV03}
+
+	testCases := map[string]DataTest{
+		"defaults": {
+			event: func(version string) ce.Event {
+				return ce.New(version)
+			},
+			set: map[string]interface{}{
+				"hello": "unittest",
+			},
+			want: []byte(`{"hello":"unittest"}`),
+		},
+		"text/json": {
+			event: func(version string) ce.Event {
+				e := ce.New(version)
+				e.SetDataContentType("text/json")
+				return e
+			},
+			set: map[string]interface{}{
+				"hello": "unittest",
+			},
+			want: []byte(`{"hello":"unittest"}`),
+		},
+		"application/json": {
+			event: func(version string) ce.Event {
+				e := ce.New(version)
+				e.SetDataContentType("application/json")
+				return e
+			},
+			set: map[string]interface{}{
+				"hello": "unittest",
+			},
+			want: []byte(`{"hello":"unittest"}`),
+		},
+		"application/json+base64": {
+			event: func(version string) ce.Event {
+				e := ce.New(version)
+				e.SetDataContentType("application/json")
+				e.SetDataContentEncoding(ce.Base64)
+				return e
+			},
+			set: map[string]interface{}{
+				"hello": "unittest",
+			},
+			want: `eyJoZWxsbyI6InVuaXR0ZXN0In0=`,
+		},
+	}
+	for n, tc := range testCases {
+		for _, version := range versions {
+			t.Run(n+":"+version, func(t *testing.T) {
+				// Make a versioned event.
+				event := tc.event(version)
+
+				event.SetData(tc.set)
+				got := event.Data
+
+				as, _ := types.Allocate(tc.set)
+
+				err := event.DataAs(&as)
+				validateData(t, tc, got, as, err)
+			})
+		}
+	}
+}
+
+type XmlExample struct {
+	AnInt   int      `xml:"a,omitempty"`
+	AString string   `xml:"b,omitempty"`
+	AnArray []string `xml:"c,omitempty"`
+}
+
+func TestEventSetData_xml(t *testing.T) {
+	// All version should be the same, so run through them all.
+
+	versions := []string{ce.CloudEventsVersionV01, ce.CloudEventsVersionV02, ce.CloudEventsVersionV03}
+
+	testCases := map[string]DataTest{
+		"text/xml": {
+			event: func(version string) ce.Event {
+				e := ce.New(version)
+				e.SetDataContentType("text/xml")
+				return e
+			},
+			set: &XmlExample{
+				AnInt:   42,
+				AString: "true fact",
+				AnArray: versions,
+			},
+			want: []byte(`<XmlExample><a>42</a><b>true fact</b><c>0.1</c><c>0.2</c><c>0.3</c></XmlExample>`),
+		},
+		"applicaiton/xml": {
+			event: func(version string) ce.Event {
+				e := ce.New(version)
+				e.SetDataContentType("application/xml")
+				return e
+			},
+			set: &XmlExample{
+				AnInt:   42,
+				AString: "true fact",
+				AnArray: versions,
+			},
+			want: []byte(`<XmlExample><a>42</a><b>true fact</b><c>0.1</c><c>0.2</c><c>0.3</c></XmlExample>`),
+		},
+		"applicaiton/xml+base64": {
+			event: func(version string) ce.Event {
+				e := ce.New(version)
+				e.SetDataContentType("application/xml")
+				e.SetDataContentEncoding(ce.Base64)
+				return e
+			},
+			set: &XmlExample{
+				AnInt:   42,
+				AString: "true fact",
+				AnArray: versions,
+			},
+			want: `PFhtbEV4YW1wbGU+PGE+NDI8L2E+PGI+dHJ1ZSBmYWN0PC9iPjxjPjAuMTwvYz48Yz4wLjI8L2M+PGM+MC4zPC9jPjwvWG1sRXhhbXBsZT4=`,
+		},
+	}
+	for n, tc := range testCases {
+		for _, version := range versions {
+			t.Run(n+":"+version, func(t *testing.T) {
+				// Make a versioned event.
+				event := tc.event(version)
+
+				event.SetData(tc.set)
+				got := event.Data
+
+				as, _ := types.Allocate(tc.set)
+
+				err := event.DataAs(&as)
+				validateData(t, tc, got, as, err)
+			})
+		}
+	}
+}
+
+func validateData(t *testing.T, tc DataTest, got, as interface{}, err error) {
+	var gotErr string
+	if err != nil {
+		gotErr = err.Error()
+		if tc.wantErr == "" {
+			t.Errorf("unexpected no error, got %q", gotErr)
+		}
+	}
+	if tc.wantErr != "" {
+		if !strings.Contains(gotErr, tc.wantErr) {
+			t.Errorf("unexpected error, expected to contain %q, got: %q ", tc.wantErr, gotErr)
+		}
+	}
+	if diff := cmp.Diff(tc.want, got); diff != "" {
+		t.Errorf("unexpected data (-want, +got) = %v", diff)
+	}
+	if diff := cmp.Diff(tc.set, as); diff != "" {
+		t.Errorf("unexpected as (-want, +got) = %v", diff)
+	}
+}

--- a/pkg/cloudevents/event_interface.go
+++ b/pkg/cloudevents/event_interface.go
@@ -66,4 +66,7 @@ type EventWriter interface {
 
 	// SetExtension performs event.Context.SetExtension.
 	SetExtension(string, interface{})
+
+	// SetData encodes the given payload with the current encoding settings.
+	SetData(interface{}) error
 }

--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -1,6 +1,7 @@
 package cloudevents_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
@@ -208,8 +209,9 @@ func TestDataAs(t *testing.T) {
 		},
 		"json simple": {
 			event: ce.Event{
-				Context: FullEventContextV01(now),
-				Data:    []byte(`{"a":"apple","b":"banana"}`),
+				Context:     FullEventContextV01(now),
+				Data:        []byte(`eyJhIjoiYXBwbGUiLCJiIjoiYmFuYW5hIn0K`),
+				DataEncoded: true,
 			},
 			want: &map[string]string{
 				"a": "apple",
@@ -218,8 +220,9 @@ func TestDataAs(t *testing.T) {
 		},
 		"json complex empty": {
 			event: ce.Event{
-				Context: FullEventContextV01(now),
-				Data:    []byte(`{}`),
+				Context:     FullEventContextV01(now),
+				Data:        []byte(`e30K`),
+				DataEncoded: true,
 			},
 			want: &DataExample{},
 		},
@@ -241,8 +244,11 @@ func TestDataAs(t *testing.T) {
 					if err != nil {
 						t.Errorf("failed to marshal test data: %s", err.Error())
 					}
-					return j
+					buf := make([]byte, base64.StdEncoding.EncodedLen(len(j)))
+					base64.StdEncoding.Encode(buf, j)
+					return buf
 				}(),
+				DataEncoded: true,
 			},
 			want: &DataExample{
 				AnInt: 42,

--- a/pkg/cloudevents/eventcontext_v03.go
+++ b/pkg/cloudevents/eventcontext_v03.go
@@ -233,8 +233,6 @@ func (ec EventContextV03) Validate() error {
 			// TODO: need to test for RFC 2046
 			errors = append(errors, "datacontentencoding: if present, MUST adhere to RFC 2045 Section 6.1")
 		}
-		// TODO: need to test that the payload is in-fact base64 encoded. This is tricky because it is only that way on
-		// the way out, and at rest the payload might be a struct that will become base64 encoded.
 	}
 
 	if len(errors) > 0 {

--- a/pkg/cloudevents/transport/http/codec_test.go
+++ b/pkg/cloudevents/transport/http/codec_test.go
@@ -449,6 +449,7 @@ func TestCodecDecode(t *testing.T) {
 					EventID:            "ABC-123",
 					ContentType:        cloudevents.StringOfApplicationJSON(),
 				},
+				DataEncoded: true,
 			},
 		},
 		"simple v0.1 structured": {
@@ -474,6 +475,7 @@ func TestCodecDecode(t *testing.T) {
 					Source:             *source,
 					EventID:            "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"simple v0.2 binary": {
@@ -495,6 +497,7 @@ func TestCodecDecode(t *testing.T) {
 					ID:          "ABC-123",
 					ContentType: cloudevents.StringOfApplicationJSON(),
 				},
+				DataEncoded: true,
 			},
 		},
 		"simple v0.2 structured": {
@@ -520,6 +523,7 @@ func TestCodecDecode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 
@@ -542,6 +546,7 @@ func TestCodecDecode(t *testing.T) {
 					ID:              "ABC-123",
 					DataContentType: cloudevents.StringOfApplicationJSON(),
 				},
+				DataEncoded: true,
 			},
 		},
 		"simple v0.3 structured": {
@@ -567,6 +572,7 @@ func TestCodecDecode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 
@@ -591,6 +597,7 @@ func TestCodecDecode(t *testing.T) {
 					ID:          "ABC-123",
 					ContentType: cloudevents.StringOfApplicationJSON(),
 				},
+				DataEncoded: true,
 			},
 		},
 		"simple v0.1 structured -> v0.2 structured": {
@@ -616,6 +623,7 @@ func TestCodecDecode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"simple v0.2 binary -> v0.1 binary": {
@@ -637,6 +645,7 @@ func TestCodecDecode(t *testing.T) {
 					EventID:            "ABC-123",
 					ContentType:        cloudevents.StringOfApplicationJSON(),
 				},
+				DataEncoded: true,
 			},
 		},
 		"simple v0.2 structured -> v0.1 structured": {
@@ -662,6 +671,7 @@ func TestCodecDecode(t *testing.T) {
 					Source:             *source,
 					EventID:            "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		// TODO:: add the v0.3 conversion tests. Might want to think of a new way to do this.
@@ -730,6 +740,7 @@ func TestCodecRoundTrip(t *testing.T) {
 						"a": "apple",
 						"b": "banana",
 					},
+					DataEncoded: true,
 				},
 			},
 			"struct data v0.1": {
@@ -757,6 +768,7 @@ func TestCodecRoundTrip(t *testing.T) {
 						AnInt:   42,
 						AString: "testing",
 					},
+					DataEncoded: true,
 				},
 			},
 			// TODO: add tests for other versions. (note not really needed because these is tested internally too)
@@ -883,6 +895,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 							AnInt:   42,
 							AString: "testing",
 						},
+						DataEncoded: true,
 					},
 				},
 			}

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -77,21 +77,11 @@ func (v CodecV01) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	//
-	//mediaType, err := e.Context.GetDataMediaType()
-	//if err != nil {
-	//	return nil, err
-	//}
 
 	body, err := e.DataBytes()
 	if err != nil {
 		panic("encode")
 	}
-
-	//body, err := marshalEventData(mediaType, e.Data)
-	//if err != nil {
-	//	return nil, err
-	//}
 
 	msg := &Message{
 		Header: header,

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -77,15 +77,21 @@ func (v CodecV01) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 	if err != nil {
 		return nil, err
 	}
+	//
+	//mediaType, err := e.Context.GetDataMediaType()
+	//if err != nil {
+	//	return nil, err
+	//}
 
-	mediaType, err := e.Context.GetDataMediaType()
+	body, err := e.DataBytes()
 	if err != nil {
-		return nil, err
+		panic("idk")
 	}
-	body, err := marshalEventData(mediaType, e.Data)
-	if err != nil {
-		return nil, err
-	}
+
+	//body, err := marshalEventData(mediaType, e.Data)
+	//if err != nil {
+	//	return nil, err
+	//}
 
 	msg := &Message{
 		Header: header,

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -85,7 +85,7 @@ func (v CodecV01) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 
 	body, err := e.DataBytes()
 	if err != nil {
-		panic("idk")
+		panic("encode")
 	}
 
 	//body, err := marshalEventData(mediaType, e.Data)
@@ -170,8 +170,9 @@ func (v CodecV01) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 		body = m.Body
 	}
 	return &cloudevents.Event{
-		Context: &ctx,
-		Data:    body,
+		Context:     &ctx,
+		Data:        body,
+		DataEncoded: true,
 	}, nil
 }
 

--- a/pkg/cloudevents/transport/http/codec_v01_test.go
+++ b/pkg/cloudevents/transport/http/codec_v01_test.go
@@ -263,6 +263,7 @@ func TestCodecV01_Decode(t *testing.T) {
 					EventID:            "ABC-123",
 					ContentType:        cloudevents.StringOfApplicationJSON(),
 				},
+				DataEncoded: true,
 			},
 		},
 		"full v0.1 binary": {
@@ -300,6 +301,7 @@ func TestCodecV01_Decode(t *testing.T) {
 				Data: toBytes(map[string]interface{}{
 					"hello": "world",
 				}),
+				DataEncoded: true,
 			},
 		},
 		"simple v0.1 structured": {
@@ -322,6 +324,7 @@ func TestCodecV01_Decode(t *testing.T) {
 					Source:             *source,
 					EventID:            "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"full v0.1 structured": {
@@ -364,6 +367,7 @@ func TestCodecV01_Decode(t *testing.T) {
 				Data: toBytes(map[string]interface{}{
 					"hello": "world",
 				}),
+				DataEncoded: true,
 			},
 		},
 		"simple v0.1 binary with short header": {
@@ -386,6 +390,7 @@ func TestCodecV01_Decode(t *testing.T) {
 					EventID:            "ABC-123",
 					ContentType:        cloudevents.StringOfApplicationJSON(),
 				},
+				DataEncoded: true,
 			},
 		},
 	}

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -174,8 +174,9 @@ func (v CodecV02) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 		body = m.Body
 	}
 	return &cloudevents.Event{
-		Context: &ctx,
-		Data:    body,
+		Context:     &ctx,
+		Data:        body,
+		DataEncoded: true,
 	}, nil
 }
 
@@ -281,8 +282,9 @@ func (v CodecV02) decodeStructured(msg transport.Message) (*cloudevents.Event, e
 	}
 
 	return &cloudevents.Event{
-		Context: &ec,
-		Data:    data,
+		Context:     &ec,
+		Data:        data,
+		DataEncoded: true,
 	}, nil
 }
 

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -78,13 +78,18 @@ func (v CodecV02) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 		return nil, err
 	}
 
-	mediaType, err := e.Context.GetDataMediaType()
+	//mediaType, err := e.Context.GetDataMediaType()
+	//if err != nil {
+	//	return nil, err
+	//}
+	//body, err := marshalEventData(mediaType, e.Data)
+	//if err != nil {
+	//	return nil, err
+	//}
+
+	body, err := e.DataBytes()
 	if err != nil {
-		return nil, err
-	}
-	body, err := marshalEventData(mediaType, e.Data)
-	if err != nil {
-		return nil, err
+		panic("idk")
 	}
 
 	msg := &Message{

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -77,19 +77,9 @@ func (v CodecV02) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	//mediaType, err := e.Context.GetDataMediaType()
-	//if err != nil {
-	//	return nil, err
-	//}
-	//body, err := marshalEventData(mediaType, e.Data)
-	//if err != nil {
-	//	return nil, err
-	//}
-
 	body, err := e.DataBytes()
 	if err != nil {
-		panic("idk")
+		return nil, err
 	}
 
 	msg := &Message{

--- a/pkg/cloudevents/transport/http/codec_v02_test.go
+++ b/pkg/cloudevents/transport/http/codec_v02_test.go
@@ -270,6 +270,7 @@ func TestCodecV02_Decode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"full v0.2 binary": {
@@ -313,6 +314,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				Data: toBytes(map[string]interface{}{
 					"hello": "world",
 				}),
+				DataEncoded: true,
 			},
 		},
 		"simple v0.2 structured": {
@@ -335,6 +337,7 @@ func TestCodecV02_Decode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"full v0.2 structured": {
@@ -375,6 +378,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				Data: toBytes(map[string]interface{}{
 					"hello": "world",
 				}),
+				DataEncoded: true,
 			},
 		},
 		"simple v0.2 binary with short header": {
@@ -397,6 +401,7 @@ func TestCodecV02_Decode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 	}

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"context"
-	"encoding/base64"
+	//"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
@@ -83,19 +83,24 @@ func (v CodecV03) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 		return nil, err
 	}
 
-	mediaType, err := e.Context.GetDataMediaType()
-	if err != nil {
-		return nil, err
-	}
-	body, err := marshalEventData(mediaType, e.Data)
-	if err != nil {
-		return nil, err
-	}
+	//mediaType, err := e.Context.GetDataMediaType()
+	//if err != nil {
+	//	return nil, err
+	//}
+	//body, err := marshalEventData(mediaType, e.Data)
+	//if err != nil {
+	//	return nil, err
+	//}
 
-	if e.Context.GetDataContentEncoding() == cloudevents.Base64 {
-		buf := make([]byte, base64.StdEncoding.EncodedLen(len(body)))
-		base64.StdEncoding.Encode(buf, body)
-		body = buf
+	//if e.Context.GetDataContentEncoding() == cloudevents.Base64 {
+	//	buf := make([]byte, base64.StdEncoding.EncodedLen(len(body)))
+	//	base64.StdEncoding.Encode(buf, body)
+	//	body = buf
+	//}
+
+	body, err := e.DataBytes()
+	if err != nil {
+		panic("idk")
 	}
 
 	msg := &Message{
@@ -184,16 +189,16 @@ func (v CodecV03) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 	}
 	var body interface{}
 	if len(m.Body) > 0 {
-		if ctx.DataContentEncoding != nil && *ctx.DataContentEncoding == cloudevents.Base64 {
-			buf := make([]byte, base64.StdEncoding.DecodedLen(len(m.Body)))
-			if n, err := base64.StdEncoding.Decode(buf, m.Body); err != nil {
-				return nil, fmt.Errorf("failed to decode data from base64: %s", err.Error())
-			} else {
-				body = string(buf[:n])
-			}
-		} else {
-			body = m.Body
-		}
+		//if ctx.DataContentEncoding != nil && *ctx.DataContentEncoding == cloudevents.Base64 {
+		//	buf := make([]byte, base64.StdEncoding.DecodedLen(len(m.Body)))
+		//	if n, err := base64.StdEncoding.Decode(buf, m.Body); err != nil {
+		//		return nil, fmt.Errorf("failed to decode data from base64: %s", err.Error())
+		//	} else {
+		//		body = string(buf[:n])
+		//	}
+		//} else {
+		body = m.Body
+		//}
 	}
 	return &cloudevents.Event{
 		Context: &ctx,
@@ -312,20 +317,20 @@ func (v CodecV03) decodeStructured(msg transport.Message) (*cloudevents.Event, e
 	var data interface{}
 	if d, ok := raw["data"]; ok {
 
-		if ec.DataContentEncoding != nil && *ec.DataContentEncoding == cloudevents.Base64 {
-			var ds string
-			if err := json.Unmarshal(d, &ds); err != nil {
-				return nil, err
-			}
-			buf := make([]byte, base64.StdEncoding.DecodedLen(len(ds)))
-			if n, err := base64.StdEncoding.Decode(buf, []byte(ds)); err != nil {
-				return nil, fmt.Errorf("failed to decode data from base64: %s", err.Error())
-			} else {
-				data = string(buf[:n])
-			}
-		} else {
-			data = []byte(d)
-		}
+		//if ec.DataContentEncoding != nil && *ec.DataContentEncoding == cloudevents.Base64 {
+		//	var ds string
+		//	if err := json.Unmarshal(d, &ds); err != nil {
+		//		return nil, err
+		//	}
+		//	buf := make([]byte, base64.StdEncoding.DecodedLen(len(ds)))
+		//	if n, err := base64.StdEncoding.Decode(buf, []byte(ds)); err != nil {
+		//		return nil, fmt.Errorf("failed to decode data from base64: %s", err.Error())
+		//	} else {
+		//		data = string(buf[:n])
+		//	}
+		//} else {
+		data = []byte(d)
+		//}
 	}
 
 	return &cloudevents.Event{

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -2,17 +2,17 @@ package http
 
 import (
 	"context"
-	//"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/textproto"
+	"strings"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/codec"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"net/http"
-	"net/textproto"
-	"strings"
 )
 
 // CodecV03 represents a http transport codec that uses CloudEvents spec v0.3
@@ -201,8 +201,9 @@ func (v CodecV03) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 		//}
 	}
 	return &cloudevents.Event{
-		Context: &ctx,
-		Data:    body,
+		Context:     &ctx,
+		Data:        body,
+		DataEncoded: true,
 	}, nil
 }
 
@@ -318,6 +319,8 @@ func (v CodecV03) decodeStructured(msg transport.Message) (*cloudevents.Event, e
 	if d, ok := raw["data"]; ok {
 
 		//if ec.DataContentEncoding != nil && *ec.DataContentEncoding == cloudevents.Base64 {
+		//	s, err := strconv.Unquote(string(d))
+		//}
 		//	var ds string
 		//	if err := json.Unmarshal(d, &ds); err != nil {
 		//		return nil, err
@@ -334,8 +337,9 @@ func (v CodecV03) decodeStructured(msg transport.Message) (*cloudevents.Event, e
 	}
 
 	return &cloudevents.Event{
-		Context: &ec,
-		Data:    data,
+		Context:     &ec,
+		Data:        data,
+		DataEncoded: true,
 	}, nil
 }
 

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -85,7 +85,7 @@ func (v CodecV03) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 
 	body, err := e.DataBytes()
 	if err != nil {
-		panic("idk")
+		return nil, err
 	}
 
 	msg := &Message{

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -83,21 +83,6 @@ func (v CodecV03) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 		return nil, err
 	}
 
-	//mediaType, err := e.Context.GetDataMediaType()
-	//if err != nil {
-	//	return nil, err
-	//}
-	//body, err := marshalEventData(mediaType, e.Data)
-	//if err != nil {
-	//	return nil, err
-	//}
-
-	//if e.Context.GetDataContentEncoding() == cloudevents.Base64 {
-	//	buf := make([]byte, base64.StdEncoding.EncodedLen(len(body)))
-	//	base64.StdEncoding.Encode(buf, body)
-	//	body = buf
-	//}
-
 	body, err := e.DataBytes()
 	if err != nil {
 		panic("idk")
@@ -189,16 +174,7 @@ func (v CodecV03) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 	}
 	var body interface{}
 	if len(m.Body) > 0 {
-		//if ctx.DataContentEncoding != nil && *ctx.DataContentEncoding == cloudevents.Base64 {
-		//	buf := make([]byte, base64.StdEncoding.DecodedLen(len(m.Body)))
-		//	if n, err := base64.StdEncoding.Decode(buf, m.Body); err != nil {
-		//		return nil, fmt.Errorf("failed to decode data from base64: %s", err.Error())
-		//	} else {
-		//		body = string(buf[:n])
-		//	}
-		//} else {
 		body = m.Body
-		//}
 	}
 	return &cloudevents.Event{
 		Context:     &ctx,
@@ -317,23 +293,7 @@ func (v CodecV03) decodeStructured(msg transport.Message) (*cloudevents.Event, e
 	}
 	var data interface{}
 	if d, ok := raw["data"]; ok {
-
-		//if ec.DataContentEncoding != nil && *ec.DataContentEncoding == cloudevents.Base64 {
-		//	s, err := strconv.Unquote(string(d))
-		//}
-		//	var ds string
-		//	if err := json.Unmarshal(d, &ds); err != nil {
-		//		return nil, err
-		//	}
-		//	buf := make([]byte, base64.StdEncoding.DecodedLen(len(ds)))
-		//	if n, err := base64.StdEncoding.Decode(buf, []byte(ds)); err != nil {
-		//		return nil, fmt.Errorf("failed to decode data from base64: %s", err.Error())
-		//	} else {
-		//		data = string(buf[:n])
-		//	}
-		//} else {
 		data = []byte(d)
-		//}
 	}
 
 	return &cloudevents.Event{

--- a/pkg/cloudevents/transport/http/codec_v03_test.go
+++ b/pkg/cloudevents/transport/http/codec_v03_test.go
@@ -371,6 +371,7 @@ func TestCodecV03_Decode(t *testing.T) {
 					Source:          *source,
 					ID:              "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"full v0.3 binary": {
@@ -416,6 +417,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				Data: toBytes(map[string]interface{}{
 					"hello": "world",
 				}),
+				DataEncoded: true,
 			},
 		},
 		"full v0.3 binary base64": {
@@ -458,7 +460,8 @@ func TestCodecV03_Decode(t *testing.T) {
 						},
 					},
 				},
-				Data: `{"hello":"world"}`,
+				Data:        []byte(`eyJoZWxsbyI6IndvcmxkIn0=`),
+				DataEncoded: true,
 			},
 		},
 		"simple v0.3 structured": {
@@ -481,6 +484,7 @@ func TestCodecV03_Decode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"full v0.3 structured": {
@@ -523,6 +527,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				Data: toBytes(map[string]interface{}{
 					"hello": "world",
 				}),
+				DataEncoded: true,
 			},
 		},
 		"full v0.3 structured base64": {
@@ -562,7 +567,8 @@ func TestCodecV03_Decode(t *testing.T) {
 						"test": "extended",
 					},
 				},
-				Data: `{"hello":"world"}`,
+				Data:        []byte(`"eyJoZWxsbyI6IndvcmxkIn0="`), // TODO: structured comes in quoted. Unquote?
+				DataEncoded: true,
 			},
 		},
 		"simple v0.3 binary with short header": {
@@ -585,6 +591,7 @@ func TestCodecV03_Decode(t *testing.T) {
 					Source:          *source,
 					ID:              "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 	}

--- a/pkg/cloudevents/transport/nats/codec_test.go
+++ b/pkg/cloudevents/transport/nats/codec_test.go
@@ -107,6 +107,7 @@ func TestCodecDecode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 	}
@@ -174,6 +175,7 @@ func TestCodecRoundTrip(t *testing.T) {
 						"a": "apple",
 						"b": "banana",
 					},
+					DataEncoded: true,
 				},
 			},
 			"struct data": {
@@ -201,6 +203,7 @@ func TestCodecRoundTrip(t *testing.T) {
 						AnInt:   42,
 						AString: "testing",
 					},
+					DataEncoded: true,
 				},
 			},
 		}
@@ -294,6 +297,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 						"a": "apple",
 						"b": "banana",
 					},
+					DataEncoded: true,
 				},
 			},
 			"struct data": {
@@ -321,6 +325,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 						AnInt:   42,
 						AString: "testing",
 					},
+					DataEncoded: true,
 				},
 			},
 		}

--- a/pkg/cloudevents/transport/nats/codec_v02_test.go
+++ b/pkg/cloudevents/transport/nats/codec_v02_test.go
@@ -210,6 +210,7 @@ func TestCodecV02_Decode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"full v2 structured": {
@@ -247,6 +248,7 @@ func TestCodecV02_Decode(t *testing.T) {
 				Data: toBytes(map[string]interface{}{
 					"hello": "world",
 				}),
+				DataEncoded: true,
 			},
 		},
 	}

--- a/pkg/cloudevents/transport/nats/codec_v03_test.go
+++ b/pkg/cloudevents/transport/nats/codec_v03_test.go
@@ -210,6 +210,7 @@ func TestCodecV03_Decode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
 			},
 		},
 		"full v0.3 structured": {
@@ -247,6 +248,7 @@ func TestCodecV03_Decode(t *testing.T) {
 				Data: toBytes(map[string]interface{}{
 					"hello": "world",
 				}),
+				DataEncoded: true,
 			},
 		},
 	}

--- a/test/http/loopback_setters_test.go
+++ b/test/http/loopback_setters_test.go
@@ -1,0 +1,466 @@
+package http
+
+import (
+	"fmt"
+	"github.com/cloudevents/sdk-go"
+	"testing"
+	"time"
+)
+
+func TestClientLoopback_setters_binary_json(t *testing.T) {
+	now := time.Now()
+
+	versions := []string{cloudevents.VersionV01, cloudevents.VersionV02, cloudevents.VersionV03}
+
+	testCases := map[string]struct {
+		event  func(string) *cloudevents.Event
+		resp   func(string) *cloudevents.Event
+		want   map[string]*cloudevents.Event
+		asSent map[string]*TapValidation
+		asRecv map[string]*TapValidation
+	}{
+		"Loopback": {
+			event: func(version string) *cloudevents.Event {
+				event := cloudevents.NewEvent(version)
+				event.SetID("ABC-123")
+				event.SetType("unit.test.client.sent")
+				event.SetSource("/unit/test/client")
+				if err := event.SetData(map[string]string{"hello": "unittest"}); err != nil {
+					t.Fatal(err)
+				}
+				return &event
+			},
+			resp: func(version string) *cloudevents.Event {
+				event := cloudevents.NewEvent(version)
+				event.SetID("321-CBA")
+				event.SetType("unit.test.client.response")
+				event.SetSource("/unit/test/client")
+				if err := event.SetData(map[string]string{"unittest": "response"}); err != nil {
+					t.Fatal(err)
+				}
+				return &event
+			},
+			want: map[string]*cloudevents.Event{
+				cloudevents.VersionV01: {
+					Context: cloudevents.EventContextV01{
+						EventID:     "321-CBA",
+						EventType:   "unit.test.client.response",
+						EventTime:   &cloudevents.Timestamp{Time: now},
+						Source:      *cloudevents.ParseURLRef("/unit/test/client"),
+						ContentType: cloudevents.StringOfApplicationJSON(),
+					}.AsV01(),
+					Data: map[string]string{"unittest": "response"},
+				},
+				cloudevents.VersionV02: {
+					Context: cloudevents.EventContextV02{
+						ID:          "321-CBA",
+						Type:        "unit.test.client.response",
+						Time:        &cloudevents.Timestamp{Time: now},
+						Source:      *cloudevents.ParseURLRef("/unit/test/client"),
+						ContentType: cloudevents.StringOfApplicationJSON(),
+					}.AsV02(),
+					Data: map[string]string{"unittest": "response"},
+				},
+				cloudevents.VersionV03: {
+					Context: cloudevents.EventContextV03{
+						ID:              "321-CBA",
+						Type:            "unit.test.client.response",
+						Time:            &cloudevents.Timestamp{Time: now},
+						Source:          *cloudevents.ParseURLRef("/unit/test/client"),
+						DataContentType: cloudevents.StringOfApplicationJSON(),
+					}.AsV03(),
+					Data: map[string]string{"unittest": "response"},
+				},
+			},
+			asSent: map[string]*TapValidation{
+				cloudevents.VersionV01: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"ce-cloudeventsversion": {"0.1"},
+						"ce-eventid":            {"ABC-123"},
+						"ce-eventtime":          {now.UTC().Format(time.RFC3339Nano)},
+						"ce-eventtype":          {"unit.test.client.sent"},
+						"ce-source":             {"/unit/test/client"},
+						"content-type":          {"application/json"},
+					},
+					Body:          `{"hello":"unittest"}`,
+					ContentLength: 20,
+				},
+				cloudevents.VersionV02: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"ce-specversion": {"0.2"},
+						"ce-id":          {"ABC-123"},
+						"ce-time":        {now.UTC().Format(time.RFC3339Nano)},
+						"ce-type":        {"unit.test.client.sent"},
+						"ce-source":      {"/unit/test/client"},
+						"content-type":   {"application/json"},
+					},
+					Body:          `{"hello":"unittest"}`,
+					ContentLength: 20,
+				},
+				cloudevents.VersionV03: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"ce-specversion": {"0.3"},
+						"ce-id":          {"ABC-123"},
+						"ce-time":        {now.UTC().Format(time.RFC3339Nano)},
+						"ce-type":        {"unit.test.client.sent"},
+						"ce-source":      {"/unit/test/client"},
+						"content-type":   {"application/json"},
+					},
+					Body:          `{"hello":"unittest"}`,
+					ContentLength: 20,
+				},
+			},
+			asRecv: map[string]*TapValidation{
+				cloudevents.VersionV01: {
+					Header: map[string][]string{
+						"ce-cloudeventsversion": {"0.1"},
+						"ce-eventid":            {"321-CBA"},
+						"ce-eventtime":          {now.UTC().Format(time.RFC3339Nano)},
+						"ce-eventtype":          {"unit.test.client.response"},
+						"ce-source":             {"/unit/test/client"},
+						"content-type":          {"application/json"},
+					},
+					Body:          `{"unittest":"response"}`,
+					Status:        "200 OK",
+					ContentLength: 23,
+				},
+				cloudevents.VersionV02: {
+					Header: map[string][]string{
+						"ce-specversion": {"0.2"},
+						"ce-id":          {"321-CBA"},
+						"ce-time":        {now.UTC().Format(time.RFC3339Nano)},
+						"ce-type":        {"unit.test.client.response"},
+						"ce-source":      {"/unit/test/client"},
+						"content-type":   {"application/json"},
+					},
+					Body:          `{"unittest":"response"}`,
+					Status:        "200 OK",
+					ContentLength: 23,
+				},
+				cloudevents.VersionV03: {
+					Header: map[string][]string{
+						"ce-specversion": {"0.3"},
+						"ce-id":          {"321-CBA"},
+						"ce-time":        {now.UTC().Format(time.RFC3339Nano)},
+						"ce-type":        {"unit.test.client.response"},
+						"ce-source":      {"/unit/test/client"},
+						"content-type":   {"application/json"},
+					},
+					Body:          `{"unittest":"response"}`,
+					Status:        "200 OK",
+					ContentLength: 23,
+				},
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		for _, version := range versions {
+			t.Run(n+version+" -> "+version, func(t *testing.T) {
+
+				testcase := TapTest{
+					now:    now,
+					event:  tc.event(version),
+					resp:   tc.resp(version),
+					want:   tc.want[version],
+					asSent: tc.asSent[version],
+					asRecv: tc.asRecv[version],
+				}
+				ClientLoopback(t, testcase)
+			})
+		}
+	}
+}
+
+func TestClientLoopback_setters_structured_json(t *testing.T) {
+	now := time.Now()
+
+	versions := []string{cloudevents.VersionV01, cloudevents.VersionV02, cloudevents.VersionV03}
+
+	testCases := map[string]struct {
+		event  func(string) *cloudevents.Event
+		resp   func(string) *cloudevents.Event
+		want   map[string]*cloudevents.Event
+		asSent map[string]*TapValidation
+		asRecv map[string]*TapValidation
+	}{
+		"Loopback": {
+			event: func(version string) *cloudevents.Event {
+				event := cloudevents.NewEvent(version)
+				event.SetID("ABC-123")
+				event.SetType("unit.test.client.sent")
+				event.SetSource("/unit/test/client")
+				if err := event.SetData(map[string]string{"hello": "unittest"}); err != nil {
+					t.Fatal(err)
+				}
+				return &event
+			},
+			resp: func(version string) *cloudevents.Event {
+				event := cloudevents.NewEvent(version)
+				event.SetID("321-CBA")
+				event.SetType("unit.test.client.response")
+				event.SetSource("/unit/test/client")
+				if err := event.SetData(map[string]string{"unittest": "response"}); err != nil {
+					t.Fatal(err)
+				}
+				return &event
+			},
+			want: map[string]*cloudevents.Event{
+				cloudevents.VersionV01: {
+					Context: cloudevents.EventContextV01{
+						EventID:     "321-CBA",
+						EventType:   "unit.test.client.response",
+						EventTime:   &cloudevents.Timestamp{Time: now},
+						Source:      *cloudevents.ParseURLRef("/unit/test/client"),
+						ContentType: cloudevents.StringOfApplicationJSON(),
+					}.AsV01(),
+					Data: map[string]string{"unittest": "response"},
+				},
+				cloudevents.VersionV02: {
+					Context: cloudevents.EventContextV02{
+						ID:          "321-CBA",
+						Type:        "unit.test.client.response",
+						Time:        &cloudevents.Timestamp{Time: now},
+						Source:      *cloudevents.ParseURLRef("/unit/test/client"),
+						ContentType: cloudevents.StringOfApplicationJSON(),
+					}.AsV02(),
+					Data: map[string]string{"unittest": "response"},
+				},
+				cloudevents.VersionV03: {
+					Context: cloudevents.EventContextV03{
+						ID:              "321-CBA",
+						Type:            "unit.test.client.response",
+						Time:            &cloudevents.Timestamp{Time: now},
+						Source:          *cloudevents.ParseURLRef("/unit/test/client"),
+						DataContentType: cloudevents.StringOfApplicationJSON(),
+					}.AsV03(),
+					Data: map[string]string{"unittest": "response"},
+				},
+			},
+			asSent: map[string]*TapValidation{
+				cloudevents.VersionV01: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body: fmt.Sprintf(`{"cloudEventsVersion":"0.1","contentType":"application/json","data":{"hello":"unittest"},"eventID":"ABC-123","eventTime":%q,"eventType":"unit.test.client.sent","source":"/unit/test/client"}`, now.UTC().Format(time.RFC3339Nano)),
+				},
+				cloudevents.VersionV02: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body: fmt.Sprintf(`{"contenttype":"application/json","data":{"hello":"unittest"},"id":"ABC-123","source":"/unit/test/client","specversion":"0.2","time":%q,"type":"unit.test.client.sent"}`, now.UTC().Format(time.RFC3339Nano)),
+				},
+				cloudevents.VersionV03: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body: fmt.Sprintf(`{"data":{"hello":"unittest"},"datacontenttype":"application/json","id":"ABC-123","source":"/unit/test/client","specversion":"0.3","time":%q,"type":"unit.test.client.sent"}`, now.UTC().Format(time.RFC3339Nano)),
+				},
+			},
+			asRecv: map[string]*TapValidation{
+				cloudevents.VersionV01: {
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body:   fmt.Sprintf(`{"cloudEventsVersion":"0.1","contentType":"application/json","data":{"unittest":"response"},"eventID":"321-CBA","eventTime":%q,"eventType":"unit.test.client.response","source":"/unit/test/client"}`, now.UTC().Format(time.RFC3339Nano)),
+					Status: "200 OK",
+				},
+				cloudevents.VersionV02: {
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body:   fmt.Sprintf(`{"contenttype":"application/json","data":{"unittest":"response"},"id":"321-CBA","source":"/unit/test/client","specversion":"0.2","time":%q,"type":"unit.test.client.response"}`, now.UTC().Format(time.RFC3339Nano)),
+					Status: "200 OK",
+				},
+				cloudevents.VersionV03: {
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body:   fmt.Sprintf(`{"data":{"unittest":"response"},"datacontenttype":"application/json","id":"321-CBA","source":"/unit/test/client","specversion":"0.3","time":%q,"type":"unit.test.client.response"}`, now.UTC().Format(time.RFC3339Nano)),
+					Status: "200 OK",
+				},
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		for _, version := range versions {
+			t.Run(n+version+" -> "+version, func(t *testing.T) {
+
+				testcase := TapTest{
+					now:    now,
+					event:  tc.event(version),
+					resp:   tc.resp(version),
+					want:   tc.want[version],
+					asSent: tc.asSent[version],
+					asRecv: tc.asRecv[version],
+				}
+
+				testcase.asSent.ContentLength = int64(len(testcase.asSent.Body))
+				testcase.asRecv.ContentLength = int64(len(testcase.asRecv.Body))
+
+				ClientLoopback(t, testcase, cloudevents.WithStructuredEncoding())
+			})
+		}
+	}
+}
+
+func TestClientLoopback_setters_structured_json_base64(t *testing.T) {
+	now := time.Now()
+
+	versions := []string{cloudevents.VersionV01, cloudevents.VersionV02, cloudevents.VersionV03}
+
+	testCases := map[string]struct {
+		event  func(string) *cloudevents.Event
+		resp   func(string) *cloudevents.Event
+		want   map[string]*cloudevents.Event
+		asSent map[string]*TapValidation
+		asRecv map[string]*TapValidation
+	}{
+		"Loopback": {
+			event: func(version string) *cloudevents.Event {
+				event := cloudevents.NewEvent(version)
+				event.SetID("ABC-123")
+				event.SetType("unit.test.client.sent")
+				event.SetSource("/unit/test/client")
+				event.SetDataContentEncoding(cloudevents.Base64)
+				if err := event.SetData(map[string]string{"hello": "unittest"}); err != nil {
+					t.Fatal(err)
+				}
+				return &event
+			},
+			resp: func(version string) *cloudevents.Event {
+				event := cloudevents.NewEvent(version)
+				event.SetID("321-CBA")
+				event.SetType("unit.test.client.response")
+				event.SetSource("/unit/test/client")
+				event.SetDataContentEncoding(cloudevents.Base64)
+				if err := event.SetData(map[string]string{"unittest": "response"}); err != nil {
+					t.Fatal(err)
+				}
+				return &event
+			},
+			want: map[string]*cloudevents.Event{
+				cloudevents.VersionV01: {
+					Context: cloudevents.EventContextV01{
+						EventID:     "321-CBA",
+						EventType:   "unit.test.client.response",
+						EventTime:   &cloudevents.Timestamp{Time: now},
+						Source:      *cloudevents.ParseURLRef("/unit/test/client"),
+						ContentType: cloudevents.StringOfApplicationJSON(),
+						Extensions: map[string]interface{}{
+							"datacontentencoding": "base64",
+						},
+					}.AsV01(),
+					Data: map[string]string{"unittest": "response"},
+				},
+				cloudevents.VersionV02: {
+					Context: cloudevents.EventContextV02{
+						ID:          "321-CBA",
+						Type:        "unit.test.client.response",
+						Time:        &cloudevents.Timestamp{Time: now},
+						Source:      *cloudevents.ParseURLRef("/unit/test/client"),
+						ContentType: cloudevents.StringOfApplicationJSON(),
+						Extensions: map[string]interface{}{
+							"datacontentencoding": "base64",
+						},
+					}.AsV02(),
+					Data: map[string]string{"unittest": "response"},
+				},
+				cloudevents.VersionV03: {
+					Context: cloudevents.EventContextV03{
+						ID:                  "321-CBA",
+						Type:                "unit.test.client.response",
+						Time:                &cloudevents.Timestamp{Time: now},
+						Source:              *cloudevents.ParseURLRef("/unit/test/client"),
+						DataContentType:     cloudevents.StringOfApplicationJSON(),
+						DataContentEncoding: cloudevents.StringOfBase64(),
+					}.AsV03(),
+					Data: map[string]string{"unittest": "response"},
+				},
+			},
+			asSent: map[string]*TapValidation{
+				cloudevents.VersionV01: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body: fmt.Sprintf(`{"cloudEventsVersion":"0.1","contentType":"application/json","data":"eyJoZWxsbyI6InVuaXR0ZXN0In0=","eventID":"ABC-123","eventTime":%q,"eventType":"unit.test.client.sent","extensions":{"datacontentencoding":"base64"},"source":"/unit/test/client"}`, now.UTC().Format(time.RFC3339Nano)),
+				},
+				cloudevents.VersionV02: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body: fmt.Sprintf(`{"-":{"datacontentencoding":"base64"},"contenttype":"application/json","data":"eyJoZWxsbyI6InVuaXR0ZXN0In0=","id":"ABC-123","source":"/unit/test/client","specversion":"0.2","time":%q,"type":"unit.test.client.sent"}`, now.UTC().Format(time.RFC3339Nano)),
+				},
+				cloudevents.VersionV03: {
+					Method: "POST",
+					URI:    "/",
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body: fmt.Sprintf(`{"data":"eyJoZWxsbyI6InVuaXR0ZXN0In0=","datacontentencoding":"base64","datacontenttype":"application/json","id":"ABC-123","source":"/unit/test/client","specversion":"0.3","time":%q,"type":"unit.test.client.sent"}`, now.UTC().Format(time.RFC3339Nano)),
+				},
+			},
+			asRecv: map[string]*TapValidation{
+				cloudevents.VersionV01: {
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body:   fmt.Sprintf(`{"cloudEventsVersion":"0.1","contentType":"application/json","data":"eyJ1bml0dGVzdCI6InJlc3BvbnNlIn0=","eventID":"321-CBA","eventTime":%q,"eventType":"unit.test.client.response","extensions":{"datacontentencoding":"base64"},"source":"/unit/test/client"}`, now.UTC().Format(time.RFC3339Nano)),
+					Status: "200 OK",
+				},
+				cloudevents.VersionV02: {
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body:   fmt.Sprintf(`{"-":{"datacontentencoding":"base64"},"contenttype":"application/json","data":"eyJ1bml0dGVzdCI6InJlc3BvbnNlIn0=","id":"321-CBA","source":"/unit/test/client","specversion":"0.2","time":%q,"type":"unit.test.client.response"}`, now.UTC().Format(time.RFC3339Nano)),
+					Status: "200 OK",
+				},
+				cloudevents.VersionV03: {
+					Header: map[string][]string{
+						"content-type": {"application/cloudevents+json"},
+					},
+					Body:   fmt.Sprintf(`{"data":"eyJ1bml0dGVzdCI6InJlc3BvbnNlIn0=","datacontentencoding":"base64","datacontenttype":"application/json","id":"321-CBA","source":"/unit/test/client","specversion":"0.3","time":%q,"type":"unit.test.client.response"}`, now.UTC().Format(time.RFC3339Nano)),
+					Status: "200 OK",
+				},
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		for _, version := range versions {
+			t.Run(n+version+" -> "+version, func(t *testing.T) {
+
+				testcase := TapTest{
+					now:    now,
+					event:  tc.event(version),
+					resp:   tc.resp(version),
+					want:   tc.want[version],
+					asSent: tc.asSent[version],
+					asRecv: tc.asRecv[version],
+				}
+
+				testcase.asSent.ContentLength = int64(len(testcase.asSent.Body))
+				testcase.asRecv.ContentLength = int64(len(testcase.asRecv.Body))
+
+				ClientLoopback(t, testcase, cloudevents.WithStructuredEncoding())
+			})
+		}
+	}
+}

--- a/test/http/validation.go
+++ b/test/http/validation.go
@@ -20,7 +20,7 @@ var (
 )
 
 func assertEventEquality(t *testing.T, ctx string, expected, actual *cloudevents.Event) {
-	if diff := cmp.Diff(expected, actual, cmpopts.IgnoreFields(cloudevents.Event{}, "Data")); diff != "" {
+	if diff := cmp.Diff(expected, actual, cmpopts.IgnoreFields(cloudevents.Event{}, "Data", "DataEncoded")); diff != "" {
 		t.Errorf("Unexpected difference in %s (-want, +got): %v", ctx, diff)
 	}
 	if expected == nil || actual == nil {


### PR DESCRIPTION
There was an issue developing where the data payload was un-trustable to the codecs. I needed a way to set the data and have it pass through the event data encoding, which is not the same as the transport encoding. So now there is a new method on event:

```go
event.SetData(mydata)
```

And this results in the event data becoming encoded on the event according to the event's encoding settings.