### PR TITLE
validate port to be in the valid port range.

### DIFF
--- a/pkg/cloudevents/transport/http/options.go
+++ b/pkg/cloudevents/transport/http/options.go
@@ -178,7 +178,7 @@ func WithPort(port int) Option {
 		if t == nil {
 			return fmt.Errorf("http port option can not set nil transport")
 		}
-		if port < 0 {
+		if port < 0 || port > 65535 {
 			return fmt.Errorf("http port option was given an invalid port: %d", port)
 		}
 		if err := checkListen(t, "http port option"); err != nil {

--- a/pkg/cloudevents/transport/http/options_test.go
+++ b/pkg/cloudevents/transport/http/options_test.go
@@ -319,10 +319,15 @@ func TestWithPort(t *testing.T) {
 				Port: intptr(8181),
 			},
 		},
-		"invalid port": {
+		"invalid port, low": {
 			t:       &Transport{},
 			port:    -1,
 			wantErr: `http port option was given an invalid port: -1`,
+		},
+		"invalid port, high": {
+			t:       &Transport{},
+			port:    65536,
+			wantErr: `http port option was given an invalid port: 65536`,
 		},
 		"nil transport": {
 			wantErr: `http port option can not set nil transport`,

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -623,6 +623,9 @@ func (t *Transport) listen() (net.Addr, error) {
 		port := 8080
 		if t.Port != nil {
 			port = *t.Port
+			if port < 0 || port > 65535 {
+				return nil, fmt.Errorf("invalid port %d", port)
+			}
 		}
 		var err error
 		if t.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", port)); err != nil {


### PR DESCRIPTION
validate port to be in the valid port range.

fixes https://github.com/cloudevents/sdk-go/issues/48