### PR TITLE
Adding Conversion hook.

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -15,6 +15,7 @@ import (
 
 type ClientOption client.Option
 type Client = client.Client
+type ConvertFn = client.ConvertFn
 
 // Event
 

--- a/alias.go
+++ b/alias.go
@@ -62,6 +62,7 @@ var (
 	WithEventDefaulter = client.WithEventDefaulter
 	WithUUIDs          = client.WithUUIDs
 	WithTimeNow        = client.WithTimeNow
+	WithConverterFn    = client.WithConverterFn
 
 	// Event Creation
 

--- a/cmd/samples/http/converter/receiver/main.go
+++ b/cmd/samples/http/converter/receiver/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+	"github.com/google/uuid"
+	"github.com/kelseyhightower/envconfig"
+	"log"
+	"os"
+	"strings"
+)
+
+type envConfig struct {
+	// Port on which to listen for cloudevents
+	Port int    `envconfig:"RCV_PORT" default:"8080"`
+	Path string `envconfig:"RCV_PATH" default:"/"`
+}
+
+// Basic data struct.
+type Example struct {
+	ID      int    `json:"id"`
+	Message string `json:"message"`
+}
+
+func gotEvent(ctx context.Context, event cloudevents.Event) error {
+	fmt.Printf("Got Event Context: %+v\n", event.Context)
+	data := &Example{}
+	if err := event.DataAs(data); err != nil {
+		fmt.Printf("Got Data Error: %s\n", err.Error())
+	}
+	fmt.Printf("Got Data: %+v\n", data)
+
+	fmt.Printf("Got Transport Context: %+v\n", cloudevents.HTTPTransportContextFrom(ctx))
+
+	fmt.Printf("----------------------------\n")
+	return nil
+}
+
+func convert(ctx context.Context, m transport.Message, err error) (*cloudevents.Event, error) {
+	log.Printf("asked to convert, %v", m)
+	log.Printf("trying to recover from %v", err)
+
+	if msg, ok := m.(*http.Message); ok {
+		tx := cloudevents.HTTPTransportContextFrom(ctx)
+
+		data := &Example{}
+		if err := json.Unmarshal(msg.Body, data); err != nil {
+			return nil, err
+		}
+
+		// Make a new event and convert the message payload.
+		event := cloudevents.NewEvent()
+		event.SetSource("github.com/cloudevents/cmd/samples/http/converter/receiver")
+		event.SetType(fmt.Sprintf("io.cloudevents.converter.http.%s", strings.ToLower(tx.Method)))
+		event.SetID(uuid.New().String())
+		event.SetSubject(fmt.Sprintf("%d", data.ID))
+
+		if err := event.SetData(data); err != nil {
+			return nil, err
+		}
+
+		return &event, nil
+	}
+	return nil, err
+}
+
+func main() {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		log.Printf("[ERROR] Failed to process env var: %s", err)
+		os.Exit(1)
+	}
+	ctx := context.Background()
+
+	t, err := cloudevents.NewHTTPTransport(
+		cloudevents.WithPort(env.Port),
+		cloudevents.WithPath(env.Path),
+	)
+	if err != nil {
+		log.Printf("failed to create transport, %v", err)
+		os.Exit(1)
+	}
+	c, err := cloudevents.NewClient(t, cloudevents.WithConverterFn(convert))
+	if err != nil {
+		log.Printf("failed to create client, %v", err)
+		os.Exit(1)
+	}
+
+	log.Printf("will listen on :%d%s\n", env.Port, env.Path)
+	log.Fatalf("failed to start receiver: %s", c.StartReceiver(ctx, gotEvent))
+}

