### PR TITLE
Single point of parsing for Time

### DIFF
--- a/pkg/cloudevents/event_test.go
+++ b/pkg/cloudevents/event_test.go
@@ -782,7 +782,7 @@ func TestExtensions(t *testing.T) {
 			},
 			extension:    "anothertest",
 			wantError:    true,
-			wantErrorMsg: "cannot convert int32 to String",
+			wantErrorMsg: "cannot convert 1 to string",
 		},
 		"full v02, test extension": {
 			event: ce.Event{
@@ -797,7 +797,7 @@ func TestExtensions(t *testing.T) {
 			},
 			extension:    "anothertest",
 			wantError:    true,
-			wantErrorMsg: "cannot convert int32 to String",
+			wantErrorMsg: "cannot convert 1 to string",
 		},
 		"full v03, test extension": {
 			event: ce.Event{
@@ -812,7 +812,7 @@ func TestExtensions(t *testing.T) {
 			},
 			extension:    "anothertest",
 			wantError:    true,
-			wantErrorMsg: "cannot convert int32 to String",
+			wantErrorMsg: "cannot convert 1 to string",
 		},
 		"full v1, test extension": {
 			event: ce.Event{
@@ -827,7 +827,7 @@ func TestExtensions(t *testing.T) {
 			},
 			extension:    "anothertest",
 			wantError:    true,
-			wantErrorMsg: "cannot convert int32 to String",
+			wantErrorMsg: "cannot convert 1 to string",
 		},
 	}
 	for n, tc := range testCases {

--- a/pkg/cloudevents/eventcontext_v03.go
+++ b/pkg/cloudevents/eventcontext_v03.go
@@ -83,9 +83,9 @@ func (ec *EventContextV03) SetExtension(name string, value interface{}) error {
 	if value == nil {
 		delete(ec.Extensions, name)
 	} else {
-		v, err := types.ValueOf(value)
+		v, err := types.Validate(value)
 		if err == nil {
-			ec.Extensions[name] = v.Interface()
+			ec.Extensions[name] = v
 		}
 		return err
 	}

--- a/pkg/cloudevents/transport/amqp/codec.go
+++ b/pkg/cloudevents/transport/amqp/codec.go
@@ -197,10 +197,10 @@ func (c Codec) fromHeaders(h map[string]interface{}, event *cloudevents.Event) e
 	delete(h, prefix+"source")
 
 	if t, ok := h[prefix+"time"].(string); ok {
-		if timestamp := types.ParseTimestamp(t); timestamp != nil {
-			if err := ec.SetTime(timestamp.Time); err != nil {
-				return err
-			}
+		if timestamp, err := types.ParseTimestamp(t); err != nil {
+			return err
+		} else if err := ec.SetTime(timestamp.Time); err != nil {
+			return err
 		}
 	}
 	delete(h, prefix+"time")

--- a/pkg/cloudevents/transport/http/codec_v01.go
+++ b/pkg/cloudevents/transport/http/codec_v01.go
@@ -182,7 +182,11 @@ func (v CodecV01) fromHeaders(h http.Header) (cloudevents.EventContextV01, error
 	if source != nil {
 		ec.Source = *source
 	}
-	ec.EventTime = types.ParseTimestamp(h.Get("CE-EventTime"))
+	var err error
+	ec.EventTime, err = types.ParseTimestamp(h.Get("CE-EventTime"))
+	if err != nil {
+		return ec, err
+	}
 	h.Del("CE-EventTime")
 	etv := h.Get("CE-EventTypeVersion")
 	h.Del("CE-EventTypeVersion")

--- a/pkg/cloudevents/transport/http/codec_v02.go
+++ b/pkg/cloudevents/transport/http/codec_v02.go
@@ -191,7 +191,11 @@ func (v CodecV02) fromHeaders(h http.Header) (cloudevents.EventContextV02, error
 	}
 	h.Del("ce-source")
 
-	ec.Time = types.ParseTimestamp(h.Get("ce-time"))
+	var err error
+	ec.Time, err = types.ParseTimestamp(h.Get("ce-time"))
+	if err != nil {
+		return ec, err
+	}
 	h.Del("ce-time")
 
 	ec.SchemaURL = types.ParseURLRef(h.Get("ce-schemaurl"))

--- a/pkg/cloudevents/transport/http/codec_v03.go
+++ b/pkg/cloudevents/transport/http/codec_v03.go
@@ -222,7 +222,11 @@ func (v CodecV03) fromHeaders(h http.Header) (cloudevents.EventContextV03, error
 	}
 	h.Del("ce-subject")
 
-	ec.Time = types.ParseTimestamp(h.Get("ce-time"))
+	var err error
+	ec.Time, err = types.ParseTimestamp(h.Get("ce-time"))
+	if err != nil {
+		return ec, err
+	}
 	h.Del("ce-time")
 
 	ec.SchemaURL = types.ParseURLRef(h.Get("ce-schemaurl"))

--- a/pkg/cloudevents/transport/http/codec_v1.go
+++ b/pkg/cloudevents/transport/http/codec_v1.go
@@ -194,7 +194,11 @@ func (v CodecV1) fromHeaders(h http.Header) (cloudevents.EventContextV1, error) 
 	}
 	h.Del("ce-subject")
 
-	ec.Time = types.ParseTimestamp(h.Get("ce-time"))
+	var err error
+	ec.Time, err = types.ParseTimestamp(h.Get("ce-time"))
+	if err != nil {
+		return ec, err
+	}
 	h.Del("ce-time")
 
 	ec.DataSchema = types.ParseURI(h.Get("ce-dataschema"))

--- a/pkg/cloudevents/transport/pubsub/codec.go
+++ b/pkg/cloudevents/transport/pubsub/codec.go
@@ -187,10 +187,10 @@ func (c Codec) fromAttributes(a map[string]string, event *cloudevents.Event) err
 	delete(a, prefix+"source")
 
 	if t := a[prefix+"time"]; t != "" {
-		if timestamp := types.ParseTimestamp(t); timestamp != nil {
-			if err := ec.SetTime(timestamp.Time); err != nil {
-				return err
-			}
+		if timestamp, err := types.ParseTimestamp(t); err != nil {
+			return err
+		} else if err := ec.SetTime(timestamp.Time); err != nil {
+			return err
 		}
 	}
 	delete(a, prefix+"time")

--- a/pkg/cloudevents/types/doc.go
+++ b/pkg/cloudevents/types/doc.go
@@ -1,12 +1,14 @@
 /*
 Package types implements the CloudEvents type system.
 
-CloudEvents defines a small set of abstract types for all event context
-attribute values, including custom extension attributes. Each CloudEvents type
-has a corresponding native Go type and a canonical string encoding.
+CloudEvents defines a set of abstract types for event context attributes. Each
+type has a corresponding native Go type and a canonical string encoding.  The
+native Go types used to represent the CloudEvents types are:
+
+    bool, int32, string, []byte, *url.URL, time.Time
 
  +----------------+----------------+-----------------------------------+
- |CloudEvents Type|Native Type     |Convertible From Types             |
+ |CloudEvents Type|Native Type     |Convertible From                   |
  +================+================+===================================+
  |Bool            |bool            |bool                               |
  +----------------+----------------+-----------------------------------+
@@ -25,16 +27,16 @@ has a corresponding native Go type and a canonical string encoding.
  |Timestamp       |time.Time       |time.Time, types.Timestamp         |
  +----------------+----------------+-----------------------------------+
 
-The native types used to represent CloudEvents types are:
+Extension attributes may be stored as a native type or a canonical string.  The
+To<Type> functions will convert to the desired <Type> from any convertible type
+or from the canonical string form.
 
-    bool, int32, string, []byte, *url.URL, time.Time
+The Parse<Type> and Format<Type> functions convert native types to/from
+canonical strings.
 
-This package provides Parse... and Format... functions to convert to/from
-canonical strings. Use standard url.URL.String() and url.Parse() for URL
-values, the canonical string for a string is the string itself.
-
-It provides To... functions to convert any extension attribute value, in native
-or string form, to the expected type.
+Note are no Parse or Format functions for URL or string. For URL use the
+standard url.Parse() and url.URL.String(). The canonical string format of a
+string is the string itself.
 
 */
 package types

--- a/pkg/cloudevents/types/value_test.go
+++ b/pkg/cloudevents/types/value_test.go
@@ -41,7 +41,7 @@ func Example() {
 	// 123 <nil>
 	// 456 <nil>
 	// 99999 <nil>
-	// 0 2147483648 is out of range for Integer
+	// 0 cannot convert 2147483648 to int32: out of range
 	// 0 strconv.ParseFloat: parsing "not an int": invalid syntax
 }
 
@@ -106,7 +106,7 @@ func TestBool(t *testing.T) {
 	x.ok(false, false, "false")
 
 	x.err("notabool", "strconv.ParseBool: parsing \"notabool\": invalid syntax")
-	x.err(0, "cannot convert int32 to Bool")
+	x.err(0, "cannot convert 0 to bool")
 	x.err(nil, "invalid CloudEvents value: <nil>")
 }
 
@@ -141,18 +141,18 @@ func TestInteger(t *testing.T) {
 	x.str(".9", int32(0))
 	x.str("-.9", int32(0))
 
-	x.err(math.MaxInt32+1, "2147483648 is out of range for Integer")
-	x.err(uint32(math.MaxInt32+1), "2147483648 is out of range for Integer")
-	x.err(int64(math.MaxInt32+1), "2147483648 is out of range for Integer")
-	x.err(int64(math.MinInt32-1), "-2147483649 is out of range for Integer")
-	x.err(float64(math.MinInt32-1), "-2.147483649e+09 is out of range for Integer")
-	x.err(float64(math.MaxInt32+1), "2.147483648e+09 is out of range for Integer")
+	x.err(math.MaxInt32+1, "cannot convert 2147483648 to int32: out of range")
+	x.err(uint32(math.MaxInt32+1), "cannot convert 0x80000000 to int32: out of range")
+	x.err(int64(math.MaxInt32+1), "cannot convert 2147483648 to int32: out of range")
+	x.err(int64(math.MinInt32-1), "cannot convert -2147483649 to int32: out of range")
+	x.err(float64(math.MinInt32-1), "cannot convert -2.147483649e+09 to int32: out of range")
+	x.err(float64(math.MaxInt32+1), "cannot convert 2.147483648e+09 to int32: out of range")
 	// Float32 doesn't keep all the bits of an int32 so we need to exaggerate fof range error.
-	x.err(float64(2*math.MinInt32), "-4.294967296e+09 is out of range for Integer")
-	x.err(float64(-2*math.MaxInt32), "-4.294967294e+09 is out of range for Integer")
+	x.err(float64(2*math.MinInt32), "cannot convert -4.294967296e+09 to int32: out of range")
+	x.err(float64(-2*math.MaxInt32), "cannot convert -4.294967294e+09 to int32: out of range")
 
 	x.err("X", "strconv.ParseFloat: parsing \"X\": invalid syntax")
-	x.err(true, "cannot convert bool to Integer")
+	x.err(true, "cannot convert true to int32")
 	x.err(nil, "invalid CloudEvents value: <nil>")
 }
 
@@ -206,7 +206,7 @@ func TestTime(t *testing.T) {
 	x.str(timeStr, someTime)
 
 	x.err(nil, "invalid CloudEvents value: <nil>")
-	x.err(5, "cannot convert int32 to Time")
+	x.err(5, "cannot convert 5 to time.Time")
 	x.err((*time.Time)(nil), "invalid CloudEvents value: (*time.Time)(nil)")
 	x.err((*types.Timestamp)(nil), "invalid CloudEvents value: (*types.Timestamp)(nil)")
 	x.err("not a time", "parsing time \"not a time\" as \"2006-01-02T15:04:05.999999999Z07:00\": cannot parse \"not a time\" as \"2006\"")


### PR DESCRIPTION
All time parsing calls types.ParseTime()

Return errors from time parsing

Added types.ConvertError error type for all conversion errors.

Improved error messages and tightened up some error handling.