### PR TITLE
Fixing error getting locally with new test.

### DIFF
--- a/pkg/cloudevents/transport/http/transport_test.go
+++ b/pkg/cloudevents/transport/http/transport_test.go
@@ -107,13 +107,15 @@ func TestStableConnectionsToSingleHost(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	concurrency := 200
+	concurrency := 64
 	duration := 1 * time.Second
+	var sent uint64
 	err = doConcurrently(concurrency, duration, func() error {
 		_, err := ceClient.Send(ctx, event)
 		if err != nil {
 			return fmt.Errorf("unexpected error sending CloudEvent %v", err.Error())
 		}
+		atomic.AddUint64(&sent, 1)
 		return nil
 	})
 	if err != nil {
@@ -125,4 +127,5 @@ func TestStableConnectionsToSingleHost(t *testing.T) {
 	if newConnectionCount > uint64(concurrency*2) {
 		t.Errorf("too many new connections opened: expected %d, got %d", concurrency, newConnectionCount)
 	}
+	t.Log("sent ", sent)
 }


### PR DESCRIPTION
I am getting errors with the new transport test if it is run on my mac:

```
  transport_test.go:122: error sending concurrent CloudEvents: unexpected error sending CloudEvent Post http://[::]:64451: read tcp [::1]:64485->[::1]:64451: read: connection reset by peer
```

I found that lowering the concurrency limit to `100` allows the test to pass ~50% of the time and `64` 100% of the time. 

used `-test.count = 100` to figure this out.

Signed-off-by: Scott Nichols <nicholss@google.com>