--- a/cmd/samples/http/converter/receiver/main.go
+++ b/cmd/samples/http/converter/receiver/main.go
@@ -27,14 +27,14 @@ type Example struct {
 }
 
 func gotEvent(ctx context.Context, event cloudevents.Event) error {
-	fmt.Printf("Got Event Context: %+v\n", event.Context)
+	fmt.Printf("CloudEvent.Event: %+v\n", event)
 	data := &Example{}
 	if err := event.DataAs(data); err != nil {
-		fmt.Printf("Got Data Error: %s\n", err.Error())
+		fmt.Printf("Data Error: %s\n", err.Error())
 	}
-	fmt.Printf("Got Data: %+v\n", data)
+	fmt.Printf("Structured Data: %+v\n", data)
 
-	fmt.Printf("Got Transport Context: %+v\n", cloudevents.HTTPTransportContextFrom(ctx))
+	fmt.Printf("Transport Context: %+v\n", cloudevents.HTTPTransportContextFrom(ctx))
 
 	fmt.Printf("----------------------------\n")
 	return nil
@@ -93,3 +93,9 @@ func main() {
 	log.Printf("will listen on :%d%s\n", env.Port, env.Path)
 	log.Fatalf("failed to start receiver: %s", c.StartReceiver(ctx, gotEvent))
 }
+
+/*
+
+curl -X POST -H "Content-Type: application/json"  -d '{"id":123,"message":"hello world"}' http://localhost:8080
+
+*/

--- a/cmd/samples/http/converter/sender/main.go
+++ b/cmd/samples/http/converter/sender/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/kelseyhightower/envconfig"
+	"log"
+	"net/http"
+	"os"
+)
+
+type envConfig struct {
+	// Target URL where to send post
+	Target string `envconfig:"TARGET" default:"http://localhost:8080" required:"true"`
+}
+
+// Basic data struct.
+type Example struct {
+	ID      int    `json:"id"`
+	Message string `json:"message"`
+}
+
+func main() {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		log.Printf("[ERROR] Failed to process env var: %s", err)
+		os.Exit(1)
+	}
+
+	data := &Example{
+		ID:      123,
+		Message: "Hello, World!",
+	}
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	_, err = http.Post(env.Target, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -72,6 +72,8 @@ type ceClient struct {
 	transport transport.Transport
 	fn        *receiverFn
 
+	convertFn ConvertFn
+
 	receiverMu        sync.Mutex
 	eventDefaulterFns []EventDefaulter
 }
@@ -181,4 +183,11 @@ func (c *ceClient) applyOptions(opts ...Option) error {
 		}
 	}
 	return nil
+}
+
+func (c *ceClient) Convert(ctx context.Context, m transport.Message, err error) (*cloudevents.Event, error) {
+	if c.convertFn != nil {
+		return c.convertFn(ctx, m, err)
+	}
+	return nil, err
 }

--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -185,6 +185,7 @@ func (c *ceClient) applyOptions(opts ...Option) error {
 	return nil
 }
 
