### PR TITLE
Package binding/spec: specversion metadata for generic mappings.

### DIFF
--- a/pkg/binding/doc.go
+++ b/pkg/binding/doc.go
@@ -1,35 +1,36 @@
 /*
 
-Package binding provides interfaces for transport bindings.
-Binding implementations are under ../bindings.
+Package binding defines interfaces for protocol bindings.
 
-Intermediary applications that forward events between different
-transport bindings may also need to use these intefaces. Normal
-clients can use the cloudevents/client API.
+NOTE: Most applications that emit or consume events can use the client
+package. This package is for implementing new protocol bindings and
+intermediaries; processes that forward events between protocols, rather than
+emitting or consuming events themselves.
 
-A transport binding implements Message, Sender, Receiver interfaces.
-An intermediary uses those interfaces to transfer event messages.  A
-binding should also provide functions to convert between
-cloudevents.Event and the binding's native message types. There are no
-interfaces as the native message type will vary by binding.
+Protocol Bindings
 
-A Message is an abstract container for a cloudevents.Event.
+A protocol binding implements at least Message, Sender and Receiver, and usually
+Encoder.
 
-A Receiver returns Message implementations based on its native message
-format. A Sender must be able to encode and send any Message, but may
-provide optimized handling for StructMessage, or for its own native
-Message implementations.
+Receiver: receives protocol messages and wraps them to implement the Message interface.
 
-Transports that support reliable delivery can implement and use
-Message.Finish() and ExactlyOnceMessage to forward acknowledgement
-between sender and receiver for QoS level 0, 1 or 2. The effective QoS
-of a sender/receiver pair will be the lower of the two.
+Message: converts to protocol-neutral cloudevents.Event or structured event
+data. It also provides methods to manage acknowledgment for reliable
+delivery across bindings.
 
-FIXME(alanconway) add a generic encoder interface or function signature.  The
-Sender implicitly uses an encoder, so it's not needed for normal use.  It is
-useful for testing and for users with inside knowledge of the implementation,
-they may want to use the encoder but send messages by some other means than the
-Sender.
+Sender: converts arbitrary Message implementations to a protocol-specific form
+and sends them.
+
+Message and ExactlyOnceMessage provide methods to allow acknowledgments to
+propagate when a reliable messages is forwarded from a Receiver to a Sender.
+QoS 0 (unreliable), 1 (at-least-once) and 2 (exactly-once) are supported.
+
+Intermediaries
+
+Intermediaries can forward Messages from a Receiver to a Sender without
+knowledge of the underlying protocols. The Message interface allows structured
+messages to be forwarded without decoding and re-encoding. It also allows any
+Message to be fully decoded and examined if needed.
 
 */
 package binding

--- a/pkg/binding/doc.go
+++ b/pkg/binding/doc.go
@@ -1,25 +1,35 @@
 /*
 
-Package binding is for implementing transport bindings and
-intermediaries like importers, brokers or channels that forward
-messages between bindings.
+Package binding provides interfaces for transport bindings.
+Binding implementations are under ../bindings.
 
-A transport binding implements Message, Sender and Receiver interfaces.
-An intermediary uses those interfaces to transfer event messages.
+Intermediary applications that forward events between different
+transport bindings may also need to use these intefaces. Normal
+clients can use the cloudevents/client API.
 
-A Message is an abstract container for an Event. It provides
-additional methods for efficient forwarding of structured events
-and reliable delivery when the underlying transports support it.
+A transport binding implements Message, Sender, Receiver interfaces.
+An intermediary uses those interfaces to transfer event messages.  A
+binding should also provide functions to convert between
+cloudevents.Event and the binding's native message types. There are no
+interfaces as the native message type will vary by binding.
 
-A Receiver can return instances of its own Message implementations. A
-Sender must be able to send any implementation of the Message
-interface, but it may provide optimized handling for its own Message
-implementations.
+A Message is an abstract container for a cloudevents.Event.
 
-For transports that support a reliable delivery QoS, the Message
-interface allows acknowledgment between sender and receiver for QoS
-level 0, 1 or 2. The effective QoS is the lowest provided by sender or
-receiver.
+A Receiver returns Message implementations based on its native message
+format. A Sender must be able to encode and send any Message, but may
+provide optimized handling for StructMessage, or for its own native
+Message implementations.
+
+Transports that support reliable delivery can implement and use
+Message.Finish() and ExactlyOnceMessage to forward acknowledgement
+between sender and receiver for QoS level 0, 1 or 2. The effective QoS
+of a sender/receiver pair will be the lower of the two.
+
+FIXME(alanconway) add a generic encoder interface or function signature.  The
+Sender implicitly uses an encoder, so it's not needed for normal use.  It is
+useful for testing and for users with inside knowledge of the implementation,
+they may want to use the encoder but send messages by some other means than the
+Sender.
 
 */
 package binding

--- a/pkg/binding/example_implementing_test.go
+++ b/pkg/binding/example_implementing_test.go
@@ -7,56 +7,68 @@ import (
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 )
 
