### PR TITLE
Issue #140: Add Message.ToRequest()/FromRequest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.2.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/fortytw2/leaktest v1.3.0 // indirect
+	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.2.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/fortytw2/leaktest v1.3.0 // indirect
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/pkg/cloudevents/transport/http/codec_test.go
+++ b/pkg/cloudevents/transport/http/codec_test.go
@@ -697,12 +697,11 @@ func TestCodecDecode(t *testing.T) {
 			// Round trip thru a http.Request
 			var req nethttp.Request
 			tc.msg.ToRequest(&req)
-			var gotm http.Message
-			err = gotm.FromRequest(&req)
+			gotm, err := http.NewMessage(req.Header, req.Body)
 			if err != nil {
 				t.Error(err)
 			}
-			if diff := cmp.Diff(*tc.msg, gotm, normalizeHeaders); diff != "" {
+			if diff := cmp.Diff(tc.msg, gotm, normalizeHeaders); diff != "" {
 				t.Errorf("unexpected message (-want, +got) = %v", diff)
 			}
 		})

--- a/pkg/cloudevents/transport/http/message.go
+++ b/pkg/cloudevents/transport/http/message.go
@@ -23,7 +23,7 @@ type Message struct {
 // Response is an http transport response.
 type Response struct {
 	StatusCode int
-	Message    Message
+	Message
 }
 
 // CloudEventsVersion inspects a message and tries to discover and return the
@@ -90,23 +90,54 @@ func readAllClose(r io.ReadCloser) ([]byte, error) {
 	return nil, nil
 }
 
-// FromRequest initializes a Message from a http.Request
-func (m *Message) FromRequest(r *http.Request) (err error) {
-	copyHeadersEnsure(r.Header, &m.Header)
-	m.Body, err = readAllClose(r.Body)
+// NewMessage creates a new message from the Header and Body of
+// an http.Request or http.Response
+func NewMessage(header http.Header, body io.ReadCloser) (*Message, error) {
+	var m Message
+	err := m.Init(header, body)
+	return &m, err
+}
+
+// NewResponse creates a new response from the Header and Body of
+// an http.Request or http.Response
+func NewResponse(header http.Header, body io.ReadCloser, statusCode int) (*Response, error) {
+	resp := Response{StatusCode: statusCode}
+	err := resp.Init(header, body)
+	return &resp, err
+}
+
+// Copy copies a new Body and Header into a message, replacing any previous data.
+func (m *Message) Init(header http.Header, body io.ReadCloser) error {
+	m.Header = make(http.Header, len(header))
+	copyHeadersEnsure(header, &m.Header)
+	var err error
+	m.Body, err = readAllClose(body)
 	return err
 }
 
-// ToRequest copies a message to a http.Request.
-// Replaces r.Body, r.ContentLength and r.Method.
-// Updates r.Headers.
-func (m *Message) ToRequest(r *http.Request) {
-	copyHeadersEnsure(m.Header, &r.Header)
+func (m *Message) copyOut(header *http.Header, body *io.ReadCloser) {
+	copyHeadersEnsure(m.Header, header)
+	*body = nil
 	if m.Body != nil {
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(m.Body))
-	} else {
-		r.Body = nil
+		copy := append([]byte(nil), m.Body...)
+		*body = ioutil.NopCloser(bytes.NewBuffer(copy))
 	}
-	r.ContentLength = int64(len(m.Body))
-	r.Method = http.MethodPost
+}
+
+// ToRequest updates a http.Request from a Message.
+// Replaces Body, ContentLength and Method, updates Headers.
+// Panic if req is nil
+func (m *Message) ToRequest(req *http.Request) {
+	m.copyOut(&req.Header, &req.Body)
+	req.ContentLength = int64(len(m.Body))
+	req.Method = http.MethodPost
+}
+
+// ToResponse updates a http.Response from a Response.
+// Replaces Body, updates Headers.
+// Panic if resp is nil
+func (m *Response) ToResponse(resp *http.Response) {
+	m.copyOut(&resp.Header, &resp.Body)
+	resp.ContentLength = int64(len(m.Body))
+	resp.StatusCode = m.StatusCode
 }

--- a/pkg/cloudevents/transport/http/message_test.go
+++ b/pkg/cloudevents/transport/http/message_test.go
@@ -1,0 +1,93 @@
+package http_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewMessage(t *testing.T) {
+	h := http.Header{"A": []string{"b"}, "X": []string{"y"}}
+	b := ioutil.NopCloser(bytes.NewBuffer([]byte("hello")))
+	m, err := cehttp.NewMessage(h, b)
+	if err != nil {
+		t.Error(err)
+	}
+	if s := cmp.Diff(h, m.Header); s != "" {
+		t.Error(s)
+	}
+	if s := cmp.Diff("hello", string(m.Body)); s != "" {
+		t.Error(s)
+	}
+	// Make sure the Message map is an independent copy
+	h.Set("a", "A")
+	if s := cmp.Diff(m.Header.Get("a"), "b"); s != "" {
+		t.Error(s)
+	}
+}
+
+func TestNewResponse(t *testing.T) {
+	h := http.Header{"A": []string{"b"}, "X": []string{"y"}}
+	b := ioutil.NopCloser(bytes.NewBuffer([]byte("hello")))
+	m, err := cehttp.NewResponse(h, b, 42)
+	if err != nil {
+		t.Error(err)
+	}
+	if s := cmp.Diff(42, m.StatusCode); s != "" {
+		if s := cmp.Diff(h, m.Header); s != "" {
+			t.Error(s)
+		}
+		if s := cmp.Diff("hello", string(m.Body)); s != "" {
+			t.Error(s)
+		}
+	}
+}
+
+func TestToRequest(t *testing.T) {
+	h := http.Header{"a": []string{"b"}, "x": []string{"y"}}
+	b := ioutil.NopCloser(bytes.NewBuffer([]byte("hello")))
+	m, err := cehttp.NewMessage(h, b)
+	var req http.Request
+	m.ToRequest(&req)
+	if s := cmp.Diff(m.Header, req.Header); s != "" {
+		t.Error(s)
+	}
+	data, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		t.Error(err)
+	}
+	if s := cmp.Diff("hello", string(data)); s != "" {
+		t.Error(s)
+	}
+	if s := cmp.Diff(len(data), int(req.ContentLength)); s != "" {
+		t.Error(s)
+	}
+	if s := cmp.Diff("POST", req.Method); s != "" {
+		t.Error(s)
+	}
+}
+
+func TestToResponse(t *testing.T) {
+	h := http.Header{"a": []string{"b"}, "x": []string{"y"}}
+	b := ioutil.NopCloser(bytes.NewBuffer([]byte("hello")))
+	m, err := cehttp.NewResponse(h, b, 42)
+	var resp http.Response
+	m.ToResponse(&resp)
+	if s := cmp.Diff(m.Header, resp.Header); s != "" {
+		t.Error(s)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error(err)
+	}
+	if s := cmp.Diff("hello", string(data)); s != "" {
+		t.Error(s)
+	}
+	if s := cmp.Diff(len(data), int(resp.ContentLength)); s != "" {
+		t.Error(s)
+	}
+}

--- a/pkg/cloudevents/transport/http/transport_test.go
+++ b/pkg/cloudevents/transport/http/transport_test.go
@@ -130,7 +130,6 @@ func TestStableConnectionsToSingleHost(t *testing.T) {
 	if newConnectionCount > uint64(concurrency*2) {
 		t.Errorf("too many new connections opened: expected %d, got %d", concurrency, newConnectionCount)
 	}
-	t.Log("sent ", sent)
 }
 
 func TestMiddleware(t *testing.T) {


### PR DESCRIPTION
For issue #140 

Related changes/fixes:

Re-use Message as part of Response so a response can also be treated
as a Message.

Added/used copyHeadersEnsure() to ensure headers are not dropped on the
floor if copied into a nil Header map in a zero-initialized
http.Request or Message.

Signed-off-by: Alan Conway <aconway@redhat.com>