+// Convert implements transport Converter.Convert.
 func (c *ceClient) Convert(ctx context.Context, m transport.Message, err error) (*cloudevents.Event, error) {
 	if c.convertFn != nil {
 		return c.convertFn(ctx, m, err)

--- a/pkg/cloudevents/client/options.go
+++ b/pkg/cloudevents/client/options.go
@@ -35,3 +35,19 @@ func WithTimeNow() Option {
 		return nil
 	}
 }
+
+// WithConverterFn defines the function the transport will use to delegate
+// conversion of non-decodable messages.
+func WithConverterFn(fn ConvertFn) Option {
+	return func(c *ceClient) error {
+		if fn == nil {
+			return fmt.Errorf("client option was given an nil message converter")
+		}
+		if c.transport.HasConverter() {
+			return fmt.Errorf("transport converter already set")
+		}
+		c.convertFn = fn
+		c.transport.SetConverter(c)
+		return nil
+	}
+}

--- a/pkg/cloudevents/client/receiver.go
+++ b/pkg/cloudevents/client/receiver.go
@@ -26,7 +26,9 @@ type receiverFn struct {
 	hasErrorOut bool
 }
 
-type ConvertFn func(context.Context, transport.Message, error) (*cloudevents.Event, error) // TODO: make transport.Message reflective?
+// ConvertFn defines the signature the client expects to enable conversion
+// delegation.
+type ConvertFn func(context.Context, transport.Message, error) (*cloudevents.Event, error)
 
 const (
 	inParamUsage  = "expected a function taking either no parameters, one or more of (context.Context, cloudevents.Event, *cloudevents.EventResponse) ordered"

--- a/pkg/cloudevents/client/receiver.go
+++ b/pkg/cloudevents/client/receiver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"reflect"
 )
 
@@ -24,6 +25,8 @@ type receiverFn struct {
 
 	hasErrorOut bool
 }
+
+type ConvertFn func(context.Context, transport.Message, error) (*cloudevents.Event, error) // TODO: make transport.Message reflective?
 
 const (
 	inParamUsage  = "expected a function taking either no parameters, one or more of (context.Context, cloudevents.Event, *cloudevents.EventResponse) ordered"

--- a/pkg/cloudevents/transport/amqp/codec.go
+++ b/pkg/cloudevents/transport/amqp/codec.go
@@ -63,10 +63,7 @@ func (c *Codec) Decode(msg transport.Message) (*cloudevents.Event, error) {
 		}
 		return c.v03.Decode(msg)
 	default:
-
-		fmt.Printf("HACKHACKHACK %+v", msg)
-
-		return nil, fmt.Errorf("unknown encoding: %s", encoding)
+		return nil, transport.NewErrMessageEncodingUnknown("wrapper", TransportName)
 	}
 }
 
