### PR TITLE
Propagate pubsub subscriber errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.2.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/fortytw2/leaktest v1.3.0 // indirect
+	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.2.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/fortytw2/leaktest v1.3.0 // indirect
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/pkg/cloudevents/transport/pubsub/transport.go
+++ b/pkg/cloudevents/transport/pubsub/transport.go
@@ -263,6 +263,7 @@ func (t *Transport) StartReceiver(ctx context.Context) error {
 	}
 
 	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	n := len(t.subscriptions)
 
 	// Make the channels for quit and errors.
@@ -286,6 +287,7 @@ func (t *Transport) StartReceiver(ctx context.Context) error {
 		var err error
 		select {
 		case <-ctx.Done(): // Block for parent context to finish.
+			success--
 		case err = <-errc: // Collect errors
 		case <-quit:
 		}


### PR DESCRIPTION
Found a blocking issue on pubsub transport if a subscriber had an error. The subscriber would never be able to signal up to the parent that it was ready because the Receive method would block until the parent context was finished.

Fixed.