### PR TITLE
Clarify doc comments on extensions.

### DIFF
--- a/pkg/cloudevents/event_interface.go
+++ b/pkg/cloudevents/event_interface.go
@@ -71,7 +71,7 @@ type EventWriter interface {
 	// Extension Attributes
 
 	// SetExtension performs event.Context.SetExtension.
-	SetExtension(string, interface{}) // TODO: this needs to move to just string.
+	SetExtension(string, interface{})
 
 	// SetData encodes the given payload with the current encoding settings.
 	SetData(interface{}) error

--- a/pkg/cloudevents/eventcontext.go
+++ b/pkg/cloudevents/eventcontext.go
@@ -78,6 +78,8 @@ type EventContextWriter interface {
 
 	// SetExtension sets the given interface onto the extension attributes
 	// determined by the provided name.
+	//
+	// Package ./types documents the types that are allowed as extension values.
 	SetExtension(string, interface{}) error
 }
 


### PR DESCRIPTION
Removed `// TODO: this needs to move to just string.` on Event.SetExtension It no longer needs to be a string.  Added a reference to the types documentation on EventContext.SetExtension.