@@ -240,7 +237,7 @@ func (c Codec) fromHeaders(h map[string]interface{}, event *cloudevents.Event) e
 			} else {
 				// key
 				var tmp interface{}
-// An attribute set to nil can be ignored
+				// An attribute set to nil can be ignored
 				if v != nil {
 					if err := json.Unmarshal([]byte(v.(string)), &tmp); err == nil {
 						extensions[ak] = tmp

--- a/pkg/cloudevents/transport/amqp/codec_v02.go
+++ b/pkg/cloudevents/transport/amqp/codec_v02.go
@@ -26,7 +26,12 @@ func (v CodecV02) Encode(e cloudevents.Event) (transport.Message, error) {
 
 func (v CodecV02) Decode(msg transport.Message) (*cloudevents.Event, error) {
 	// only structured is supported as of v0.2
-	return v.decodeStructured(msg)
+	switch v.inspectEncoding(msg) {
+	case StructuredV02:
+		return v.decodeStructured(msg)
+	default:
+		return nil, transport.NewErrMessageEncodingUnknown("v02", TransportName)
+	}
 }
 
 func (v CodecV02) encodeStructured(e cloudevents.Event) (transport.Message, error) {
@@ -43,7 +48,7 @@ func (v CodecV02) encodeStructured(e cloudevents.Event) (transport.Message, erro
 func (v CodecV02) decodeStructured(msg transport.Message) (*cloudevents.Event, error) {
 	m, ok := msg.(*Message)
 	if !ok {
-		return nil, fmt.Errorf("failed to convert transport.Message to http.Message")
+		return nil, fmt.Errorf("failed to convert transport.Message to amqp.Message")
 	}
 	return codec.JsonDecodeV02(m.Body)
 }

--- a/pkg/cloudevents/transport/amqp/codec_v02_test.go
+++ b/pkg/cloudevents/transport/amqp/codec_v02_test.go
@@ -35,7 +35,7 @@ func TestCodecV02_Encode(t *testing.T) {
 				},
 			},
 			want: &amqp.Message{
-				ContentType: "application/cloudevents+json",
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: func() []byte {
 					body := map[string]interface{}{
 						"contenttype": "application/json",
@@ -67,7 +67,7 @@ func TestCodecV02_Encode(t *testing.T) {
 				},
 			},
 			want: &amqp.Message{
-				ContentType: "application/cloudevents+json",
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: func() []byte {
 					body := map[string]interface{}{
 						"specversion": "0.2",
@@ -96,7 +96,7 @@ func TestCodecV02_Encode(t *testing.T) {
 				},
 			},
 			want: &amqp.Message{
-				ContentType: "application/cloudevents+json",
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: func() []byte {
 					body := map[string]interface{}{
 						"contenttype": "application/json",
@@ -128,7 +128,7 @@ func TestCodecV02_Encode(t *testing.T) {
 				},
 			},
 			want: &amqp.Message{
-				ContentType: "application/cloudevents+json",
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: func() []byte {
 					body := map[string]interface{}{
 						"specversion": "0.2",
@@ -197,6 +197,7 @@ func TestCodecV02_Decode(t *testing.T) {
 		"simple v2 structured": {
 			codec: amqp.CodecV02{},
 			msg: &amqp.Message{
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: toBytes(map[string]interface{}{
 					"specversion": "0.2",
 					"id":          "ABC-123",
@@ -217,6 +218,7 @@ func TestCodecV02_Decode(t *testing.T) {
 		"full v2 structured": {
 			codec: amqp.CodecV02{},
 			msg: &amqp.Message{
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: toBytes(map[string]interface{}{
 					"specversion": "0.2",
 					"contenttype": "application/json",

--- a/pkg/cloudevents/transport/amqp/codec_v03.go
+++ b/pkg/cloudevents/transport/amqp/codec_v03.go
@@ -26,7 +26,12 @@ func (v CodecV03) Encode(e cloudevents.Event) (transport.Message, error) {
 
 func (v CodecV03) Decode(msg transport.Message) (*cloudevents.Event, error) {
 	// only structured is supported as of v0.3
-	return v.decodeStructured(msg)
+	switch v.inspectEncoding(msg) {
+	case StructuredV03:
+		return v.decodeStructured(msg)
+	default:
+		return nil, transport.NewErrMessageEncodingUnknown("v03", TransportName)
+	}
 }
 
 func (v CodecV03) encodeStructured(e cloudevents.Event) (transport.Message, error) {
@@ -43,7 +48,7 @@ func (v CodecV03) encodeStructured(e cloudevents.Event) (transport.Message, erro
 func (v CodecV03) decodeStructured(msg transport.Message) (*cloudevents.Event, error) {
 	m, ok := msg.(*Message)
 	if !ok {
-		return nil, fmt.Errorf("failed to convert transport.Message to http.Message")
+		return nil, fmt.Errorf("failed to convert transport.Message to amqp.Message")
 	}
 	return codec.JsonDecodeV03(m.Body)
 }

--- a/pkg/cloudevents/transport/amqp/codec_v03_test.go
+++ b/pkg/cloudevents/transport/amqp/codec_v03_test.go
@@ -67,7 +67,7 @@ func TestCodecV03_Encode(t *testing.T) {
 				},
 			},
 			want: &amqp.Message{
-				ContentType: "application/cloudevents+json",
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: func() []byte {
 					body := map[string]interface{}{
 						"specversion":     "0.3",
@@ -96,7 +96,7 @@ func TestCodecV03_Encode(t *testing.T) {
 				},
 			},
 			want: &amqp.Message{
-				ContentType: "application/cloudevents+json",
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: func() []byte {
 					body := map[string]interface{}{
 						"datacontenttype": "application/json",
@@ -128,7 +128,7 @@ func TestCodecV03_Encode(t *testing.T) {
 				},
 			},
 			want: &amqp.Message{
-				ContentType: "application/cloudevents+json",
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: func() []byte {
 					body := map[string]interface{}{
 						"specversion":     "0.3",
@@ -197,6 +197,7 @@ func TestCodecV03_Decode(t *testing.T) {
 		"simple v0.3 structured": {
 			codec: amqp.CodecV03{},
 			msg: &amqp.Message{
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: toBytes(map[string]interface{}{
 					"specversion": "0.3",
 					"id":          "ABC-123",
@@ -217,6 +218,7 @@ func TestCodecV03_Decode(t *testing.T) {
 		"full v0.3 structured": {
 			codec: amqp.CodecV03{},
 			msg: &amqp.Message{
+				ContentType: cloudevents.ApplicationCloudEventsJSON,
 				Body: toBytes(map[string]interface{}{
 					"specversion":     "0.3",
 					"datacontenttype": "application/json",

--- a/pkg/cloudevents/transport/amqp/transport.go
+++ b/pkg/cloudevents/transport/amqp/transport.go
@@ -38,6 +38,9 @@ type Transport struct {
 
 	// Receiver
 	Receiver transport.Receiver
+	// Converter is invoked if the incoming transport receives an undecodable
+	// message.
+	Converter transport.Converter
 }
 
 // New creates a new amqp transport.
@@ -130,6 +133,16 @@ func (t *Transport) Send(ctx context.Context, event cloudevents.Event) (*cloudev
 // SetReceiver implements Transport.SetReceiver
 func (t *Transport) SetReceiver(r transport.Receiver) {
 	t.Receiver = r
+}
+
+// SetConverter implements Transport.SetConverter
+func (t *Transport) SetConverter(c transport.Converter) {
+	t.Converter = c
+}
+
+// HasConverter implements Transport.HasConverter
+func (t *Transport) HasConverter() bool {
+	return t.Converter != nil
 }
 
 // StartReceiver implements Transport.StartReceiver

--- a/pkg/cloudevents/transport/amqp/transport.go
+++ b/pkg/cloudevents/transport/amqp/transport.go
@@ -13,6 +13,11 @@ import (
 // Transport adheres to transport.Transport.
 var _ transport.Transport = (*Transport)(nil)
 
+const (
+	// TransportName is the name of this transport.
+	TransportName = "AMQP"
+)
+
 // Transport acts as both a http client and a http handler.
 type Transport struct {
 	connOpts         []amqp.ConnOption

--- a/pkg/cloudevents/transport/codec.go
+++ b/pkg/cloudevents/transport/codec.go
@@ -1,10 +1,32 @@
 package transport
 
-import "github.com/cloudevents/sdk-go/pkg/cloudevents"
+import (
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+)
 
 // Codec is the interface for transport codecs to convert between transport
 // specific payloads and the Message interface.
 type Codec interface {
 	Encode(cloudevents.Event) (Message, error)
 	Decode(Message) (*cloudevents.Event, error)
+}
+
+// ErrMessageEncodingUnknown is an error produced when the encoding for an incoming
+// message can not be understood.
+type ErrMessageEncodingUnknown struct {
+	codec     string
+	transport string
+}
+
+// NewErrMessageEncodingUnknown makes a new ErrMessageEncodingUnknown.
+func NewErrMessageEncodingUnknown(transport string) *ErrMessageEncodingUnknown {
+	return &ErrMessageEncodingUnknown{
+		transport: transport,
+	}
+}
+
+// Error implements error.Error
+func (e *ErrMessageEncodingUnknown) Error() string {
+	return fmt.Sprintf("message encoding unknown for %s codec on %s transport", e.codec, e.transport)
 }

--- a/pkg/cloudevents/transport/codec.go
+++ b/pkg/cloudevents/transport/codec.go
@@ -20,8 +20,9 @@ type ErrMessageEncodingUnknown struct {
 }
 
 // NewErrMessageEncodingUnknown makes a new ErrMessageEncodingUnknown.
-func NewErrMessageEncodingUnknown(transport string) *ErrMessageEncodingUnknown {
+func NewErrMessageEncodingUnknown(codec, transport string) *ErrMessageEncodingUnknown {
 	return &ErrMessageEncodingUnknown{
+		codec:     codec,
 		transport: transport,
 	}
 }

--- a/pkg/cloudevents/transport/http/codec.go
+++ b/pkg/cloudevents/transport/http/codec.go
@@ -130,7 +130,7 @@ func (c *Codec) Decode(msg transport.Message) (*cloudevents.Event, error) {
 			return c.convertEvent(event), nil
 		}
 	default:
-		return nil, fmt.Errorf("unknown encoding")
+		return nil, transport.NewErrMessageEncodingUnknown("http")
 	}
 }
 

--- a/pkg/cloudevents/transport/http/codec.go
+++ b/pkg/cloudevents/transport/http/codec.go
@@ -130,7 +130,7 @@ func (c *Codec) Decode(msg transport.Message) (*cloudevents.Event, error) {
 			return c.convertEvent(event), nil
 		}
 	default:
-		return nil, transport.NewErrMessageEncodingUnknown("http")
+		return nil, transport.NewErrMessageEncodingUnknown("wrapper", TransportName)
 	}
 }
 

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -68,7 +68,7 @@ func (v CodecV01) obsDecode(msg transport.Message) (*cloudevents.Event, error) {
 	case StructuredV01:
 		return v.decodeStructured(msg)
 	default:
-		return nil, fmt.Errorf("unknown encoding")
+		return nil, transport.NewErrMessageEncodingUnknown("http")
 	}
 }
 

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -68,7 +68,7 @@ func (v CodecV01) obsDecode(msg transport.Message) (*cloudevents.Event, error) {
 	case StructuredV01:
 		return v.decodeStructured(msg)
 	default:
-		return nil, transport.NewErrMessageEncodingUnknown("http")
+		return nil, transport.NewErrMessageEncodingUnknown("v01", TransportName)
 	}
 }
 

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -68,7 +68,7 @@ func (v CodecV02) obsDecode(msg transport.Message) (*cloudevents.Event, error) {
 	case StructuredV02:
 		return v.decodeStructured(msg)
 	default:
-		return nil, fmt.Errorf("unknown encoding")
+		return nil, transport.NewErrMessageEncodingUnknown("v02", TransportName)
 	}
 }
 

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -73,7 +73,7 @@ func (v CodecV03) obsDecode(msg transport.Message) (*cloudevents.Event, error) {
 	case BatchedV03:
 		return nil, fmt.Errorf("not implemented")
 	default:
-		return nil, fmt.Errorf("unknown encoding")
+		return nil, transport.NewErrMessageEncodingUnknown("v03", TransportName)
 	}
 }
 

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -28,6 +28,9 @@ var _ transport.Transport = (*Transport)(nil)
 const (
 	// DefaultShutdownTimeout defines the default timeout given to the http.Server when calling Shutdown.
 	DefaultShutdownTimeout = time.Minute * 1
+
+	// TransportName is the name of this transport.
+	TransportName = "HTTP"
 )
 
 // Transport acts as both a http client and a http handler.

--- a/pkg/cloudevents/transport/nats/codec.go
+++ b/pkg/cloudevents/transport/nats/codec.go
@@ -49,6 +49,6 @@ func (c *Codec) Decode(msg transport.Message) (*cloudevents.Event, error) {
 		}
 		return c.v03.Decode(msg)
 	default:
-		return nil, fmt.Errorf("unknown encoding: %d", c.Encoding)
+		return nil, transport.NewErrMessageEncodingUnknown("wrapper", TransportName)
 	}
 }

--- a/pkg/cloudevents/transport/nats/codec_v02.go
+++ b/pkg/cloudevents/transport/nats/codec_v02.go
@@ -26,7 +26,12 @@ func (v CodecV02) Encode(e cloudevents.Event) (transport.Message, error) {
 
 func (v CodecV02) Decode(msg transport.Message) (*cloudevents.Event, error) {
 	// only structured is supported as of v0.2
-	return v.decodeStructured(msg)
+	switch v.inspectEncoding(msg) {
+	case StructuredV02:
+		return v.decodeStructured(msg)
+	default:
+		return nil, transport.NewErrMessageEncodingUnknown("v02", TransportName)
+	}
 }
 
 func (v CodecV02) encodeStructured(e cloudevents.Event) (transport.Message, error) {
@@ -42,7 +47,19 @@ func (v CodecV02) encodeStructured(e cloudevents.Event) (transport.Message, erro
 func (v CodecV02) decodeStructured(msg transport.Message) (*cloudevents.Event, error) {
 	m, ok := msg.(*Message)
 	if !ok {
-		return nil, fmt.Errorf("failed to convert transport.Message to http.Message")
+		return nil, fmt.Errorf("failed to convert transport.Message to nats.Message")
 	}
 	return codec.JsonDecodeV02(m.Body)
+}
+
+func (v CodecV02) inspectEncoding(msg transport.Message) Encoding {
+	version := msg.CloudEventsVersion()
+	if version != cloudevents.CloudEventsVersionV02 {
+		return Unknown
+	}
+	_, ok := msg.(*Message)
+	if !ok {
+		return Unknown
+	}
+	return StructuredV02
 }

--- a/pkg/cloudevents/transport/nats/transport.go
+++ b/pkg/cloudevents/transport/nats/transport.go
@@ -13,6 +13,11 @@ import (
 // Transport adheres to transport.Transport.
 var _ transport.Transport = (*Transport)(nil)
 
+const (
+	// TransportName is the name of this transport.
+	TransportName = "NATS"
+)
+
 // Transport acts as both a http client and a http handler.
 type Transport struct {
 	Encoding Encoding

--- a/pkg/cloudevents/transport/nats/transport.go
+++ b/pkg/cloudevents/transport/nats/transport.go
@@ -27,6 +27,9 @@ type Transport struct {
 	sub *nats.Subscription
 
 	Receiver transport.Receiver
+	// Converter is invoked if the incoming transport receives an undecodable
+	// message.
+	Converter transport.Converter
 
 	codec transport.Codec
 }
@@ -96,6 +99,16 @@ func (t *Transport) SetReceiver(r transport.Receiver) {
 	t.Receiver = r
 }
 
+// SetConverter implements Transport.SetConverter
+func (t *Transport) SetConverter(c transport.Converter) {
+	t.Converter = c
+}
+
+// HasConverter implements Transport.HasConverter
+func (t *Transport) HasConverter() bool {
+	return t.Converter != nil
+}
+
 // StartReceiver implements Transport.StartReceiver
 // NOTE: This is a blocking call.
 func (t *Transport) StartReceiver(ctx context.Context) error {
@@ -124,6 +137,10 @@ func (t *Transport) StartReceiver(ctx context.Context) error {
 			Body: m.Data,
 		}
 		event, err := t.codec.Decode(msg)
+		// If codec returns and error, try with the converter if it is set.
+		if err != nil && t.HasConverter() {
+			event, err = t.Converter.Convert(ctx, msg, err)
+		}
 		if err != nil {
 			logger.Errorw("failed to decode message", zap.Error(err)) // TODO: create an error channel to pass this up
 			return

--- a/pkg/cloudevents/transport/transport.go
+++ b/pkg/cloudevents/transport/transport.go
@@ -12,10 +12,24 @@ type Transport interface {
 
 	SetReceiver(Receiver)
 	StartReceiver(context.Context) error
+
+	// SetConverter sets the delegate to use for converting messages that have
+	// failed to be decoded from known codecs for this transport.
+	SetConverter(Converter)
+	// HasConverter is true when a non-nil converter has been set.
+	HasConverter() bool
 }
 
 // Receiver is an interface to define how a transport will invoke a listener
 // of incoming events.
 type Receiver interface {
 	Receive(context.Context, cloudevents.Event, *cloudevents.EventResponse) error
+}
+
+// Converter is an interface to define how a transport delegate to convert an
+// non-understood transport message from the internal codecs. Providing a
+// Converter allows incoming requests to be bridged to CloudEvents format if
+// they have not been sent as an event in CloudEvents format.
+type Converter interface {
+	Convert(context.Context, Message, error) (*cloudevents.Event, error)
 }

--- a/test/http/conversion.go
+++ b/test/http/conversion.go
@@ -1,0 +1,114 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
+	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+	"github.com/google/uuid"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Conversion Test:
+
+//         Data -> POST -> Wire Format -> Receive -> Error -> Convert -> Got
+// Given:   ^                                                            ^==Want
+// Data is a payload.
+
+type ConversionTest struct {
+	now       time.Time
+	data      interface{}
+	convertFn cloudevents.ConvertFn
+	asSent    *TapValidation
+	asRecv    *TapValidation
+	want      *cloudevents.Event
+}
+
+type ConversionTestCases map[string]ConversionTest
+
+func UnitTestConvert(ctx context.Context, m transport.Message, err error) (*cloudevents.Event, error) {
+	if msg, ok := m.(*cehttp.Message); ok {
+		tx := cloudevents.HTTPTransportContextFrom(ctx)
+
+		// Make a new event and convert the message payload.
+		event := cloudevents.NewEvent()
+		event.SetSource("github.com/cloudevents/test/http/conversion")
+		event.SetType(fmt.Sprintf("io.cloudevents.conversion.http.%s", strings.ToLower(tx.Method)))
+		event.SetID("321-CBA")
+		event.SetExtension(unitTestIDKey, msg.Header.Get(unitTestIDKey))
+		event.Data = msg.Body
+
+		return &event, nil
+	}
+	return nil, err
+}
+
+func ClientConversion(t *testing.T, tc ConversionTest, topts ...cehttp.Option) {
+	tap := NewTap()
+	server := httptest.NewServer(tap)
+	defer server.Close()
+
+	if len(topts) == 0 {
+		topts = append(topts, cloudevents.WithBinaryEncoding())
+	}
+	topts = append(topts, cloudevents.WithPort(0)) // random port
+	trans, err := cloudevents.NewHTTPTransport(
+		topts...,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tap.handler = trans
+
+	ce, err := cloudevents.NewClient(
+		trans,
+		cloudevents.WithEventDefaulter(AlwaysThen(tc.now)),
+		cloudevents.WithConverterFn(tc.convertFn),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testID := uuid.New().String()
+
+	recvCtx, recvCancel := context.WithCancel(context.Background())
+	go func() {
+		t.Log(ce.StartReceiver(recvCtx, func(got *cloudevents.Event) {
+			assertEventEquality(t, "got event", tc.want, got)
+		}))
+	}()
+
+	b, err := json.Marshal(tc.data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", server.URL, bytes.NewBuffer(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(unitTestIDKey, testID)
+	got, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = got
+
+	recvCancel()
+
+	if req, ok := tap.req[testID]; ok {
+		assertTappedEquality(t, "http request", tc.asSent, &req)
+	}
+
+	if resp, ok := tap.resp[testID]; ok {
+		assertTappedEquality(t, "http response", tc.asRecv, &resp)
+	}
+}

--- a/test/http/conversion_v02_test.go
+++ b/test/http/conversion_v02_test.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"github.com/cloudevents/sdk-go"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestClientConversion_v02(t *testing.T) {
+	now := time.Now()
+
+	testCases := ConversionTestCases{
+		"Conversion v0.2": {
+			now:       now,
+			convertFn: UnitTestConvert,
+			data:      map[string]string{"hello": "unittest"},
+			want: &cloudevents.Event{
+				Context: cloudevents.EventContextV02{
+					ID:     "321-CBA",
+					Type:   "io.cloudevents.conversion.http.post",
+					Source: *cloudevents.ParseURLRef("github.com/cloudevents/test/http/conversion"),
+				}.AsV02(),
+				Data: map[string]string{"unittest": "response"},
+			},
+			asSent: &TapValidation{
+				Method: "POST",
+				URI:    "/",
+				Header: map[string][]string{
+					"content-type": {"application/json"},
+				},
+				Body:          `{"hello":"unittest"}`,
+				ContentLength: 20,
+			},
+			asRecv: &TapValidation{
+				Header:        http.Header{},
+				Status:        "202 Accepted",
+				ContentLength: 0,
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			ClientConversion(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
There are cases when receiving cloudevents that the incoming message needs to be normalized into a cloudevents format to be consumed by downstream functions. This PR adds the ability to add a conversion function for unconvertible transport messages.

See the conversion test or the new sample code for an example.