### PR TITLE
HTTP Middleware

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -95,6 +95,7 @@ var (
 	WithStructuredEncoding = http.WithStructuredEncoding
 	WithPort               = http.WithPort
 	WithPath               = http.WithPath
+	WithMiddleware         = http.WithMiddleware
 
 	// HTTP Context
 

--- a/pkg/cloudevents/transport/http/options.go
+++ b/pkg/cloudevents/transport/http/options.go
@@ -179,8 +179,8 @@ func WithPath(path string) Option {
 type Middleware func(next nethttp.Handler) nethttp.Handler
 
 // WithMiddleware adds an HTTP middleware to the transport. It may be specified multiple times.
-// Middleware is applied in order. For example `NewClient(WithMiddleware(foo), WithMiddleware(bar))`
-// would result in `bar(foo(original))`.
+// Middleware is applied to everything before it. For example
+// `NewClient(WithMiddleware(foo), WithMiddleware(bar))` would result in `bar(foo(original))`.
 func WithMiddleware(middleware Middleware) Option {
 	return func (t *Transport) error {
 		if t == nil {

--- a/pkg/cloudevents/transport/http/options.go
+++ b/pkg/cloudevents/transport/http/options.go
@@ -173,3 +173,20 @@ func WithPath(path string) Option {
 		return nil
 	}
 }
+
+// Middleware is a function that takes an existing http.Handler and wraps it in middleware,
+// returning the wrapped http.Handler.
+type Middleware func(next nethttp.Handler) nethttp.Handler
+
+// WithMiddleware adds an HTTP middleware to the transport. It may be specified multiple times.
+// Middleware is applied in order. For example `NewClient(WithMiddleware(foo), WithMiddleware(bar))`
+// would result in `bar(foo(original))`.
+func WithMiddleware(middleware Middleware) Option {
+	return func (t *Transport) error {
+		if t == nil {
+			return fmt.Errorf("http middleware option can not set nil transport")
+		}
+		t.middleware = append(t.middleware, middleware)
+		return nil
+	}
+}

--- a/pkg/cloudevents/transport/http/options_test.go
+++ b/pkg/cloudevents/transport/http/options_test.go
@@ -629,3 +629,31 @@ func TestWithStructuredEncoding(t *testing.T) {
 		})
 	}
 }
+
+func TestWithMiddleware(t *testing.T) {
+	testCases := map[string]struct{
+		t *Transport
+		wantErr string
+	}{
+		"nil transport": {
+			wantErr: "http middleware option can not set nil transport",
+		},
+		"non-nil transport": {
+			t: &Transport{},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			err := tc.t.applyOptions(WithMiddleware(func(next http.Handler) http.Handler {
+				return next
+			}))
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("Expected error '%s'. Actual '%v'", tc.wantErr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add HTTP middleware as an option.

I am planning to use this to add OpenCensus zipkin tracing:

```golang
httpTransport, err := cloudevents.NewHTTPTransport(cloudevents.WithBinaryEncoding(), cloudevents.WithMiddleware(tracing.HTTPSpanMiddleware))
```