### PR TITLE
Fix segfault if ce-specversion header missing

### DIFF
--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -546,13 +546,11 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		Body:   body,
 	})
 	if err != nil {
-		isErr := true
+		isFatal := true
 		if txerr, ok := err.(*transport.ErrTransportMessageConversion); ok {
-			if !txerr.IsFatal() {
-				isErr = false
-			}
+			isFatal = txerr.IsFatal()
 		}
-		if isErr {
+		if isFatal || event == nil {
 			logger.Errorw("failed to convert http message to event", zap.Error(err))
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))


### PR DESCRIPTION
If a HTTP request does not contain the `ce-specversion` header then the
process of converting the request to an event returns a `nil`
event and a non-fatal error value. Unfortunately, in this situation,
the code continued to process the request resulting in an attempt to
de-reference the `nil` event value.

Fix by adding an additional condition to the error handling. Now
conversions that yield a non-fatal error must also return a non-nil
event, otherwise a HTTP 400 (Bad Request) status is returned.