-// ExMessage is a json.RawMessage, which is just a byte slice
-// containing a JSON encoded event.
-type ExMessage struct{ json.RawMessage }
+// ExMessage is a json.RawMessage, a byte slice containing a JSON encoded event.
+// It implements binding.StructMessage
+//
+// Note: a good binding implementation should provide an easy way to convert
+// between the Message implementation and the "native" message format.
+// In this case it's as simple as:
+//
+//    native = ExMessage(impl)
+//    impl = json.RawMessage(native)
+//
+// For example in a HTTP binding it should be easy to convert between
+// the HTTP binding.Message implementation and net/http.Request and
+// Response types.  There are no interfaces for this conversion as it
+// requires the use of unknown types.
+type ExMessage json.RawMessage
 
 func (m ExMessage) Structured() (string, []byte) {
-	return cloudevents.ApplicationCloudEventsJSON, []byte(m.RawMessage)
+	return cloudevents.ApplicationCloudEventsJSON, []byte(m)
 }
 
 func (m ExMessage) Event() (e cloudevents.Event, err error) {
-	err = json.Unmarshal(m.RawMessage, &e)
+	err = json.Unmarshal(json.RawMessage(m), &e)
 	return e, err
 }
 
-func (m ExMessage) Finish(error) {}
+func (m ExMessage) Finish(error) error { return nil }
 
 // ExSender sends by writing JSON encoded events to an io.Writer
