### PR TITLE
Fixes the propagation of DataContentEncoding for 1.0 and adding testing.

### DIFF
--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -758,6 +758,17 @@ func MinEventContextV03() *ce.EventContextV03 {
 	}.AsV03()
 }
 
+func MinEventContextV1() *ce.EventContextV1 {
+	sourceUrl, _ := url.Parse("http://example.com/source")
+	source := &types.URIRef{URL: *sourceUrl}
+
+	return ce.EventContextV1{
+		Type:   "com.example.simple",
+		Source: *source,
+		ID:     "ABC-123",
+	}.AsV1()
+}
+
 func FullEventContextV01(now types.Timestamp) *ce.EventContextV01 {
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
@@ -777,7 +788,7 @@ func FullEventContextV01(now types.Timestamp) *ce.EventContextV01 {
 	_ = eventContextV01.SetExtension(ce.SubjectKey, "topic")
 	_ = eventContextV01.SetExtension(ce.DataContentEncodingKey, ce.Base64)
 	_ = eventContextV01.SetExtension("test", "extended")
-	_ = eventContextV01.SetExtension("anothertest", 1)
+	_ = eventContextV01.SetExtension("anothertest", int32(1))
 	return eventContextV01.AsV01()
 }
 
@@ -790,7 +801,7 @@ func FullEventContextV02(now types.Timestamp) *ce.EventContextV02 {
 
 	extensions := make(map[string]interface{})
 	extensions["test"] = "extended"
-	extensions["anothertest"] = 1
+	extensions["anothertest"] = int32(1)
 
 	eventContextV02 := ce.EventContextV02{
 		ID:          "ABC-123",
@@ -825,7 +836,29 @@ func FullEventContextV03(now types.Timestamp) *ce.EventContextV03 {
 		Subject:             strptr("topic"),
 	}
 	_ = eventContextV03.SetExtension("test", "extended")
-	_ = eventContextV03.SetExtension("anothertest", 1)
+	_ = eventContextV03.SetExtension("anothertest", int32(1))
 	_ = eventContextV03.SetExtension(ce.EventTypeVersionKey, "v1alpha1")
 	return eventContextV03.AsV03()
+}
+
+func FullEventContextV1(now types.Timestamp) *ce.EventContextV1 {
+	sourceUrl, _ := url.Parse("http://example.com/source")
+	source := &types.URIRef{URL: *sourceUrl}
+
+	schemaUrl, _ := url.Parse("http://example.com/schema")
+	schema := &types.URI{URL: *schemaUrl}
+
+	eventContextV1 := ce.EventContextV1{
+		ID:              "ABC-123",
+		Time:            &now,
+		Type:            "com.example.simple",
+		DataSchema:      schema,
+		DataContentType: ce.StringOfApplicationJSON(),
+		Source:          *source,
+		Subject:         strptr("topic"),
+	}
+	_ = eventContextV1.SetExtension("test", "extended")
+	_ = eventContextV1.SetExtension("anothertest", 1)
+	_ = eventContextV1.SetExtension(ce.EventTypeVersionKey, "v1alpha1")
+	return eventContextV1.AsV1()
 }

--- a/pkg/cloudevents/eventcontext_test.go
+++ b/pkg/cloudevents/eventcontext_test.go
@@ -60,6 +60,18 @@ func TestContextAsV01(t *testing.T) {
 			},
 			want: FullEventContextV01(now),
 		},
+		"min v1 -> v01": {
+			event: ce.Event{
+				Context: MinEventContextV1(),
+			},
+			want: MinEventContextV01(),
+		},
+		"full v1 -> v01": {
+			event: ce.Event{
+				Context: FullEventContextV1(now),
+			},
+			want: FullEventContextV01(now),
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
@@ -124,6 +136,19 @@ func TestContextAsV02(t *testing.T) {
 			},
 			want: FullEventContextV02(now),
 		},
+
+		"min v1 -> v02": {
+			event: ce.Event{
+				Context: MinEventContextV1(),
+			},
+			want: MinEventContextV02(),
+		},
+		"full v1 -> v02": {
+			event: ce.Event{
+				Context: FullEventContextV1(now),
+			},
+			want: FullEventContextV02(now),
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
@@ -185,6 +210,18 @@ func TestContextAsV03(t *testing.T) {
 		"full v03, no conversion": {
 			event: ce.Event{
 				Context: FullEventContextV03(now),
+			},
+			want: FullEventContextV03(now),
+		},
+		"min v1 -> v03": {
+			event: ce.Event{
+				Context: MinEventContextV1(),
+			},
+			want: MinEventContextV03(),
+		},
+		"full v1 -> v03": {
+			event: ce.Event{
+				Context: FullEventContextV1(now),
 			},
 			want: FullEventContextV03(now),
 		},

--- a/pkg/cloudevents/eventcontext_test.go
+++ b/pkg/cloudevents/eventcontext_test.go
@@ -94,7 +94,7 @@ func TestContextAsV02(t *testing.T) {
 			},
 			want: MinEventContextV02(),
 		},
-		"full v01 -> v2": {
+		"full v01 -> v02": {
 			event: ce.Event{
 				Context: FullEventContextV01(now),
 			},
@@ -146,7 +146,7 @@ func TestContextAsV03(t *testing.T) {
 	}{
 		"empty, no conversion": {
 			event: ce.Event{
-				Context: &ce.EventContextV02{},
+				Context: &ce.EventContextV03{},
 			},
 			want: &ce.EventContextV03{
 				SpecVersion: "0.3",
@@ -158,7 +158,7 @@ func TestContextAsV03(t *testing.T) {
 			},
 			want: MinEventContextV03(),
 		},
-		"full v01 -> v3": {
+		"full v01 -> v03": {
 			event: ce.Event{
 				Context: FullEventContextV01(now),
 			},
@@ -193,6 +193,82 @@ func TestContextAsV03(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 
 			got := tc.event.Context.AsV03()
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestContextAsV1(t *testing.T) {
+	now := types.Timestamp{Time: time.Now()}
+
+	testCases := map[string]struct {
+		event ce.Event
+		want  *ce.EventContextV1
+	}{
+		"empty, no conversion": {
+			event: ce.Event{
+				Context: &ce.EventContextV1{},
+			},
+			want: &ce.EventContextV1{
+				SpecVersion: "1.0",
+			},
+		},
+		"min v01 -> v1": {
+			event: ce.Event{
+				Context: MinEventContextV01(),
+			},
+			want: MinEventContextV1(),
+		},
+		"full v01 -> v1": {
+			event: ce.Event{
+				Context: FullEventContextV01(now),
+			},
+			want: FullEventContextV1(now),
+		},
+		"min v02 -> v1": {
+			event: ce.Event{
+				Context: MinEventContextV02(),
+			},
+			want: MinEventContextV1(),
+		},
+		"full v02 -> v1": {
+			event: ce.Event{
+				Context: FullEventContextV02(now),
+			},
+			want: FullEventContextV1(now),
+		},
+		"min v03 -> v1": {
+			event: ce.Event{
+				Context: MinEventContextV03(),
+			},
+			want: MinEventContextV1(),
+		},
+		"full v03 -> v1": {
+			event: ce.Event{
+				Context: FullEventContextV03(now),
+			},
+			want: FullEventContextV1(now),
+		},
+		"min v1, no conversion": {
+			event: ce.Event{
+				Context: MinEventContextV1(),
+			},
+			want: MinEventContextV1(),
+		},
+		"full v1, no conversion": {
+			event: ce.Event{
+				Context: FullEventContextV1(now),
+			},
+			want: FullEventContextV1(now),
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+
+			got := tc.event.Context.AsV1()
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected (-want, +got) = %v", diff)

--- a/pkg/cloudevents/eventcontext_v03.go
+++ b/pkg/cloudevents/eventcontext_v03.go
@@ -143,11 +143,10 @@ func (ec EventContextV03) AsV03() *EventContextV03 {
 // AsV04 implements EventContextConverter.AsV04
 func (ec EventContextV03) AsV1() *EventContextV1 {
 	ret := EventContextV1{
-		SpecVersion: CloudEventsVersionV1,
-		ID:          ec.ID,
-		Time:        ec.Time,
-		Type:        ec.Type,
-
+		SpecVersion:     CloudEventsVersionV1,
+		ID:              ec.ID,
+		Time:            ec.Time,
+		Type:            ec.Type,
 		DataContentType: ec.DataContentType,
 		Source:          types.URIRef{URL: ec.Source.URL},
 		Subject:         ec.Subject,
@@ -156,6 +155,12 @@ func (ec EventContextV03) AsV1() *EventContextV1 {
 	if ec.SchemaURL != nil {
 		ret.DataSchema = &types.URI{URL: ec.SchemaURL.URL}
 	}
+
+	// DataContentEncoding was removed in 1.0, so put it in an extension for 1.0.
+	if ec.DataContentEncoding != nil {
+		_ = ret.SetExtension(DataContentEncodingKey, *ec.DataContentEncoding)
+	}
+
 	if ec.Extensions != nil {
 		for k, v := range ec.Extensions {
 			k = strings.ToLower(k)

--- a/pkg/cloudevents/eventcontext_v03.go
+++ b/pkg/cloudevents/eventcontext_v03.go
@@ -83,7 +83,11 @@ func (ec *EventContextV03) SetExtension(name string, value interface{}) error {
 	if value == nil {
 		delete(ec.Extensions, name)
 	} else {
-		ec.Extensions[name] = value
+		v, err := types.ValueOf(value)
+		if err == nil {
+			ec.Extensions[name] = v.Interface()
+		}
+		return err
 	}
 	return nil
 }
@@ -155,7 +159,7 @@ func (ec EventContextV03) AsV1() *EventContextV1 {
 	if ec.Extensions != nil {
 		for k, v := range ec.Extensions {
 			k = strings.ToLower(k)
-			ret.Extensions[k] = fmt.Sprintf("%v", v) // TODO: This is wrong. Follow up with what should be done.
+			ret.Extensions[k] = v
 		}
 	}
 	if len(ret.Extensions) == 0 {

--- a/pkg/cloudevents/eventcontext_v1.go
+++ b/pkg/cloudevents/eventcontext_v1.go
@@ -119,10 +119,9 @@ func (ec EventContextV1) AsV03() *EventContextV03 {
 		Time:            ec.Time,
 		Type:            ec.Type,
 		DataContentType: ec.DataContentType,
-		//DeprecatedDataContentEncoding: ec.DeprecatedDataContentEncoding, // TODO fix up DeprecatedDataContentEncoding
-		Source:     types.URLRef{URL: ec.Source.URL},
-		Subject:    ec.Subject,
-		Extensions: make(map[string]interface{}),
+		Source:          types.URLRef{URL: ec.Source.URL},
+		Subject:         ec.Subject,
+		Extensions:      make(map[string]interface{}),
 	}
 
 	if ec.DataSchema != nil {
@@ -133,6 +132,14 @@ func (ec EventContextV1) AsV03() *EventContextV03 {
 	if ec.Extensions != nil {
 		for k, v := range ec.Extensions {
 			k = strings.ToLower(k)
+			// DeprecatedDataContentEncoding was introduced in 0.3, removed in 1.0
+			if strings.EqualFold(k, DataContentEncodingKey) {
+				etv, ok := v.(string)
+				if ok && etv != "" {
+					ret.DataContentEncoding = &etv
+				}
+				continue
+			}
 			ret.Extensions[k] = v
 		}
 	}

--- a/pkg/cloudevents/transport/http/codec_v1.go
+++ b/pkg/cloudevents/transport/http/codec_v1.go
@@ -126,10 +126,6 @@ func (v CodecV1) toHeaders(ec *cloudevents.EventContextV1) (http.Header, error) 
 	} else {
 		h.Set("Content-Type", cloudevents.ApplicationJSON)
 	}
-	// TODO: fix data content encoding for new v1.0 format.
-	//if ec.DataContentEncoding != nil {
-	//	h.Set("ce-datacontentencoding", *ec.DataContentEncoding)
-	//}
 
 	for k, v := range ec.Extensions {
 		k = strings.ToLower(k)


### PR DESCRIPTION
Fixes the propagation of DataContentEncoding for 1.0 and adding testing.

Fixes https://github.com/cloudevents/sdk-go/issues/195

