### PR TITLE
Changes to keep `go vet` happy.

### DIFF
--- a/pkg/cloudevents/event_marshal_test.go
+++ b/pkg/cloudevents/event_marshal_test.go
@@ -489,19 +489,6 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
-func TestUnmarshal_nilEvent(t *testing.T) {
-	wantErr := "json: Unmarshal(nil)"
-
-	err := json.Unmarshal(toBytes("{}"), nil)
-
-	if err != nil {
-		if diff := cmp.Diff(wantErr, err.Error()); diff != "" {
-			t.Errorf("unexpected error (-want, +got) = %v", diff)
-		}
-		return
-	}
-}
-
 func toBytes(body interface{}) []byte {
 	b, err := json.Marshal(body)
 	if err != nil {

--- a/pkg/cloudevents/transport/amqp/codec_test.go
+++ b/pkg/cloudevents/transport/amqp/codec_test.go
@@ -371,7 +371,7 @@ func TestCodecRoundTrip(t *testing.T) {
 					got.Data = data
 				}
 
-				if tc.wantErr != nil || err != nil {
+				if tc.wantErr != nil {
 					if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 						t.Errorf("unexpected error (-want, +got) = %v", diff)
 					}
@@ -509,7 +509,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 					got.Data = data
 				}
 
-				if tc.wantErr != nil || err != nil {
+				if tc.wantErr != nil {
 					if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 						t.Errorf("unexpected error (-want, +got) = %v", diff)
 					}

--- a/pkg/cloudevents/transport/http/codec_test.go
+++ b/pkg/cloudevents/transport/http/codec_test.go
@@ -819,7 +819,7 @@ func TestCodecRoundTrip(t *testing.T) {
 					got.Data = data
 				}
 
-				if tc.wantErr != nil || err != nil {
+				if tc.wantErr != nil {
 					if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 						t.Errorf("unexpected error (-want, +got) = %v", diff)
 					}
@@ -961,7 +961,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 						got.Data = data
 					}
 
-					if tc.wantErr != nil || err != nil {
+					if tc.wantErr != nil {
 						if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 							t.Errorf("unexpected error (-want, +got) = %v", diff)
 						}

--- a/pkg/cloudevents/transport/http/message.go
+++ b/pkg/cloudevents/transport/http/message.go
@@ -35,7 +35,10 @@ func (m Message) CloudEventsVersion() string {
 	if m.Header != nil {
 		// Try headers first.
 		// v0.1, cased from the spec
-		if v := m.Header["CE-CloudEventsVersion"]; len(v) == 1 {
+		// Note: don't pass literal string direct to m.Header[] so that
+		// go vet won't complain about non-canonical case.
+		name := "CE-CloudEventsVersion"
+		if v := m.Header[name]; len(v) == 1 {
 			return v[0]
 		}
 		// v0.2, canonical casing
@@ -44,11 +47,13 @@ func (m Message) CloudEventsVersion() string {
 		}
 
 		// v0.2, cased from the spec
-		if v := m.Header["ce-specversion"]; len(v) == 1 {
+		name = "ce-specversion"
+		if v := m.Header[name]; len(v) == 1 {
 			return v[0]
 		}
 		// v0.2, canonical casing
-		if ver := m.Header.Get("ce-specversion"); ver != "" {
+		name = "ce-specversion"
+		if ver := m.Header.Get(name); ver != "" {
 			return ver
 		}
 	}

--- a/pkg/cloudevents/transport/nats/codec_test.go
+++ b/pkg/cloudevents/transport/nats/codec_test.go
@@ -237,7 +237,7 @@ func TestCodecRoundTrip(t *testing.T) {
 					got.Data = data
 				}
 
-				if tc.wantErr != nil || err != nil {
+				if tc.wantErr != nil {
 					if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 						t.Errorf("unexpected error (-want, +got) = %v", diff)
 					}
@@ -375,7 +375,7 @@ func TestCodecAsMiddleware(t *testing.T) {
 					got.Data = data
 				}
 
-				if tc.wantErr != nil || err != nil {
+				if tc.wantErr != nil {
 					if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 						t.Errorf("unexpected error (-want, +got) = %v", diff)
 					}

--- a/test/http/loopback.go
+++ b/test/http/loopback.go
@@ -151,3 +151,7 @@ func printTap(t *testing.T, tap *tapHandler, testID string) {
 		}
 	}
 }
+
+// Don't consider printTap as dead code even if not currently in use.
+// We want to keep it for possible future debugging.
+var _ = printTap


### PR DESCRIPTION
Various minor syntactic changes, no change in behavior.

Removed TestUnmarshal_nilEvent(t *testing.T)
Calling json.Unmarshal with a nil argument is always an error as
per the json package doc. `go vet` even reports it statically.
There is no need to verify that here, it's not special to cloudevents.

Signed-off-by: Alan Conway <aconway@redhat.com>