### PR TITLE
Add a method to disable tracing.

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/context"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 )
@@ -97,6 +98,10 @@ var (
 	// Event Creation
 
 	NewEvent = cloudevents.New
+
+	// Tracing
+
+	EnableTracing = observability.EnableTracing
 
 	// Context
 

--- a/cmd/samples/stats/main.go
+++ b/cmd/samples/stats/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/json"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/xml"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
@@ -35,7 +36,7 @@ func main() {
 	}
 
 	// Uncomment the following to see that tracing can be disabled.
-	// observability.EnableTracing(false)
+	observability.EnableTracing(false)
 
 	go mainSender()
 	go mainMetrics()

--- a/cmd/samples/stats/main.go
+++ b/cmd/samples/stats/main.go
@@ -8,20 +8,22 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/json"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/xml"
 	"go.opencensus.io/examples/exporter"
 	"go.opencensus.io/trace"
 	"go.opencensus.io/zpages"
 
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/json"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/xml"
+
 	"contrib.go.opencensus.io/exporter/prometheus"
+	"go.opencensus.io/stats/view"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	cecontext "github.com/cloudevents/sdk-go/pkg/cloudevents/context"
 	transporthttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"go.opencensus.io/stats/view"
 )
 
 func main() {
@@ -31,6 +33,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
+
+	// Uncomment the following to see that tracing can be disabled.
+	// observability.EnableTracing(false)
 
 	go mainSender()
 	go mainMetrics()

--- a/pkg/cloudevents/observability/observer.go
+++ b/pkg/cloudevents/observability/observer.go
@@ -39,10 +39,23 @@ func LatencyTags() []tag.Key {
 	return []tag.Key{KeyMethod, KeyResult}
 }
 
+var (
+	tracingEnabled = true
+)
+
+// EnableTracing allows control over if tracing is enabled for the sdk.
+// Default is true. This applies to all of the `github.com/cloudevents/sdk-go/...` package.
+func EnableTracing(enabled bool) {
+	tracingEnabled = enabled
+}
+
 // NewReporter creates and returns a reporter wrapping the provided Observable,
 // and injects a trace span into the context.
 func NewReporter(ctx context.Context, on Observable) (context.Context, Reporter) {
-	ctx, span := trace.StartSpan(ctx, on.TraceName())
+	var span *trace.Span
+	if tracingEnabled {
+		ctx, span = trace.StartSpan(ctx, on.TraceName())
+	}
 	r := &reporter{
 		ctx:   ctx,
 		on:    on,
@@ -64,7 +77,9 @@ func (r *reporter) tagMethod() {
 func (r *reporter) record() {
 	ms := float64(time.Since(r.start) / time.Millisecond)
 	stats.Record(r.ctx, r.on.LatencyMs().M(ms))
-	r.span.End()
+	if r.span != nil {
+		r.span.End()
+	}
 }
 
 // Error records the result as an error.

--- a/pkg/cloudevents/observability/observer.go
+++ b/pkg/cloudevents/observability/observer.go
@@ -40,11 +40,14 @@ func LatencyTags() []tag.Key {
 }
 
 var (
-	tracingEnabled = true
+	// Tracing is disabled by default. It is very useful for profiling an
+	// application.
+	tracingEnabled = false
 )
 
 // EnableTracing allows control over if tracing is enabled for the sdk.
-// Default is true. This applies to all of the `github.com/cloudevents/sdk-go/...` package.
+// Default is false. This applies to all of the
+// `github.com/cloudevents/sdk-go/...` package.
 func EnableTracing(enabled bool) {
 	tracingEnabled = enabled
 }


### PR DESCRIPTION
For applications that want to use tracing to do network level traces and not profile traces, the sdk pushes too much data. 

Fixes #168 

cc: @Harwayne 