### PR TITLE
New value conversion API (replace type Value)

### DIFF
--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -700,10 +700,7 @@ func TestExtensions(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got string
-			v, err := types.ValueOf(tc.event.Context.GetExtensions()[tc.extension])
-			if err == nil {
-				got, err = v.ToString()
-			}
+			got, err := types.ToString(tc.event.Context.GetExtensions()[tc.extension])
 			if tc.wantError {
 				if err == nil {
 					t.Errorf("expected error %q, got nil", tc.wantErrorMsg)

--- a/pkg/cloudevents/eventcontext_v1.go
+++ b/pkg/cloudevents/eventcontext_v1.go
@@ -86,9 +86,9 @@ func (ec *EventContextV1) SetExtension(name string, value interface{}) error {
 		delete(ec.Extensions, name)
 		return nil
 	} else {
-		v, err := types.ValueOf(value)
+		v, err := types.Validate(value) // Ensure it's a legal CE attribute value
 		if err == nil {
-			ec.Extensions[name] = v.Interface()
+			ec.Extensions[name] = v
 		}
 		return err
 	}

--- a/pkg/cloudevents/transport/http/codec_v1.go
+++ b/pkg/cloudevents/transport/http/codec_v1.go
@@ -135,11 +135,11 @@ func (v CodecV1) toHeaders(ec *cloudevents.EventContextV1) (http.Header, error) 
 		k = strings.ToLower(k)
 		// Per spec, extensions are strings and converted to a list of headers as:
 		// ce-key: value
-		val, err := types.ValueOf(v)
+		cstr, err := types.Format(v)
 		if err != nil {
 			return h, err
 		}
-		h.Set("ce-"+k, val.String())
+		h.Set("ce-"+k, cstr)
 	}
 
 	return h, nil

--- a/pkg/cloudevents/types/doc.go
+++ b/pkg/cloudevents/types/doc.go
@@ -17,16 +17,24 @@ has a corresponding native Go type and a canonical string encoding.
  +----------------+----------------+-----------------------------------+
  |Binary          |[]byte          |[]byte                             |
  +----------------+----------------+-----------------------------------+
- |URI-Reference   |url.URL         |url.URL, types.URIRef, types.URI   |
+ |URI-Reference   |*url.URL        |url.URL, types.URIRef, types.URI   |
  +----------------+----------------+-----------------------------------+
- |URI             |url.URL         |url.URL, types.URIRef, types.URI   |
+ |URI             |*url.URL        |url.URL, types.URIRef, types.URI   |
  |                |                |Must be an absolute URI.           |
  +----------------+----------------+-----------------------------------+
  |Timestamp       |time.Time       |time.Time, types.Timestamp         |
  +----------------+----------------+-----------------------------------+
 
-NOTE: CloudEvents has overlapping types 'URI' and 'URI-Reference'. Both are
-represented by the native url.URL
+The native types used to represent CloudEvents types are:
+
+    bool, int32, string, []byte, *url.URL, time.Time
+
+This package provides Parse... and Format... functions to convert to/from
+canonical strings. Use standard url.URL.String() and url.Parse() for URL
+values, the canonical string for a string is the string itself.
+
+It provides To... functions to convert any extension attribute value, in native
+or string form, to the expected type.
 
 */
 package types

--- a/pkg/cloudevents/types/value.go
+++ b/pkg/cloudevents/types/value.go
@@ -10,201 +10,212 @@ import (
 	"time"
 )
 
-// StringOf returns the canonical string encoding of x.
-// x can be any type that is convertible to a CloudEvents attribute.
-func StringOf(x interface{}) (string, error) {
-	v, err := ValueOf(x)
-	return v.String(), err
+// FormatBool returns canonical string format: "true" or "false"
+func FormatBool(v bool) string { return strconv.FormatBool(v) }
+
+// FormatInteger returns canonical string format: decimal notation.
+func FormatInteger(v int32) string { return strconv.Itoa(int(v)) }
+
+// FormatBinary returns canonical string format: standard base64 encoding
+func FormatBinary(v []byte) string { return base64.StdEncoding.EncodeToString(v) }
+
+// FormatTime returns canonical string format: RFC3339 with nanoseconds
+func FormatTime(v time.Time) string { return v.UTC().Format(time.RFC3339Nano) }
+
+// ParseBool parse canonical string format: "true" or "false"
+func ParseBool(v string) (bool, error) { return strconv.ParseBool(v) }
+
+// ParseInteger parse canonical string format: decimal notation.
+func ParseInteger(v string) (int32, error) {
+	// Accept floating-point but truncate to int32 as per CE spec.
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return 0, err
+	}
+	if f > math.MaxInt32 || f < math.MinInt32 {
+		return 0, rangeErr(v)
+	}
+	return int32(f), nil
 }
 
-// Value holds the value of a CloudEvents attribute.
-//
-// Value can hold the native type or the string representation.
-// The To...() methods extract the value as a native type.
-type Value struct{ v interface{} }
+// ParseBinary parse canonical string format: standard base64 encoding
+func ParseBinary(v string) ([]byte, error) { return base64.StdEncoding.DecodeString(v) }
 
-// Interface returns the value as an interface{}.
-//
-// The return value may be nil if the Value is empty, otherwise it will always
-// be one of the native types: bool, int32, string, []byte, url.URL, time.Time.
-func (v Value) Interface() interface{} { return v.v }
+// ParseTime parse canonical string format: RFC3339 with nanoseconds
+func ParseTime(v string) (time.Time, error) { return time.Parse(time.RFC3339Nano, v) }
 
-// ValueOf validates the type and range of x and wraps it in a Value.
-// x can be any type that is convertible to a CloudEvents attribute.
-func ValueOf(x interface{}) (Value, error) {
-	switch x := x.(type) {
+// Format returns the canonical string format of v, where v can be
+// any type that is convertible to a CloudEvents type.
+func Format(v interface{}) (string, error) {
+	v, err := Validate(v)
+	switch v := v.(type) {
+	case nil:
+		return "", err
+	case bool:
+		return FormatBool(v), nil
+	case int32:
+		return FormatInteger(v), nil
+	case string:
+		return v, nil
+	case []byte:
+		return FormatBinary(v), nil
+	case url.URL:
+		return v.String(), nil
+	case *url.URL:
+		// url.URL is often passed by pointer so allow both
+		return v.String(), nil
+	case time.Time:
+		return FormatTime(v), nil
+	default:
+		return "", fmt.Errorf("%T is not a CloudEvents type", v)
+	}
+}
 
-	case Value: // Already a Value, no wrapping
-		return x, nil
-
-	case bool, int32, string, []byte, url.URL, time.Time:
-		return Value{x}, nil // Already a preferred type, no conversion needed.
+// Validate v is a valid CloudEvents attribute value, convert it to one of:
+//     bool, int32, string, []byte, *url.URL, time.Time
+func Validate(v interface{}) (interface{}, error) {
+	switch v := v.(type) {
+	case bool, int32, string, []byte, time.Time:
+		return v, nil // Already a CloudEvents type, no validation needed.
 
 	case uint, uintptr, uint8, uint16, uint32, uint64:
-		u := reflect.ValueOf(x).Uint()
+		u := reflect.ValueOf(v).Uint()
 		if u > math.MaxInt32 {
-			return Value{}, rangeErr(x)
+			return nil, rangeErr(v)
 		}
-		return Value{int32(u)}, nil
+		return int32(u), nil
 	case int, int8, int16, int64:
-		i := reflect.ValueOf(x).Int()
+		i := reflect.ValueOf(v).Int()
 		if i > math.MaxInt32 || i < math.MinInt32 {
-			return Value{}, rangeErr(x)
+			return nil, rangeErr(v)
 		}
-		return Value{int32(i)}, nil
+		return int32(i), nil
 	case float32, float64:
-		f := reflect.ValueOf(x).Float()
+		f := reflect.ValueOf(v).Float()
 		if f > math.MaxInt32 || f < math.MinInt32 {
-			return Value{}, rangeErr(x)
+			return nil, rangeErr(v)
 		}
-		return Value{int32(f)}, nil
+		return int32(f), nil
 
+	case *url.URL:
+		if v == nil {
+			break
+		}
+		return v, nil
+	case url.URL:
+		return &v, nil
 	case URIRef:
-		return Value{x.URL}, nil
+		return &v.URL, nil
 	case URI:
-		return Value{x.URL}, nil
+		return &v.URL, nil
 	case URLRef:
-		return Value{x.URL}, nil
+		return &v.URL, nil
 
 	case Timestamp:
-		return Value{x.Time}, nil
-
-	case *url.URL, *URIRef, *URLRef, *URI, *Timestamp, *time.Time:
-		rx := reflect.ValueOf(x)
-		if rx.IsNil() {
-			return Value{}, valueErr("", x)
-		}
-		return ValueOf(rx.Elem().Interface())
-
-	default:
-		return Value{}, fmt.Errorf("%T is not a CloudEvents type", x)
+		return v.Time, nil
 	}
+	rx := reflect.ValueOf(v)
+	if rx.Kind() == reflect.Ptr && !rx.IsNil() {
+		// Allow pointers-to convertible types
+		return Validate(rx.Elem().Interface())
+	}
+	return nil, fmt.Errorf("invalid CloudEvents value: %#v", v)
 }
 
-func ValueOfBool(x bool) Value           { return Value{x} }
-func ValueOfInteger(x int32) Value       { return Value{x} }
-func ValueOfString(x string) Value       { return Value{x} }
-func ValueOfBinary(x []byte) Value       { return Value{x} }
-func ValueOfURIRef(x URIRef) Value       { return Value{x} }
-func ValueOfTimestamp(x time.Time) Value { return Value{x} }
-
-// String returns the canonical string encoded representation of the value.
-// Use ToString() to extract the value only if it is of type string.
-func (v Value) String() string {
-	switch x := v.Interface().(type) {
+// ToBool accepts a bool value or canonical "true"/"false" string.
+func ToBool(v interface{}) (bool, error) {
+	v, err := Validate(v)
+	switch v := v.(type) {
 	case bool:
-		return strconv.FormatBool(x)
+		return v, nil
+	case string:
+		return ParseBool(v)
+	default:
+		return false, convertErr("Bool", v, err)
+	}
+}
+
+// ToInteger accepts any numeric value in int32 range, or canonical string.
+func ToInteger(v interface{}) (int32, error) {
+	v, err := Validate(v)
+	switch v := v.(type) {
 	case int32:
-		return strconv.Itoa(int(x))
+		return v, nil
 	case string:
-		return x
+		return ParseInteger(v)
+	default:
+		return 0, convertErr("Integer", v, err)
+	}
+}
+
+// ToString returns a string value unaltered.
+//
+// This function does not perform canonical string encoding, use one of the
+// Format functions for that.
+func ToString(v interface{}) (string, error) {
+	v, err := Validate(v)
+	switch v := v.(type) {
+	case string:
+		return v, nil
+	default:
+		return "", convertErr("String", v, err)
+	}
+}
+
+// ToBinary returns a []byte value, decoding from base64 string if necessary.
+func ToBinary(v interface{}) ([]byte, error) {
+	v, err := Validate(v)
+	switch v := v.(type) {
 	case []byte:
-		return base64.StdEncoding.EncodeToString(x)
-	case url.URL:
-		return x.String()
-	case time.Time:
-		return x.UTC().Format(time.RFC3339Nano)
-	case nil:
-		return "<nil>"
+		return v, nil
+	case string:
+		return base64.StdEncoding.DecodeString(v)
 	default:
-		return fmt.Sprintf("<unknown:%T>", v.v)
+		return nil, convertErr("Binary", v, err)
 	}
 }
 
-// ToBool returns a bool value, decoding from string if necessary.
-func (v Value) ToBool() (bool, error) {
-	switch x := v.v.(type) {
-	case bool:
-		return x, nil
+// ToURL returns a *url.URL value, parsing from string if necessary.
+func ToURL(v interface{}) (*url.URL, error) {
+	v, err := Validate(v)
+	switch v := v.(type) {
+	case *url.URL:
+		return v, nil
 	case string:
-		return strconv.ParseBool(x)
-	default:
-		return false, typeErr("Bool", x)
-	}
-}
-
-// ToInteger returns an int32 value, decoding from string if necessary.
-func (v Value) ToInteger() (int32, error) {
-	switch x := v.v.(type) {
-	case int32:
-		return x, nil
-	case string:
-		// Accept floating-point but truncate to int32 as per CE spec.
-		f, err := strconv.ParseFloat(x, 64)
-		if f > math.MaxInt32 || f < math.MinInt32 {
-			return 0, rangeErr(x)
-		}
-		return int32(f), err
-	default:
-		return 0, typeErr("Integer", x)
-	}
-}
-
-// ToString returns a string value. It does NOT encode non-string, use String() for that.
-func (v Value) ToString() (string, error) {
-	switch x := v.v.(type) {
-	case string:
-		return x, nil
-	default:
-		return "", typeErr("String", x)
-	}
-}
-
-// ToBinary returns a []byte value, decoding from string if necessary.
-func (v Value) ToBinary() ([]byte, error) {
-	switch x := v.v.(type) {
-	case []byte:
-		return x, nil
-	case string:
-		return base64.StdEncoding.DecodeString(x)
-	default:
-		return nil, typeErr("Binary", x)
-	}
-}
-
-// ToURIRef returns a url.URL value, decoding from string if necessary.
-func (v Value) ToURIRef() (url.URL, error) {
-	switch x := v.v.(type) {
-	case url.URL:
-		return x, nil
-	case string:
-		u, err := url.Parse(x)
+		u, err := url.Parse(v)
 		if err != nil {
-			return url.URL{}, err
+			return nil, err
 		}
-		return *u, nil
+		return u, nil
 	default:
-		return url.URL{}, typeErr("URI-Reference", x)
+		return nil, convertErr("URL", v, err)
 	}
 }
 
-// ToTimestamp returns a Timestamp value, decoding from string if necessary.
-func (v Value) ToTimestamp() (time.Time, error) {
-	switch x := v.v.(type) {
+// ToTime returns a time.Time value, parsing from RFC3339 string if necessary.
+func ToTime(v interface{}) (time.Time, error) {
+	v, err := Validate(v)
+	switch v := v.(type) {
 	case time.Time:
-		return x, nil
+		return v, nil
 	case string:
-		ts, err := time.Parse(time.RFC3339Nano, x)
+		ts, err := time.Parse(time.RFC3339Nano, v)
 		if err != nil {
 			return time.Time{}, err
 		}
 		return ts, nil
 	default:
-		return time.Time{}, typeErr("Timestamp", x)
+		return time.Time{}, convertErr("Time", v, err)
 	}
+}
+
+func convertErr(name string, v interface{}, err error) error {
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("cannot convert %T to %s", v, name)
 }
 
 func rangeErr(v interface{}) error {
 	return fmt.Errorf("%v is out of range for Integer", v)
-}
-
-func typeErr(name string, v interface{}) error {
-	return fmt.Errorf("cannot convert %T to %s", v, name)
-}
-
-func valueErr(name string, v interface{}) error {
-	if name == "" {
-		return fmt.Errorf("invalid CloudEvents value: %#v", v)
-	}
-	return fmt.Errorf("invalid CloudEvents %s: %#v", name, v)
 }


### PR DESCRIPTION
CloudEvents types are represented by these 6 native Go types (or canonical strings):

    bool, int32, string, []byte, *url.URL, time.Time

Simple canonical string conversions following package strconv conventions:

    FormatX(X) string ParseX(string)(X, error)

Where X is one of Bool, Integer, String, Binary, URL, Time:

Flex conversion: accepts any native value or canonical string and converts to native:

    ToX(interface{}) (X, error)

Flex format: accepts any native value and produces the canonical string:

    Format(interface{}) string

Validation: validates and converts any convertible value into one of the preferred native types. This is for internal use and for bindings with their own type-mapping rules; the binding's type switch only need consider the 6 types above, and can ignore conversions.

    Validate(interface{}) (interface{}, error)

Signed-off-by: Alan Conway <aconway@redhat.com>