-type ExSender struct{ *json.Encoder }
+type ExSender struct{ encoder *json.Encoder }
 
 func NewExSender(w io.Writer) ExSender { return ExSender{json.NewEncoder(w)} }
 
 func (s ExSender) Send(ctx context.Context, m binding.Message) error {
-	if t, b := m.Structured(); t != "" {
-		// Fast case: if the Message is already structured JSON we can
-		// send it directly, no need to decode and re-encode. Encoding a
-		// json.RawMessage to a json.Encoder() is just a byte-buffer copy.
-		return s.Encode(json.RawMessage(b))
+	if f, b := m.Structured(); f == ce.ApplicationCloudEventsJSON {
+		// Fast case: Message is already structured JSON.
+		return s.encoder.Encode(json.RawMessage(b))
 	}
-	// Some other message encoding. Decode as a generic cloudevents.Event
-	// and then re-encode as JSON
+	// Some other message encoding. Decode as generic Event and re-encode.
 	if e, err := m.Event(); err != nil {
 		return err
-	} else if err := s.Encode(e); err != nil {
+	} else if err := s.encoder.Encode(&e); err != nil {
 		return err
 	}
 	return nil
 }
+func (s ExSender) Close(context.Context) error { return nil }
 
 // ExReceiver receives by reading JSON encoded events from an io.Reader
-type ExReceiver struct{ *json.Decoder }
+type ExReceiver struct{ decoder *json.Decoder }
 
 func NewExReceiver(r io.Reader) ExReceiver { return ExReceiver{json.NewDecoder(r)} }
 
-func (sr ExReceiver) Receive(context.Context) (binding.Message, error) {
-	var m ExMessage
-	err := sr.Decode(&m) // This is just a byte copy since m is a json.RawMessage
-	return m, err
+func (r ExReceiver) Receive(context.Context) (binding.Message, error) {
+	var rm json.RawMessage
+	err := r.decoder.Decode(&rm) // This is just a byte copy.
+	return ExMessage(rm), err
 }
+func (r ExReceiver) Close(context.Context) error { return nil }
 
 // NewExTransport returns a transport.Transport which is implemented by
 // an ExSender and an ExReceiver

--- a/pkg/binding/format/format.go
+++ b/pkg/binding/format/format.go
@@ -9,6 +9,7 @@ package format
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
 )
@@ -25,6 +26,9 @@ type Format interface {
 
 // Prefix for event-format media types.
 const Prefix = "application/cloudevents"
+
+// IsFormat returns true if mediaType begins with "application/cloudevents"
+func IsFormat(mediaType string) bool { return strings.HasPrefix(mediaType, Prefix) }
 
 // JSON is the built-in "application/cloudevents+json" format.
 var JSON = jsonFmt{}

--- a/pkg/binding/format/format.go
+++ b/pkg/binding/format/format.go
@@ -1,0 +1,71 @@
+/*
+Package format formats structured events.
+
+The "application/cloudevents+json" format is built-in and always
+available. Other formats may be added.
+*/
+package format
+
+import (
+	"encoding/json"
+	"fmt"
+
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+)
+
+// Format marshals and unmarshals structured events to bytes.
+type Format interface {
+	// MediaType identifies the format
+	MediaType() string
+	// Marshal event to bytes
+	Marshal(ce.Event) ([]byte, error)
+	// Unmarshal bytes to event
+	Unmarshal([]byte, *ce.Event) error
+}
+
+// Prefix for event-format media types.
+const Prefix = "application/cloudevents"
+
+// JSON is the built-in "application/cloudevents+json" format.
+var JSON = jsonFmt{}
+
+type jsonFmt struct{}
+
+func (jsonFmt) MediaType() string { return ce.ApplicationCloudEventsJSON }
+
+func (jsonFmt) Marshal(e ce.Event) ([]byte, error)    { return json.Marshal(e) }
+func (jsonFmt) Unmarshal(b []byte, e *ce.Event) error { return json.Unmarshal(b, e) }
+
+// built-in formats
+var formats map[string]Format
+
+func init() {
+	formats = map[string]Format{}
+	Add(JSON)
+}
+
+// Lookup returns the format for mediaType, or nil if not found.
+func Lookup(mediaType string) Format { return formats[mediaType] }
+
+func unknown(mediaType string) error {
+	return fmt.Errorf("unknown event format media-type %#v", mediaType)
+}
+
+// Add a new Format. It can be retrieved by Lookup(f.MediaType())
+func Add(f Format) { formats[f.MediaType()] = f }
+
+// Marshal an event to bytes using the mediaType event format.
+func Marshal(mediaType string, e ce.Event) ([]byte, error) {
+	if f := formats[mediaType]; f != nil {
+		return f.Marshal(e)
+	}
+	return nil, unknown(mediaType)
+}
+
+// Unmarshal bytes to an event using the mediaType event format.
+func Unmarshal(mediaType string, b []byte, e *ce.Event) error {
+	if f := formats[mediaType]; f != nil {
+		return f.Unmarshal(b, e)
+	}
+	return unknown(mediaType)
+}

--- a/pkg/binding/format/format_test.go
+++ b/pkg/binding/format/format_test.go
@@ -1,0 +1,82 @@
+package format_test
+
+import (
+	"testing"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSON(t *testing.T) {
+	assert := assert.New(t)
+	e := ce.Event{
+		Context: ce.EventContextV03{
+			Type:   "type",
+			ID:     "id",
+			Source: *types.ParseURLRef("source"),
+		}.AsV03(),
+	}
+	assert.NoError(e.SetData("foo"))
+	b, err := format.JSON.Marshal(e)
+	assert.NoError(err)
+	assert.Equal(`{"data":"foo","datacontenttype":"application/json","id":"id","source":"source","specversion":"0.3","type":"type"}`, string(b))
+
+	var e2 ce.Event
+	assert.NoError(format.JSON.Unmarshal(b, &e2))
+	assert.Equal(e, e2)
+}
+
+func TestLookup(t *testing.T) {
+	assert := assert.New(t)
+	assert.Nil(format.Lookup("nosuch"))
+
+	f := format.Lookup(ce.ApplicationCloudEventsJSON)
+	assert.Equal(f.MediaType(), ce.ApplicationCloudEventsJSON)
+	assert.Equal(format.JSON, f)
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	assert := assert.New(t)
+	e := ce.Event{
+		Context: ce.EventContextV03{
+			Type:   "type",
+			ID:     "id",
+			Source: *types.ParseURLRef("source"),
+		}.AsV03(),
+	}
+	assert.NoError(e.SetData("foo"))
+	b, err := format.Marshal(format.JSON.MediaType(), e)
+	assert.NoError(err)
+	assert.Equal(`{"data":"foo","datacontenttype":"application/json","id":"id","source":"source","specversion":"0.3","type":"type"}`, string(b))
+
+	var e2 ce.Event
+	assert.NoError(format.Unmarshal(format.JSON.MediaType(), b, &e2))
+	assert.Equal(e, e2)
+
+	_, err = format.Marshal("nosuchformat", e)
+	assert.EqualError(err, "unknown event format media-type \"nosuchformat\"")
+	err = format.Unmarshal("nosuchformat", nil, &e)
+	assert.EqualError(err, "unknown event format media-type \"nosuchformat\"")
+}
+
+type dummyFormat struct{}
+
+func (dummyFormat) MediaType() string                     { return "dummy" }
+func (dummyFormat) Marshal(ce.Event) ([]byte, error)      { return []byte("dummy!"), nil }
+func (dummyFormat) Unmarshal(b []byte, e *ce.Event) error { e.Data = "undummy!"; return nil }
+
+func TestAdd(t *testing.T) {
+	assert := assert.New(t)
+	format.Add(dummyFormat{})
+	assert.Equal(dummyFormat{}, format.Lookup("dummy"))
+
+	e := ce.Event{}
+	b, err := format.Marshal("dummy", e)
+	assert.NoError(err)
+	assert.Equal("dummy!", string(b))
+	err = format.Unmarshal("dummy", b, &e)
+	assert.NoError(err)
+	assert.Equal("undummy!", e.Data)
+}

--- a/pkg/binding/interfaces.go
+++ b/pkg/binding/interfaces.go
@@ -1,0 +1,112 @@
+package binding
+
+import (
+	"context"
+
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+)
+
+// Message is the interface to a binding-specific message containing an event.
+//
+// Reliable Delivery
+//
+// There are 3 reliable qualities of service for messages:
+//
+// 0/at-most-once/unreliable: messages can be dropped silently.
+//
+// 1/at-least-once: messages are not dropped without signaling an error
+// to the sender, but they may be duplicated in the event of a re-send.
+//
+// 2/exactly-once: messages are never dropped (without error) or
+// duplicated, as long as both sending and receiving ends maintain
+// some binding-specific delivery state. Whether this is persisted
+// depends on the configuration of the binding implementations.
+//
+// The Message interface supports QoS 0 and 1, the ExactlyOnceMessage interface
+// supports QoS 2
+//
+type Message interface {
+	// Event decodes and returns the contained Event.
+	Event() (ce.Event, error)
+
+	// Structured optionally returns a structured event encoding and its
+	// format type, if the message contains such an encoding. Returns
+	// ("", nil) if not.
+	//
+	// This allows Senders to avoid re-encoding messages that are
+	// already in suitable structured form.
+	//
+	Structured() (formatMediaType string, encodedEvent []byte)
+
+	// Finish *must* be called when message from a Receiver can be forgotten by
+	// the receiver. Sender.Send() calls Finish() when the message is sent.  A QoS
+	// 1 sender should not call Finish() until it gets an acknowledgment of
+	// receipt on the underlying transport.  For QoS 2 see ExactlyOnceMessage.
+	//
+	// Passing a non-nil err indicates sending or processing failed.
+	// A non-nil return indicates that the message was not accepted
+	// by the receivers peer.
+	Finish(error) error
+}
+
+// ExactlyOnceMessage is implemented by received Messages
+// that support QoS 2.  Only transports that support QoS 2 need to
+// implement or use this interface.
+type ExactlyOnceMessage interface {
+	Message
+
+	// Received is called by a forwarding QoS2 Sender when it gets
+	// acknowledgment of receipt (e.g. AMQP 'accept' or MQTT PUBREC)
+	//
+	// The receiver must call settle(nil) when it get's the ack-of-ack
+	// (e.g. AMQP 'settle' or MQTT PUBCOMP) or settle(err) if the
+	// transfer fails.
+	//
+	// Finally the Sender calls Finish() to indicate the message can be
+	// discarded.
+	//
+	// If sending fails, or if the sender does not support QoS 2, then
+	// Finish() may be called without any call to Received()
+	Received(settle func(error))
+}
+
+// Receiver receives messages.
+type Receiver interface {
+	// Receive blocks till a message is received or ctx expires.
+	//
+	// A non-nil error means the receiver is closed.
+	// io.EOF means it closed cleanly, any other value indicates an error.
+	Receive(ctx context.Context) (Message, error)
+}
+
+// Sender sends messages.
+type Sender interface {
+	// Send blocks till the message is sent or ctx expires.
+	//
+	// To support optimized forwading of structured-mode messages, Send()
+	// should use the encoding returned by m.Structured() if there is one.
+	// Otherwise m.Event() can be encoded as per the binding's rules.
+	Send(ctx context.Context, m Message) error
+}
+
+// Closer is the common interface for things that can be closed
+type Closer interface {
+	Close(ctx context.Context) error
+}
+
+// ReceiveCloser is a Receiver that can be closed.
+type ReceiveCloser interface {
+	Receiver
+	Closer
+}
+
+// SendCloser is a Sender that can be closed.
+type SendCloser interface {
+	Sender
+	Closer
+}
+
+// Encoder encodes events as messages.
+type Encoder interface {
+	Encode(ce.Event) (Message, error)
+}

--- a/pkg/binding/message.go
+++ b/pkg/binding/message.go
@@ -1,92 +1,60 @@
 package binding
 
 import (
-	"context"
-
-	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
 )
 
-// Message is the interface to a transport-specific message containing an event.
-//
-// There are 3 reliable qualities of service for messages:
-//
-// 0/at-most-once/unreliable: messages can be dropped silently.
-//
-// 1/at-least-once: messages are not dropped without signaling an error
-// at the sender but may be duplicated.
-//
-// 2/exactly-once: messages are never dropped (without error) or
-// duplicated, as long as both ends maintain some transport-specific
-// state.
-//
-// The Message interface supports QoS 0 and 1, the ExactlyOnceMessage inteface
-// supports QoS 2
-//
-type Message interface {
-	// Event decodes and returns the contained Event.
-	Event() (cloudevents.Event, error)
+// EventMessage type-converts a cloudevents.Event object to implement Message.
+// This allows local cloudevents.Event objects to be sent directly via Sender.Send()
+//     s.Send(ctx, binding.EventMessage(e))
+type EventMessage ce.Event
 
-	// Structured optionally returns an encoded structured event if it
-	// is efficient to do so, or ("", nil) if not.
-	//
-	// Enables Senders to optimize the case where structured events are
-	// passed from transport to transport without being decoded and
-	// re-encoded.
-	//
-	// Transport Message and Sender implementations are not required to
-	// implement the optimization, they can ignore it.
-	Structured() (encodingMediaType string, encodedEvent []byte)
-
-	// Finish *must* be called when message from a Receiver can be
-	// forgotten by the receiver.
-	//
-	// A QoS 1 sender forwarding messages should not call Finish()
-	// until it gets an acknowledgment of receipt.
-	//
-	// A non-nil error indicates an error in sending or processing.
-	Finish(error)
-}
-
-// ExactlyOnceMessage is implemented by incoming transport messages
-// that support QoS 2.  Only transports that support QoS 2 need to
-// implement or use this interface.
-type ExactlyOnceMessage interface {
-	Message
-
-	// Received is called by a Sender when it gets acknowledgment of receipt
-	// (e.g. AMQP ACCEPT or MQTT PUBREC)
-	//
-	// The sender passes a finish() function that the original receiver
-	// must call when it get's the ack-of-the-ack (e.g. AMQP SETTLE, MQTT
-	// PUBCOMP)
-	//
-	// If sending fails, the sender must call Finish(err) with a non-nil
-	// error instead of Received. ExactlyOnceMessage implementations
-	// must also be prepared to handle Finish(nil) if the sender does
-	// not support QoS 3.
-	Received(finish func(error))
-}
-
-// EventMessage wraps a local cloudevents.Event as a Message.
-type EventMessage cloudevents.Event
-
-// Event returns the event.
-func (m EventMessage) Event() (cloudevents.Event, error) { return cloudevents.Event(m), nil }
-
-// Structured returns ("", nil).
-func (EventMessage) Structured() (string, []byte) { return "", nil }
-
-// Finish does nothing.
-func (EventMessage) Finish(error) {}
+func (m EventMessage) Event() (ce.Event, error)     { return ce.Event(m), nil }
+func (m EventMessage) Structured() (string, []byte) { return "", nil }
+func (EventMessage) Finish(error) error             { return nil }
 
 var _ Message = EventMessage{} // Test it conforms to the interface
 
-// Receiver receives messages.
-type Receiver interface {
-	Receive(ctx context.Context) (Message, error)
+// StructMessage implements a structured-mode message as a simple struct.
+type StructMessage struct {
+	Format string
+	Bytes  []byte
 }
 
-// Sender sends messages.
-type Sender interface {
-	Send(ctx context.Context, m Message) error
+// Event can only decode built-in formats supported by format.Unmarshal.
+func (m StructMessage) Event() (e ce.Event, err error) {
+	err = format.Unmarshal(m.Format, m.Bytes, &e)
+	return e, err
+}
+func (m StructMessage) Structured() (string, []byte) { return m.Format, m.Bytes }
+func (StructMessage) Finish(error) error             { return nil }
+
+var _ Message = StructMessage{} // Test it conforms to the interface
+
+// StructEncoder encodes events as StructMessage using a Format.
+type StructEncoder struct{ Format format.Format }
+
+func (enc StructEncoder) Encode(e ce.Event) (Message, error) {
+	b, err := enc.Format.Marshal(e)
+	return StructMessage{Format: enc.Format.MediaType(), Bytes: b}, err
+}
+
+type BinaryEncoder struct{}
+
+func (BinaryEncoder) Encode(e ce.Event) (Message, error) { return EventMessage(e), nil }
+
+// Structured returns the structured encoding of a message using a format.
+// m.Structured() returns the correct format, return that.
+// Otherwise use format the message's event with f.Format().
+func Structured(m Message, f format.Format) ([]byte, error) {
+	mt, b := m.Structured()
+	if mt == f.MediaType() {
+		return b, nil
+	}
+	e, err := m.Event()
+	if err != nil {
+		return nil, err
+	}
+	return f.Marshal(e)
 }

--- a/pkg/binding/message_test.go
+++ b/pkg/binding/message_test.go
@@ -1,0 +1,72 @@
+package binding_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/stretchr/testify/assert"
+)
+
+var testEvent = ce.Event{
+	Data:    "data",
+	Context: ce.EventContextV03{Source: types.URLRef{URL: url.URL{Path: "source"}}, ID: "id", Type: "type"}.AsV03(),
+}
+
+var testJSON = `{"data":"data","datacontenttype":"application/json","id":"id","source":"source","specversion":"0.3","type":"type"}`
+
+func TestEventMessage(t *testing.T) {
+	assert := assert.New(t)
+	m, err := binding.BinaryEncoder{}.Encode(testEvent)
+	assert.NoError(err)
+	f, b := m.Structured()
+	assert.Empty(f)
+	assert.Empty(b)
+	e, err := m.Event()
+	assert.NoError(err)
+	assert.Equal(testEvent, e)
+}
+
+func TestStructMessage(t *testing.T) {
+	assert := assert.New(t)
+	m, err := binding.StructEncoder{format.JSON}.Encode(testEvent)
+	assert.NoError(err)
+	f, b := m.Structured()
+	assert.Equal(ce.ApplicationCloudEventsJSON, f)
+	assert.Equal(testJSON, string(b))
+	e, err := m.Event()
+	assert.NoError(err)
+	assert.Equal(testEvent.Context, e.Context)
+	var s string
+	assert.NoError(e.DataAs(&s))
+	assert.Equal(testEvent.Data, s)
+
+	_, err = binding.StructMessage{Format: "nosuch"}.Event()
+	assert.EqualError(err, "unknown event format media-type \"nosuch\"")
+}
+
+type dummyFormat struct{}
+
+func (dummyFormat) MediaType() string                     { return "dummy" }
+func (dummyFormat) Marshal(ce.Event) ([]byte, error)      { return []byte("dummy!"), nil }
+func (dummyFormat) Unmarshal(b []byte, e *ce.Event) error { e.Data = "undummy!"; return nil }
+
+func TestStructured(t *testing.T) {
+	sm := binding.StructMessage{Format: format.JSON.MediaType(), Bytes: []byte(testJSON)}
+	b, err := binding.Structured(sm, format.JSON)
+	assert.NoError(t, err)
+	assert.Equal(t, &sm.Bytes, &b) // Not just equal but at the same address.
+
+	d := dummyFormat{}
+	b, err = binding.Structured(sm, d)
+	assert.NoError(t, err)
+	assert.Equal(t, "dummy!", string(b)) // Reformat as dummy
+
+	bm := binding.EventMessage(testEvent)
+	b, err = binding.Structured(bm, format.JSON)
+	assert.NoError(t, err)
+	assert.Equal(t, sm.Bytes, b) // Same bytes
+}

--- a/pkg/binding/message_test.go
+++ b/pkg/binding/message_test.go
@@ -32,7 +32,7 @@ func TestEventMessage(t *testing.T) {
 
 func TestStructMessage(t *testing.T) {
 	assert := assert.New(t)
-	m, err := binding.StructEncoder{format.JSON}.Encode(testEvent)
+	m, err := binding.StructEncoder{Format: format.JSON}.Encode(testEvent)
 	assert.NoError(err)
 	f, b := m.Structured()
 	assert.Equal(ce.ApplicationCloudEventsJSON, f)

--- a/pkg/binding/spec/attributes.go
+++ b/pkg/binding/spec/attributes.go
@@ -1,0 +1,122 @@
+package spec
+
+import (
+	"errors"
+	"time"
+
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+)
+
+// Kind is a version-independent identifier for a CloudEvent context attribute.
+type Kind uint8
+
+const (
+	// Required cloudevents attributes
+	ID Kind = iota
+	Source
+	SpecVersion
+	Type
+	// Optional cloudevents attributes
+	DataContentType
+	DataSchema
+	Subject
+	Time
+)
+const nAttrs = int(Time) + 1
+
+var kindNames = [nAttrs]string{
+	"id",
+	"source",
+	"specversion",
+	"type",
+	"datacontenttype",
+	"dataschema",
+	"subject",
+	"time",
+}
+
+// String is a human-readable string, for a valid attribute name use Attribute.Name
+func (k Kind) String() string { return kindNames[k] }
+
+// IsRequired returns true for attributes defined as "required" by the CE spec.
+func (k Kind) IsRequired() bool { return k < DataContentType }
+
+// ErrBadType returned when there is an attribute/value type mismatch.
+var ErrBadType = errors.New("bad context attribute type")
+
+// Attribute is a named attribute accessor.
+// The attribute name is specific to a Version.
+type Attribute interface {
+	Kind() Kind
+	// Name of the attribute with respect to the current spec Version()
+	Name() string
+	// Version of the spec that this attribute belongs to
+	Version() Version
+	// Get the value of this attribute from an event context
+	Get(ce.EventContextReader) interface{}
+	// Set the value of this attribute on an event context
+	Set(ce.EventContextWriter, interface{}) error
+}
+
+// accessor provides Kind, Get, Set.
+type accessor interface {
+	Kind() Kind
+	Get(ce.EventContextReader) interface{}
+	Set(ce.EventContextWriter, interface{}) error
+}
+
+var acc = [nAttrs]accessor{
+	&aStr{aKind(ID), ce.EventContextReader.GetID, ce.EventContextWriter.SetID},
+	&aStr{aKind(Source), ce.EventContextReader.GetSource, ce.EventContextWriter.SetSource},
+	&aStr{aKind(SpecVersion), ce.EventContextReader.GetSpecVersion, ce.EventContextWriter.SetSpecVersion},
+	&aStr{aKind(Type), ce.EventContextReader.GetType, ce.EventContextWriter.SetType},
+	&aStr{aKind(DataContentType), ce.EventContextReader.GetDataContentType, ce.EventContextWriter.SetDataContentType},
+	&aStr{aKind(DataSchema), ce.EventContextReader.GetDataSchema, ce.EventContextWriter.SetDataSchema},
+	&aStr{aKind(Subject), ce.EventContextReader.GetSubject, ce.EventContextWriter.SetSubject},
+	&aTime{aKind(Time), ce.EventContextReader.GetTime, ce.EventContextWriter.SetTime},
+}
+
+// aKind implements Kind()
+type aKind Kind
+
+func (kind aKind) Kind() Kind { return Kind(kind) }
+
+type aStr struct {
+	aKind
+	get func(ce.EventContextReader) string
+	set func(ce.EventContextWriter, string) error
+}
+
+func (a *aStr) Get(c ce.EventContextReader) interface{} {
+	if s := a.get(c); s != "" {
+		return s
+	}
+	return nil // Treat blank as missing
+}
+
+func (a *aStr) Set(c ce.EventContextWriter, v interface{}) error {
+	if v, ok := v.(string); ok {
+		return a.set(c, v)
+	}
+	return ErrBadType
+}
+
+type aTime struct {
+	aKind
+	get func(ce.EventContextReader) time.Time
+	set func(ce.EventContextWriter, time.Time) error
+}
+
+func (a *aTime) Get(c ce.EventContextReader) interface{} {
+	if v := a.get(c); !v.IsZero() {
+		return v
+	}
+	return nil // Treat zero time as missing.
+}
+
+func (a *aTime) Set(c ce.EventContextWriter, v interface{}) error {
+	if v, ok := v.(time.Time); ok {
+		return a.set(c, v)
+	}
+	return ErrBadType
+}

--- a/pkg/binding/spec/attributes_test.go
+++ b/pkg/binding/spec/attributes_test.go
@@ -1,0 +1,93 @@
+package spec_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttributes03(t *testing.T) {
+	assert := assert.New(t)
+	v, err := spec.WithPrefix("x:").Version("0.3")
+	assert.NoError(err)
+	subject := v.Attribute("x:subject")
+	assert.Equal(spec.Subject, subject.Kind())
+	assert.Equal("x:subject", subject.Name())
+
+	c := v.NewContext()
+	assert.Equal("0.3", c.GetSpecVersion())
+	assert.NoError(subject.Set(c, "foobar"))
+	got := subject.Get(c)
+	assert.Equal("foobar", got)
+	assert.Equal("foobar", c.GetSubject())
+
+	now := time.Now()
+	atime := v.Attribute("x:time")
+	assert.Equal(spec.Time, atime.Kind())
+	assert.NoError(atime.Set(c, now))
+	tm := atime.Get(c)
+	assert.Empty(cmp.Diff(now, tm))
+	assert.Empty(cmp.Diff(now, c.GetTime()))
+
+	nosuch := v.Attribute("nosuch")
+	assert.Nil(nosuch)
+
+	err = subject.Set(c, 1)
+	assert.Equal(err, spec.ErrBadType)
+	err = atime.Set(c, "foo")
+	assert.Equal(err, spec.ErrBadType)
+}
+
+func TestAttributes02(t *testing.T) {
+	assert := assert.New(t)
+	v, err := spec.WithPrefix("x:").Version("0.2")
+	assert.NoError(err)
+	c := v.NewContext()
+	id := v.Attribute("x:id")
+	assert.NoError(id.Set(c, "foobar"))
+	s := id.Get(c)
+	assert.Equal("foobar", s)
+	assert.Equal("foobar", c.GetID())
+
+	now := time.Now()
+	atime := v.Attribute("x:time")
+	assert.Equal(spec.Time, atime.Kind())
+	assert.NoError(atime.Set(c, now))
+	tm := atime.Get(c)
+	assert.Empty(cmp.Diff(now, tm))
+	assert.Empty(cmp.Diff(now, c.GetTime()))
+
+	nosuch := v.Attribute("nosuch")
+	assert.Nil(nosuch)
+
+	err = id.Set(c, 1)
+	assert.Equal(err, spec.ErrBadType)
+	err = atime.Set(c, "foo")
+	assert.Equal(err, spec.ErrBadType)
+}
+
+func TestAttributes01(t *testing.T) {
+	assert := assert.New(t)
+	v, err := spec.WithPrefix("x:").Version("0.1")
+	assert.NoError(err)
+	c := v.NewContext()
+	contentType := v.Attribute("x:contentType")
+	assert.Equal(spec.DataContentType, contentType.Kind())
+	assert.NoError(contentType.Set(c, "foobar"))
+	s := contentType.Get(c)
+	assert.Equal("foobar", s)
+	assert.Equal("foobar", c.GetDataContentType())
+
+	nosuch := v.Attribute("x:subject")
+	assert.Nil(nosuch)
+}
+
+func TestAttributesBadVersions(t *testing.T) {
+	assert := assert.New(t)
+	v, err := spec.WithPrefix("x:").Version("0.x")
+	assert.Nil(v)
+	assert.EqualError(err, `invalid spec version "0.x"`)
+}

--- a/pkg/binding/spec/doc.go
+++ b/pkg/binding/spec/doc.go
@@ -1,0 +1,8 @@
+/*
+Package spec provides spec-version metadata.
+
+For use by code that maps events using (prefixed) attribute name strings.
+Supports handling multiple spec versions uniformly.
+
+*/
+package spec

--- a/pkg/binding/spec/spec.go
+++ b/pkg/binding/spec/spec.go
@@ -1,0 +1,166 @@
+package spec
+
+import (
+	"fmt"
+
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+)
+
+// Version provides meta-data for a single spec-version.
+type Version interface {
+	// String name of the version, e.g. "1.0"
+	String() string
+	// Prefix for attribute names.
+	Prefix() string
+	// Attribute looks up a prefixed attribute name.
+	// Returns nil if not found.
+	Attribute(name string) Attribute
+	// Attributes returns all the context attributes for this version.
+	Attributes() []Attribute
+	// NewContext returns a new context for this version.
+	NewContext() ce.EventContext
+	// Convert translates a context to this version.
+	Convert(ce.EventContextConverter) ce.EventContext
+}
+
+// Versions contains all known versions with the same attribute prefix.
+type Versions struct {
+	prefix  string
+	all     []Version
+	m       map[string]Version
+	svnames []string
+}
+
+// Versions returns the list of all known versions, most recent first.
+func (vs *Versions) Versions() []Version { return vs.all }
+
+// Version returns the named version.
+func (vs *Versions) Version(name string) (Version, error) {
+	if v := vs.m[name]; v != nil {
+		return v, nil
+	}
+	return nil, fmt.Errorf("invalid spec version %#v", name)
+}
+
+// Latest returns the latest Version
+func (vs *Versions) Latest() Version { return vs.all[0] }
+
+// SpecVersionNames returns distinct names of the specversion
+// attribute used in all versions, newest first.
+// Names are prefixed.
+func (vs *Versions) SpecVersionNames() []string { return vs.svnames }
+
+// Prefix is the attribute name prefix.
+func (vs *Versions) Prefix() string { return vs.prefix }
+
+type attribute struct {
+	accessor
+	name    string
+	version Version
+}
+
+func (a *attribute) Name() string     { return a.name }
+func (a *attribute) Version() Version { return a.version }
+
+type version struct {
+	prefix  string
+	context ce.EventContext
+	convert func(ce.EventContextConverter) ce.EventContext
+	attrMap map[string]Attribute
+	attrs   []Attribute
+}
+
+func (v *version) Attribute(name string) Attribute { return v.attrMap[name] }
+func (v *version) Attributes() []Attribute         { return v.attrs }
+func (v *version) String() string                  { return v.context.GetSpecVersion() }
+func (v *version) Prefix() string                  { return v.prefix }
+func (v *version) NewContext() ce.EventContext     { return v.context.Clone() }
+
+func (v *version) Convert(c ce.EventContextConverter) ce.EventContext { return v.convert(c) }
+
+func newVersion(
+	prefix string,
+	context ce.EventContext,
+	convert func(ce.EventContextConverter) ce.EventContext,
+	attrs ...*attribute,
+) *version {
+	v := &version{
+		prefix:  prefix,
+		context: context,
+		convert: convert,
+		attrMap: map[string]Attribute{},
+		attrs:   make([]Attribute, len(attrs)),
+	}
+	for i, a := range attrs {
+		a.name = prefix + a.name
+		a.version = v
+		v.attrs[i] = a
+		v.attrMap[a.name] = a
+	}
+	return v
+}
+
+// WithPrefix returns a set of versions with prefix added to all attribute names.
+func WithPrefix(prefix string) *Versions {
+	attr := func(name string, kind Kind) *attribute {
+		return &attribute{accessor: acc[kind], name: name}
+	}
+	vs := &Versions{
+		m: map[string]Version{},
+		svnames: []string{
+			prefix + "specversion",
+			prefix + "cloudEventsVersion",
+		},
+		all: []Version{
+			newVersion(prefix, ce.EventContextV1{}.AsV1(),
+				func(c ce.EventContextConverter) ce.EventContext { return c.AsV1() },
+				attr("id", ID),
+				attr("source", Source),
+				attr("specversion", SpecVersion),
+				attr("type", Type),
+				attr("datacontenttype", DataContentType),
+				attr("dataschema", DataSchema),
+				attr("subject", Subject),
+				attr("time", Time),
+			),
+			newVersion(prefix, ce.EventContextV03{}.AsV03(),
+				func(c ce.EventContextConverter) ce.EventContext { return c.AsV03() },
+				attr("specversion", SpecVersion),
+				attr("type", Type),
+				attr("source", Source),
+				attr("schemaurl", DataSchema),
+				attr("subject", Subject),
+				attr("id", ID),
+				attr("time", Time),
+				attr("datacontenttype", DataContentType),
+			),
+			newVersion(prefix, ce.EventContextV02{}.AsV02(),
+				func(c ce.EventContextConverter) ce.EventContext { return c.AsV02() },
+				attr("specversion", SpecVersion),
+				attr("type", Type),
+				attr("source", Source),
+				attr("schemaurl", DataSchema),
+				attr("id", ID),
+				attr("time", Time),
+				attr("contenttype", DataContentType),
+			),
+			newVersion(prefix, ce.EventContextV01{}.AsV01(),
+				func(c ce.EventContextConverter) ce.EventContext { return c.AsV01() },
+				attr("cloudEventsVersion", SpecVersion),
+				attr("eventType", Type),
+				attr("source", Source),
+				attr("schemaURL", DataSchema),
+				attr("eventID", ID),
+				attr("eventTime", Time),
+				attr("contentType", DataContentType),
+			),
+		},
+	}
+	for _, v := range vs.all {
+		vs.m[v.String()] = v
+	}
+	return vs
+}
+
+// New returns a set of versions
+func New() *Versions { return WithPrefix("") }

--- a/pkg/binding/spec/spec_test.go
+++ b/pkg/binding/spec/spec_test.go
@@ -1,0 +1,26 @@
+package spec_test
+
+import (
+	"testing"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersions(t *testing.T) {
+	assert := assert.New(t)
+	versions := spec.New()
+	assert.Equal([]string{"specversion", "cloudEventsVersion"}, versions.SpecVersionNames())
+
+	want := []string{"1.0", "0.3", "0.2", "0.1"}
+	all := versions.Versions()
+	assert.Equal(len(want), len(all))
+	for i, s := range want {
+		assert.Equal(s, all[i].String())
+		assert.Equal(s, all[i].NewContext().GetSpecVersion())
+		converted := all[i].Convert(ce.EventContextV01{}.AsV01())
+		assert.Equal(s, converted.GetSpecVersion(), "%v %v %v", i, s, converted)
+	}
+	assert.Equal(want[0], versions.Latest().NewContext().GetSpecVersion())
+}


### PR DESCRIPTION
Provides string attribute names for all versions, useful for mappings
like AMQP or HTTP that use prefixed CE attribute names in their encoding.

Fixes #225