### PR TITLE
Use Structured encoding for any contenttype containing application/json

### DIFF
--- a/pkg/cloudevents/content_type.go
+++ b/pkg/cloudevents/content_type.go
@@ -1,5 +1,7 @@
 package cloudevents
 
+import "regexp"
+
 const (
 	TextJSON                        = "text/json"
 	ApplicationJSON                 = "application/json"
@@ -32,4 +34,11 @@ func StringOfApplicationCloudEventsJSON() *string {
 func StringOfApplicationCloudEventsBatchJSON() *string {
 	a := ApplicationCloudEventsBatchJSON
 	return &a
+}
+
+// ContainsApplicationJSON checks if the passed contentType value is
+// either "application/json" or any media type with a structured +json suffix
+func ContainsApplicationJSON(contentType string) bool {
+	re := regexp.MustCompile("^(application\\/[a-z0-9.+-]*json[a-z0-9.+-]*)$")
+	return re.MatchString(contentType)
 }

--- a/pkg/cloudevents/transport/amqp/codec_v02.go
+++ b/pkg/cloudevents/transport/amqp/codec_v02.go
@@ -63,7 +63,7 @@ func (v CodecV02) inspectEncoding(msg transport.Message) Encoding {
 		return Unknown
 	}
 	contentType := m.ContentType
-	if contentType == cloudevents.ApplicationCloudEventsJSON {
+	if cloudevents.ContainsApplicationJSON(contentType) {
 		return StructuredV02
 	}
 	return BinaryV02

--- a/pkg/cloudevents/transport/amqp/codec_v03.go
+++ b/pkg/cloudevents/transport/amqp/codec_v03.go
@@ -63,7 +63,7 @@ func (v CodecV03) inspectEncoding(msg transport.Message) Encoding {
 		return Unknown
 	}
 	contentType := m.ContentType
-	if contentType == cloudevents.ApplicationCloudEventsJSON {
+	if cloudevents.ContainsApplicationJSON(contentType) {
 		return StructuredV03
 	}
 	return BinaryV03

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -237,7 +237,7 @@ func (v CodecV01) inspectEncoding(msg transport.Message) Encoding {
 		return Unknown
 	}
 	contentType := m.Header.Get("Content-Type")
-	if contentType == cloudevents.ApplicationCloudEventsJSON {
+	if cloudevents.ContainsApplicationJSON(contentType) {
 		return StructuredV01
 	}
 	return BinaryV01

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -269,7 +269,7 @@ func (v CodecV02) inspectEncoding(msg transport.Message) Encoding {
 		return Unknown
 	}
 	contentType := m.Header.Get("Content-Type")
-	if contentType == cloudevents.ApplicationCloudEventsJSON {
+	if cloudevents.ContainsApplicationJSON(contentType) {
 		return StructuredV02
 	}
 	return BinaryV02

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -294,11 +294,11 @@ func (v CodecV03) inspectEncoding(msg transport.Message) Encoding {
 		return Unknown
 	}
 	contentType := m.Header.Get("Content-Type")
-	if contentType == cloudevents.ApplicationCloudEventsJSON {
-		return StructuredV03
-	}
 	if contentType == cloudevents.ApplicationCloudEventsBatchJSON {
 		return BatchedV03
+	}
+	if cloudevents.ContainsApplicationJSON(contentType) {
+		return StructuredV03
 	}
 	return BinaryV03
 }


### PR DESCRIPTION
According to the specification (e.g. https://github.com/cloudevents/spec/blob/v0.2/json-format.md#31-special-handling-of-the-data-attribute for v0.2), if the `contenttype` value is `application/json` or any media type with a `structured +json` suffix, the data attribute value has to be translated into a JSON value.

This PR extends the matching of the `contentype` in this regard.