### PR TITLE
allow conversion functions to not convert and not throw an error.

### DIFF
--- a/pkg/cloudevents/transport/error.go
+++ b/pkg/cloudevents/transport/error.go
@@ -6,15 +6,17 @@ import "fmt"
 // message can not be converted.
 type ErrTransportMessageConversion struct {
 	fatal     bool
+	handled   bool
 	transport string
 	message   string
 }
 
 // NewErrMessageEncodingUnknown makes a new ErrMessageEncodingUnknown.
-func NewErrTransportMessageConversion(transport, message string, fatal bool) *ErrTransportMessageConversion {
+func NewErrTransportMessageConversion(transport, message string, handled, fatal bool) *ErrTransportMessageConversion {
 	return &ErrTransportMessageConversion{
 		transport: transport,
 		message:   message,
+		handled:   handled,
 		fatal:     fatal,
 	}
 }
@@ -22,6 +24,11 @@ func NewErrTransportMessageConversion(transport, message string, fatal bool) *Er
 // IsFatal reports if this error should be considered fatal.
 func (e *ErrTransportMessageConversion) IsFatal() bool {
 	return e.fatal
+}
+
+// Handled reports if this error should be considered accepted and no further action.
+func (e *ErrTransportMessageConversion) Handled() bool {
+	return e.handled
 }
 
 // Error implements error.Error

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -214,13 +214,20 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (conte
 			})
 			if err != nil {
 				isErr := true
+				handled := false
 				if txerr, ok := err.(*transport.ErrTransportMessageConversion); ok {
 					if !txerr.IsFatal() {
 						isErr = false
 					}
+					if txerr.Handled() {
+						handled = true
+					}
 				}
 				if isErr {
 					return rctx, nil, err
+				}
+				if handled {
+					return rctx, nil, nil
 				}
 			}
 			if accepted(resp) {
@@ -240,13 +247,13 @@ func (t *Transport) MessageToEvent(ctx context.Context, msg *Message) (*cloudeve
 	if msg.CloudEventsVersion() != "" {
 		// This is likely a cloudevents encoded message, try to decode it.
 		if ok := t.loadCodec(ctx); !ok {
-			err = transport.NewErrTransportMessageConversion("http", fmt.Sprintf("unknown encoding set on transport: %d", t.Encoding), true)
+			err = transport.NewErrTransportMessageConversion("http", fmt.Sprintf("unknown encoding set on transport: %d", t.Encoding), false, true)
 			logger.Error("failed to load codec", zap.Error(err))
 		} else {
 			event, err = t.codec.Decode(ctx, msg)
 		}
 	} else {
-		err = transport.NewErrTransportMessageConversion("http", "cloudevents version unknown", false)
+		err = transport.NewErrTransportMessageConversion("http", "cloudevents version unknown", false, false)
 	}
 
 	// If codec returns and error, or could not load the correct codec, try
@@ -254,10 +261,17 @@ func (t *Transport) MessageToEvent(ctx context.Context, msg *Message) (*cloudeve
 	if err != nil && t.HasConverter() {
 		event, err = t.Converter.Convert(ctx, msg, err)
 	}
+
 	// If err is still set, it means that there was no converter, or the
 	// converter failed to convert.
 	if err != nil {
 		logger.Debug("failed to decode message", zap.Error(err))
+	}
+
+	// If event and error are both nil, then there is nothing to do with this event, it was handled.
+	if err == nil && event == nil {
+		logger.Debug("convert function returned (nil, nil)")
+		err = transport.NewErrTransportMessageConversion("http", "convert function handled request", true, false)
 	}
 
 	return event, err
@@ -548,16 +562,30 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	})
 	if err != nil {
 		isFatal := true
+		handled := false
 		if txerr, ok := err.(*transport.ErrTransportMessageConversion); ok {
 			isFatal = txerr.IsFatal()
+			handled = txerr.Handled()
 		}
-		if isFatal || event == nil {
+		if isFatal {
 			logger.Errorw("failed to convert http message to event", zap.Error(err))
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))
 			r.Error()
 			return
 		}
+		// if handled, do not pass to receiver.
+		if handled {
+			w.WriteHeader(http.StatusNoContent)
+			r.OK()
+			return
+		}
+	}
+	if event == nil {
+		logger.Error("failed to get non-nil event from MessageToEvent")
+		w.WriteHeader(http.StatusBadRequest)
+		r.Error()
+		return
 	}
 
 	resp, err := t.invokeReceiver(ctx, *event)

--- a/pkg/cloudevents/transport/http/transport_test.go
+++ b/pkg/cloudevents/transport/http/transport_test.go
@@ -106,6 +106,7 @@ func TestStableConnectionsToSingleHost(t *testing.T) {
 		Context: &cloudevents.EventContextV02{
 			SpecVersion: cloudevents.CloudEventsVersionV02,
 			Type:        "test.event",
+			ID:          "abc-123",
 			Source:      *types.ParseURLRef("test"),
 		},
 	}

--- a/test/http/conversion.go
+++ b/test/http/conversion.go
@@ -50,6 +50,10 @@ func UnitTestConvert(ctx context.Context, m transport.Message, err error) (*clou
 	return nil, err
 }
 
+func UnitTestConvertNilNil(context.Context, transport.Message, error) (*cloudevents.Event, error) {
+	return nil, nil
+}
+
 func ClientConversion(t *testing.T, tc ConversionTest, topts ...cehttp.Option) {
 	tap := NewTap()
 	server := httptest.NewServer(tap)

--- a/test/http/conversion_v02_test.go
+++ b/test/http/conversion_v02_test.go
@@ -47,3 +47,36 @@ func TestClientConversion_v02(t *testing.T) {
 		})
 	}
 }
+
+func TestClientConversion_nil(t *testing.T) {
+	now := time.Now()
+
+	testCases := ConversionTestCases{
+		"Conversion NOP": {
+			now:       now,
+			convertFn: UnitTestConvertNilNil,
+			data:      map[string]string{"hello": "unittest"},
+			want:      nil,
+			asSent: &TapValidation{
+				Method: "POST",
+				URI:    "/",
+				Header: map[string][]string{
+					"content-type": {"application/json"},
+				},
+				Body:          `{"hello":"unittest"}`,
+				ContentLength: 20,
+			},
+			asRecv: &TapValidation{
+				Header:        http.Header{},
+				Status:        "204 No Content",
+				ContentLength: 0,
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			ClientConversion(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
fixes: https://github.com/cloudevents/sdk-go/issues/175

Signed-off-by: Scott Nichols <nicholss@google.com>