### PR TITLE
CloudEvents 1.0 only  allows attributes to be a-z0-9

### DIFF
--- a/pkg/cloudevents/event_marshal.go
+++ b/pkg/cloudevents/event_marshal.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 )
@@ -210,6 +211,7 @@ func (e *Event) JsonDecodeV02(body []byte, raw map[string]json.RawMessage) error
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
 		for k, v := range raw {
+			k = strings.ToLower(k)
 			extensions[k] = v
 		}
 		ec.Extensions = extensions
@@ -250,6 +252,7 @@ func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
 		for k, v := range raw {
+			k = strings.ToLower(k)
 			extensions[k] = v
 		}
 		ec.Extensions = extensions
@@ -298,6 +301,7 @@ func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error 
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
 		for k, v := range raw {
+			k = strings.ToLower(k)
 			var tmp string
 			if err := json.Unmarshal(v, &tmp); err != nil {
 				return err
@@ -341,6 +345,7 @@ func marshalEvent(event interface{}, extensions map[string]interface{}) (map[str
 	}
 
 	for k, v := range extensions {
+		k = strings.ToLower(k)
 		vb, err := json.Marshal(v)
 		if err != nil {
 			return nil, err

--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -458,7 +458,7 @@ Context Attributes,
   schemaURL: http://example.com/schema
   contentType: application/json
 Extensions,
-  another-test: 1
+  anothertest: 1
   datacontentencoding: base64
   subject: topic
   test: extended
@@ -484,9 +484,9 @@ Context Attributes,
   schemaurl: http://example.com/schema
   contenttype: application/json
 Extensions,
-  another-test: 1
+  anothertest: 1
   datacontentencoding: base64
-  eventTypeVersion: v1alpha1
+  eventtypeversion: v1alpha1
   subject: topic
   test: extended
 Data,
@@ -513,8 +513,8 @@ Context Attributes,
   datacontenttype: application/json
   datacontentencoding: base64
 Extensions,
-  another-test: 1
-  eventTypeVersion: v1alpha1
+  anothertest: 1
+  eventtypeversion: v1alpha1
   test: extended
 Data,
   {
@@ -563,13 +563,13 @@ func TestExtensionAs(t *testing.T) {
 			extension: "test",
 			want:      "extended",
 		},
-		"full v01, another-test extension invalid type": {
+		"full v01, anothertest extension invalid type": {
 			event: ce.Event{
 				Context: FullEventContextV01(now),
 			},
-			extension:    "another-test",
+			extension:    "anothertest",
 			wantError:    true,
-			wantErrorMsg: `invalid type for extension "another-test"`,
+			wantErrorMsg: `invalid type for extension "anothertest"`,
 		},
 		"min v02, no extension": {
 			event: ce.Event{
@@ -586,13 +586,13 @@ func TestExtensionAs(t *testing.T) {
 			extension: "test",
 			want:      "extended",
 		},
-		"full v02, another-test extension invalid type": {
+		"full v02, anothertest extension invalid type": {
 			event: ce.Event{
 				Context: FullEventContextV02(now),
 			},
-			extension:    "another-test",
+			extension:    "anothertest",
 			wantError:    true,
-			wantErrorMsg: `invalid type for extension "another-test"`,
+			wantErrorMsg: `invalid type for extension "anothertest"`,
 		},
 		"min v03, no extension": {
 			event: ce.Event{
@@ -609,13 +609,13 @@ func TestExtensionAs(t *testing.T) {
 			extension: "test",
 			want:      "extended",
 		},
-		"full v03, another-test extension invalid type": {
+		"full v03, anothertest extension invalid type": {
 			event: ce.Event{
 				Context: FullEventContextV03(now),
 			},
-			extension:    "another-test",
+			extension:    "anothertest",
 			wantError:    true,
-			wantErrorMsg: `invalid type for extension "another-test"`,
+			wantErrorMsg: `invalid type for extension "anothertest"`,
 		},
 	}
 	for n, tc := range testCases {
@@ -658,11 +658,11 @@ func TestExtensions(t *testing.T) {
 			extension: "test",
 			want:      "extended",
 		},
-		"full v01, another-test extension invalid type": {
+		"full v01, anothertest extension invalid type": {
 			event: ce.Event{
 				Context: FullEventContextV01(now),
 			},
-			extension:    "another-test",
+			extension:    "anothertest",
 			wantError:    true,
 			wantErrorMsg: "cannot convert int32 to String",
 		},
@@ -673,11 +673,11 @@ func TestExtensions(t *testing.T) {
 			extension: "test",
 			want:      "extended",
 		},
-		"full v02, another-test extension invalid type": {
+		"full v02, anothertest extension invalid type": {
 			event: ce.Event{
 				Context: FullEventContextV02(now),
 			},
-			extension:    "another-test",
+			extension:    "anothertest",
 			wantError:    true,
 			wantErrorMsg: "cannot convert int32 to String",
 		},
@@ -688,11 +688,11 @@ func TestExtensions(t *testing.T) {
 			extension: "test",
 			want:      "extended",
 		},
-		"full v03, another-test extension invalid type": {
+		"full v03, anothertest extension invalid type": {
 			event: ce.Event{
 				Context: FullEventContextV03(now),
 			},
-			extension:    "another-test",
+			extension:    "anothertest",
 			wantError:    true,
 			wantErrorMsg: "cannot convert int32 to String",
 		},
@@ -777,7 +777,7 @@ func FullEventContextV01(now types.Timestamp) *ce.EventContextV01 {
 	_ = eventContextV01.SetExtension(ce.SubjectKey, "topic")
 	_ = eventContextV01.SetExtension(ce.DataContentEncodingKey, ce.Base64)
 	_ = eventContextV01.SetExtension("test", "extended")
-	_ = eventContextV01.SetExtension("another-test", 1)
+	_ = eventContextV01.SetExtension("anothertest", 1)
 	return eventContextV01.AsV01()
 }
 
@@ -790,7 +790,7 @@ func FullEventContextV02(now types.Timestamp) *ce.EventContextV02 {
 
 	extensions := make(map[string]interface{})
 	extensions["test"] = "extended"
-	extensions["another-test"] = 1
+	extensions["anothertest"] = 1
 
 	eventContextV02 := ce.EventContextV02{
 		ID:          "ABC-123",
@@ -825,7 +825,7 @@ func FullEventContextV03(now types.Timestamp) *ce.EventContextV03 {
 		Subject:             strptr("topic"),
 	}
 	_ = eventContextV03.SetExtension("test", "extended")
-	_ = eventContextV03.SetExtension("another-test", 1)
+	_ = eventContextV03.SetExtension("anothertest", 1)
 	_ = eventContextV03.SetExtension(ce.EventTypeVersionKey, "v1alpha1")
 	return eventContextV03.AsV03()
 }

--- a/pkg/cloudevents/eventcontext_v03.go
+++ b/pkg/cloudevents/eventcontext_v03.go
@@ -145,16 +145,16 @@ func (ec EventContextV03) AsV1() *EventContextV1 {
 		Type:        ec.Type,
 
 		DataContentType: ec.DataContentType,
-		// DataContentEncoding: ec.DataContentEncoding, TODO: move this to extensions.
-		Source:     types.URIRef{URL: ec.Source.URL},
-		Subject:    ec.Subject,
-		Extensions: make(map[string]interface{}),
+		Source:          types.URIRef{URL: ec.Source.URL},
+		Subject:         ec.Subject,
+		Extensions:      make(map[string]interface{}),
 	}
 	if ec.SchemaURL != nil {
 		ret.DataSchema = &types.URI{URL: ec.SchemaURL.URL}
 	}
 	if ec.Extensions != nil {
 		for k, v := range ec.Extensions {
+			k = strings.ToLower(k)
 			ret.Extensions[k] = fmt.Sprintf("%v", v) // TODO: This is wrong. Follow up with what should be done.
 		}
 	}

--- a/pkg/cloudevents/eventcontext_v1.go
+++ b/pkg/cloudevents/eventcontext_v1.go
@@ -1,6 +1,7 @@
 package cloudevents
 
 import (
+	"errors"
 	"fmt"
 	"mime"
 	"sort"
@@ -56,6 +57,7 @@ var _ EventContext = (*EventContextV1)(nil)
 
 // ExtensionAs implements EventContext.ExtensionAs
 func (ec EventContextV1) ExtensionAs(name string, obj interface{}) error {
+	name = strings.ToLower(name)
 	value, ok := ec.Extensions[name]
 	if !ok {
 		return fmt.Errorf("extension %q does not exist", name)
@@ -72,6 +74,11 @@ func (ec EventContextV1) ExtensionAs(name string, obj interface{}) error {
 
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
 func (ec *EventContextV1) SetExtension(name string, value interface{}) error {
+	if !IsAlphaNumericLowercaseLetters(name) {
+		return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set")
+	}
+
+	name = strings.ToLower(name)
 	if ec.Extensions == nil {
 		ec.Extensions = make(map[string]interface{})
 	}
@@ -125,6 +132,7 @@ func (ec EventContextV1) AsV03() *EventContextV03 {
 	// TODO: DeprecatedDataContentEncoding needs to be moved to extensions.
 	if ec.Extensions != nil {
 		for k, v := range ec.Extensions {
+			k = strings.ToLower(k)
 			ret.Extensions[k] = v
 		}
 	}

--- a/pkg/cloudevents/extensions.go
+++ b/pkg/cloudevents/extensions.go
@@ -1,6 +1,9 @@
 package cloudevents
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 const (
 	// DataContentEncodingKey is the key to DeprecatedDataContentEncoding for versions that do not support data content encoding
@@ -8,7 +11,7 @@ const (
 	DataContentEncodingKey = "datacontentencoding"
 
 	// EventTypeVersionKey is the key to EventTypeVersion for versions that do not support event type version directly.
-	EventTypeVersionKey = "eventTypeVersion"
+	EventTypeVersionKey = "eventtypeversion"
 
 	// SubjectKey is the key to Subject for versions that do not support subject directly.
 	SubjectKey = "subject"
@@ -23,3 +26,5 @@ func caseInsensitiveSearch(key string, space map[string]interface{}) (interface{
 	}
 	return nil, false
 }
+
+var IsAlphaNumericLowercaseLetters = regexp.MustCompile(`^[a-z0-9]+$`).MatchString

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -134,6 +134,7 @@ func (v CodecV03) toHeaders(ec *cloudevents.EventContextV03) (http.Header, error
 	}
 
 	for k, v := range ec.Extensions {
+		k = strings.ToLower(k)
 		// Per spec, map-valued extensions are converted to a list of headers as:
 		// CE-attrib-key
 		switch v.(type) {
@@ -244,6 +245,7 @@ func (v CodecV03) fromHeaders(h http.Header) (cloudevents.EventContextV03, error
 
 	extensions := make(map[string]interface{})
 	for k, v := range h {
+		k = strings.ToLower(k)
 		if len(k) > len("ce-") && strings.EqualFold(k[:len("ce-")], "ce-") {
 			ak := strings.ToLower(k[len("ce-"):])
 			if i := strings.Index(ak, "-"); i > 0 {

--- a/pkg/cloudevents/transport/http/codec_v1.go
+++ b/pkg/cloudevents/transport/http/codec_v1.go
@@ -132,6 +132,7 @@ func (v CodecV1) toHeaders(ec *cloudevents.EventContextV1) (http.Header, error) 
 	//}
 
 	for k, v := range ec.Extensions {
+		k = strings.ToLower(k)
 		// Per spec, extensions are strings and converted to a list of headers as:
 		// ce-key: value
 		val, err := types.ValueOf(v)
@@ -214,6 +215,7 @@ func (v CodecV1) fromHeaders(h http.Header) (cloudevents.EventContextV1, error) 
 
 	extensions := make(map[string]interface{})
 	for k := range h {
+		k = strings.ToLower(k)
 		if len(k) > len("ce-") && strings.EqualFold(k[:len("ce-")], "ce-") {
 			ak := strings.ToLower(k[len("ce-"):])
 			extensions[ak] = h.Get(k)


### PR DESCRIPTION
CloudEvents 1.0 only  allows attributes to be a-z0-9

Fixes: https://github.com/cloudevents/sdk-go/issues/150
Fixes: https://github.com/cloudevents/sdk-go/issues/212

Signed-off-by: Scott Nichols <nicholss@google.com>