### PR TITLE
Fix issues found by  golangci-lint

### DIFF
--- a/cmd/samples/amqp/receiver/main.go
+++ b/cmd/samples/amqp/receiver/main.go
@@ -33,11 +33,6 @@ func main() {
 	os.Exit(_main(os.Args[1:], env))
 }
 
-type Example struct {
-	Sequence int    `json:"id"`
-	Message  string `json:"message"`
-}
-
 func receive(ctx context.Context, event cloudevents.Event, resp *cloudevents.EventResponse) error {
 	fmt.Printf("Got CloudEvent,\n%+v\n", event)
 	fmt.Println("----------------------------")

--- a/cmd/samples/complex/sender/main.go
+++ b/cmd/samples/complex/sender/main.go
@@ -53,8 +53,6 @@ type Demo struct {
 
 	// Data
 	Message string
-
-	seq int
 }
 
 var seq int
@@ -96,11 +94,6 @@ func _main(args []string, env envConfig) int {
 	for _, contentType := range []string{"application/json", "application/xml"} {
 		// HTTP
 		for _, encoding := range []cloudeventshttp.Encoding{cloudeventshttp.Default, cloudeventshttp.BinaryV01, cloudeventshttp.StructuredV01, cloudeventshttp.BinaryV02, cloudeventshttp.StructuredV02, cloudeventshttp.BinaryV03, cloudeventshttp.StructuredV03} {
-
-			if err != nil {
-				log.Printf("failed to create client, %v", err)
-				return 1
-			}
 
 			t, err := cloudeventshttp.New(
 				cloudeventshttp.WithTarget(env.HTTPTarget),

--- a/cmd/samples/http/sleepy/main.go
+++ b/cmd/samples/http/sleepy/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -55,10 +55,6 @@ func _main(args []string, env envConfig) int {
 	if err != nil {
 		log.Printf("failed to create client, %v", err)
 		return 1
-	}
-
-	if err != nil {
-		log.Fatalf("failed to start receiver: %s", err.Error())
 	}
 
 	log.Printf("listening on :%d%s\n", env.Port, env.Path)

--- a/pkg/cloudevents/client/client_test.go
+++ b/pkg/cloudevents/client/client_test.go
@@ -459,9 +459,6 @@ func TestClientReceive(t *testing.T) {
 			},
 		},
 	}
-
-	type startFn func(events chan cloudevents.Event, opts ...client.Option) (context.Context, client.Client, error)
-
 	for n, tc := range testCases {
 		for _, path := range []string{"", "/", "/unittest/"} {
 			t.Run(n+" at path "+path, func(t *testing.T) {
@@ -598,12 +595,12 @@ func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(f.response.StatusCode)
 		var buf bytes.Buffer
 		if f.response.ContentLength > 0 {
-			buf.ReadFrom(f.response.Body)
-			w.Write(buf.Bytes())
+			_, _ = buf.ReadFrom(f.response.Body)
+			_, _ = w.Write(buf.Bytes())
 		}
 	} else {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(""))
+		_, _ = w.Write([]byte(""))
 	}
 }
 

--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -693,10 +693,10 @@ func FullEventContextV01(now types.Timestamp) *ce.EventContextV01 {
 		ContentType:      ce.StringOfApplicationJSON(),
 		Source:           *source,
 	}
-	eventContextV01.SetExtension(ce.SubjectKey, "topic")
-	eventContextV01.SetExtension(ce.DataContentEncodingKey, ce.Base64)
-	eventContextV01.SetExtension("test", "extended")
-	eventContextV01.SetExtension("another-test", 1)
+	_ = eventContextV01.SetExtension(ce.SubjectKey, "topic")
+	_ = eventContextV01.SetExtension(ce.DataContentEncodingKey, ce.Base64)
+	_ = eventContextV01.SetExtension("test", "extended")
+	_ = eventContextV01.SetExtension("another-test", 1)
 	return eventContextV01.AsV01()
 }
 
@@ -720,9 +720,9 @@ func FullEventContextV02(now types.Timestamp) *ce.EventContextV02 {
 		Source:      *source,
 		Extensions:  extensions,
 	}
-	eventContextV02.SetExtension(ce.SubjectKey, "topic")
-	eventContextV02.SetExtension(ce.DataContentEncodingKey, ce.Base64)
-	eventContextV02.SetExtension(ce.EventTypeVersionKey, "v1alpha1")
+	_ = eventContextV02.SetExtension(ce.SubjectKey, "topic")
+	_ = eventContextV02.SetExtension(ce.DataContentEncodingKey, ce.Base64)
+	_ = eventContextV02.SetExtension(ce.EventTypeVersionKey, "v1alpha1")
 	return eventContextV02.AsV02()
 }
 
@@ -743,8 +743,8 @@ func FullEventContextV03(now types.Timestamp) *ce.EventContextV03 {
 		Source:              *source,
 		Subject:             strptr("topic"),
 	}
-	eventContextV03.SetExtension("test", "extended")
-	eventContextV03.SetExtension("another-test", 1)
-	eventContextV03.SetExtension(ce.EventTypeVersionKey, "v1alpha1")
+	_ = eventContextV03.SetExtension("test", "extended")
+	_ = eventContextV03.SetExtension("another-test", 1)
+	_ = eventContextV03.SetExtension(ce.EventTypeVersionKey, "v1alpha1")
 	return eventContextV03.AsV03()
 }

--- a/pkg/cloudevents/eventcontext_v01.go
+++ b/pkg/cloudevents/eventcontext_v01.go
@@ -100,7 +100,7 @@ func (ec EventContextV01) AsV02() *EventContextV02 {
 
 	// eventTypeVersion was retired in v0.2, so put it in an extension.
 	if ec.EventTypeVersion != nil {
-		ret.SetExtension(EventTypeVersionKey, *ec.EventTypeVersion)
+		_ = ret.SetExtension(EventTypeVersionKey, *ec.EventTypeVersion)
 	}
 	if ec.Extensions != nil {
 		for k, v := range ec.Extensions {

--- a/pkg/cloudevents/eventcontext_v03.go
+++ b/pkg/cloudevents/eventcontext_v03.go
@@ -115,11 +115,11 @@ func (ec EventContextV03) AsV02() *EventContextV02 {
 	}
 	// Subject was introduced in 0.3, so put it in an extension for 0.2.
 	if ec.Subject != nil {
-		ret.SetExtension(SubjectKey, *ec.Subject)
+		_ = ret.SetExtension(SubjectKey, *ec.Subject)
 	}
 	// DataContentEncoding was introduced in 0.3, so put it in an extension for 0.2.
 	if ec.DataContentEncoding != nil {
-		ret.SetExtension(DataContentEncodingKey, *ec.DataContentEncoding)
+		_ = ret.SetExtension(DataContentEncodingKey, *ec.DataContentEncoding)
 	}
 	if ec.Extensions != nil {
 		for k, v := range ec.Extensions {

--- a/pkg/cloudevents/observability/observer.go
+++ b/pkg/cloudevents/observability/observer.go
@@ -27,12 +27,11 @@ type Reporter interface {
 }
 
 type reporter struct {
-	ctx     context.Context
-	span    *trace.Span
-	on      Observable
-	start   time.Time
-	measure stats.Measure
-	once    sync.Once
+	ctx   context.Context
+	span  *trace.Span
+	on    Observable
+	start time.Time
+	once  sync.Once
 }
 
 // All tags used for Latency measurements.

--- a/pkg/cloudevents/transport/http/message_test.go
+++ b/pkg/cloudevents/transport/http/message_test.go
@@ -51,6 +51,9 @@ func TestToRequest(t *testing.T) {
 	h := http.Header{"a": []string{"b"}, "x": []string{"y"}}
 	b := ioutil.NopCloser(bytes.NewBuffer([]byte("hello")))
 	m, err := cehttp.NewMessage(h, b)
+	if err != nil {
+		t.Error(err)
+	}
 	var req http.Request
 	m.ToRequest(&req)
 	if s := cmp.Diff(m.Header, req.Header); s != "" {
@@ -75,6 +78,9 @@ func TestToResponse(t *testing.T) {
 	h := http.Header{"a": []string{"b"}, "x": []string{"y"}}
 	b := ioutil.NopCloser(bytes.NewBuffer([]byte("hello")))
 	m, err := cehttp.NewResponse(h, b, 42)
+	if err != nil {
+		t.Error(err)
+	}
 	var resp http.Response
 	m.ToResponse(&resp)
 	if s := cmp.Diff(m.Header, resp.Header); s != "" {

--- a/pkg/cloudevents/transport/http/options_test.go
+++ b/pkg/cloudevents/transport/http/options_test.go
@@ -357,7 +357,7 @@ func TestWithPort(t *testing.T) {
 // Force a transport to close its server/listener by cancelling StartReceiver
 func forceClose(tr *Transport) {
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { tr.StartReceiver(ctx) }()
+	go func() { _ = tr.StartReceiver(ctx) }()
 	cancel()
 }
 

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -285,7 +285,7 @@ func (t *Transport) StartReceiver(ctx context.Context) error {
 	defer t.reMu.Unlock()
 
 	if t.LongPollReq != nil {
-		go t.longPollStart(ctx)
+		go func() { _ = t.longPollStart(ctx) }()
 	}
 
 	if t.Handler == nil {
@@ -536,7 +536,7 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		logger.Errorw("failed to handle request", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error":"Invalid request"}`))
+		_, _ = w.Write([]byte(`{"error":"Invalid request"}`))
 		r.Error()
 		return
 	}
@@ -565,7 +565,7 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		logger.Warnw("error returned from invokeReceiver", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))
 		r.Error()
 		return
 	}

--- a/pkg/cloudevents/transport/http/transport_test.go
+++ b/pkg/cloudevents/transport/http/transport_test.go
@@ -31,7 +31,7 @@ func startTestServer(handler http.Handler) (*http.Server, error) {
 		Addr:    listener.Addr().String(),
 		Handler: handler,
 	}
-	go server.Serve(listener)
+	go func() { _ = server.Serve(listener) }()
 	return server, nil
 }
 
@@ -135,7 +135,6 @@ func TestStableConnectionsToSingleHost(t *testing.T) {
 func TestMiddleware(t *testing.T) {
 	testCases := map[string]struct {
 		middleware []string
-		want       string
 	}{
 		"none": {},
 		"one": {
@@ -194,7 +193,7 @@ func makeRequestToServer(t *testing.T, tr *cehttp.Transport, responseText string
 	// Start the server.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go tr.StartReceiver(ctx)
+	go func() { _ = tr.StartReceiver(ctx) }()
 
 	// Give some time for the receiver to start. One second was chosen arbitrarily.
 	time.Sleep(time.Second)

--- a/pkg/cloudevents/transport/nats/codec_test.go
+++ b/pkg/cloudevents/transport/nats/codec_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func strptr(s string) *string {
-	return &s
-}
-
 func TestCodecEncode(t *testing.T) {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}

--- a/pkg/cloudevents/types/urlref.go
+++ b/pkg/cloudevents/types/urlref.go
@@ -51,8 +51,7 @@ func (u *URLRef) UnmarshalJSON(b []byte) error {
 // MarshalXML implements a custom xml marshal method used when this type is
 // marshaled using xml.Marshal.
 func (u URLRef) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	v := fmt.Sprintf("%s", u.String())
-	return e.EncodeElement(v, start)
+	return e.EncodeElement(u.String(), start)
 }
 
 // UnmarshalXML implements the xml unmarshal method used when this type is

--- a/test/http/loopback.go
+++ b/test/http/loopback.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"

--- a/test/http/tap_handler.go
+++ b/test/http/tap_handler.go
@@ -87,7 +87,7 @@ func (t *tapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func copyHeaders(from http.Header) http.Header {
 	to := http.Header{}
-	if from == nil || to == nil {
+	if from == nil {
 		return to
 	}
 	for header, values := range from {

--- a/test/http/validation.go
+++ b/test/http/validation.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -27,7 +27,7 @@ func assertEventEquality(t *testing.T, ctx string, expected, actual *cloudevents
 	if expected == nil || actual == nil {
 		return
 	}
-	data := make(map[string]string, 0)
+	data := make(map[string]string)
 	err := actual.DataAs(&data)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
golangcli-lint combines multiple linters, including go vet. It has
good default settings - not much noise, I recommend it. Fixes are to:

- Remove dead/unreachable code
- Fix missing error checks:
  I mostly marked them intentional with `_ = foo()`, I think this is right
  One was in in a `defer` statement I fixed by returning it.
- Minor simplifications (from 'gosimple' linter)