### PR TITLE
use []byte and not string for base64 json key.

### DIFF
--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -11,7 +11,7 @@ import (
 type Event struct {
 	Context     EventContext
 	Data        interface{}
-	DataBase64  string // TODO this field is new and not used yet.
+	DataBase64  []byte
 	DataEncoded bool
 }
 

--- a/pkg/cloudevents/event_marshal.go
+++ b/pkg/cloudevents/event_marshal.go
@@ -96,7 +96,7 @@ func JsonEncode(e Event) ([]byte, error) {
 	}
 	var data []byte
 	isBase64 := e.Context.DeprecatedGetDataContentEncoding() == Base64
-	if e.DataBase64 != "" {
+	if e.DataBase64 != nil {
 		isBase64 = true
 		var err error
 		data, err = json.Marshal(e.DataBase64)
@@ -285,9 +285,9 @@ func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error 
 	}
 	delete(raw, "data")
 
-	var dataBase64 string
+	var dataBase64 []byte
 	if d, ok := raw["data_base64"]; ok {
-		var tmp string
+		var tmp []byte
 		if err := json.Unmarshal(d, &tmp); err != nil {
 			return err
 		}

--- a/pkg/cloudevents/transport/http/codec_v1_test.go
+++ b/pkg/cloudevents/transport/http/codec_v1_test.go
@@ -217,7 +217,7 @@ func TestCodecV1_Encode(t *testing.T) {
 						"test": "extended",
 					},
 				}.AsV1(),
-				DataBase64:  "eyJoZWxsbyI6IndvcmxkIn0=",
+				DataBase64:  []byte(`{"hello":"world"}`),
 				DataEncoded: true,
 			},
 			want: &http.Message{
@@ -443,7 +443,7 @@ func TestCodecV1_Decode(t *testing.T) {
 						"test": "extended",
 					},
 				}.AsV1(),
-				DataBase64: "eyJoZWxsbyI6IndvcmxkIn0=",
+				DataBase64: []byte(`{"hello":"world"}`),
 			},
 		},
 		"simple v1.0 binary with short header": {


### PR DESCRIPTION
Related to https://github.com/cloudevents/sdk-go/issues/195

Leverage the native base64 encoding that the golang json lib uses.