### PR TITLE
Fix crash with nil value in binary AMQP message

### DIFF
--- a/pkg/cloudevents/transport/amqp/codec.go
+++ b/pkg/cloudevents/transport/amqp/codec.go
@@ -240,11 +240,14 @@ func (c Codec) fromHeaders(h map[string]interface{}, event *cloudevents.Event) e
 			} else {
 				// key
 				var tmp interface{}
-				if err := json.Unmarshal([]byte(v.(string)), &tmp); err == nil {
-					extensions[ak] = tmp
-				} else {
-					// If we can't unmarshal the data, treat it as a string.
-					extensions[ak] = v
+// An attribute set to nil can be ignored
+				if v != nil {
+					if err := json.Unmarshal([]byte(v.(string)), &tmp); err == nil {
+						extensions[ak] = tmp
+					} else {
+						// If we can't unmarshal the data, treat it as a string.
+						extensions[ak] = v
+					}
 				}
 			}
 		}

--- a/pkg/cloudevents/transport/amqp/codec_test.go
+++ b/pkg/cloudevents/transport/amqp/codec_test.go
@@ -84,6 +84,11 @@ func TestCodecDecode(t *testing.T) {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
 
+	rawBody,_ := json.Marshal(DataExample{
+		AnInt:   42,
+		AString: "testing",
+	})
+
 	testCases := map[string]struct {
 		codec   amqp.Codec
 		msg     *amqp.Message
@@ -111,6 +116,33 @@ func TestCodecDecode(t *testing.T) {
 					Source:      *source,
 					ID:          "ABC-123",
 				},
+				DataEncoded: true,
+			},
+		},
+		"binary v3 with nil attribute": {
+
+			codec: amqp.Codec{Encoding: amqp.BinaryV03},
+			msg: &amqp.Message{
+				ContentType: cloudevents.ApplicationJSON,
+				ApplicationProperties: map[string]interface{}{
+					"cloudEvents:specversion": "0.3",
+					"cloudEvents:type":        "com.example.test",
+					"cloudEvents:source":      "http://example.com/source",
+					"cloudEvents:subject":     "mySubject",
+					"cloudEvents:id":          "123myID",
+					"cloudEvents:cause":       nil,
+				},
+				Body: rawBody,
+			},
+			want: &cloudevents.Event{
+				Context: &cloudevents.EventContextV03{
+					SpecVersion: cloudevents.CloudEventsVersionV03,
+					Type:        "com.example.test",
+					Source:      *source,
+					Subject:     strptr("mySubject"),
+					ID:          "123myID",
+				},
+				Data:rawBody,
 				DataEncoded: true,
 			},
 		},


### PR DESCRIPTION
An extension attribute with value `nil` is now ignored. 