### PR TITLE
Added Requester and async ack support.

### DIFF
--- a/pkg/binding/chan.go
+++ b/pkg/binding/chan.go
@@ -1,0 +1,52 @@
+package binding
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// ChanSender implements Sender by sending on a channel.
+type ChanSender chan<- Message
+
+// ChanReceiver implements Receiver by receiving from a channel.
+type ChanReceiver <-chan Message
+
+func (s ChanSender) Send(ctx context.Context, m Message) (err error) {
+	defer func() {
+		err2 := m.Finish(err)
+		if err == nil {
+			err = err2
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s <- m:
+		return nil
+	}
+}
+
+func (s ChanSender) Close(ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.New("send on closed channel")
+		}
+	}()
+	close(s)
+	return nil
+}
+
+func (r ChanReceiver) Receive(ctx context.Context) (Message, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case m, ok := <-r:
+		if !ok {
+			return nil, io.EOF
+		}
+		return m, nil
+	}
+}
+
+func (r ChanReceiver) Close(ctx context.Context) error { return nil }

--- a/pkg/binding/doc.go
+++ b/pkg/binding/doc.go
@@ -2,11 +2,14 @@
 
 Package binding defines interfaces for protocol bindings.
 
-NOTE: Most applications that emit or consume events can use the client
-package. This package is for implementing new protocol bindings and
-intermediaries; processes that forward events between protocols, rather than
-emitting or consuming events themselves.
+NOTE: Most applications that emit or consume events should use the ../client
+package, which provides a simpler API to the underlying binding.
 
+The interfaces in this package provide extra encoding and protocol information
+to allow efficient forwarding and end-to-end reliable delivery between a
+Receiver and a Sender belonging to different bindings. This is useful for
+intermediary applications that route or forward events, but not necessary for
+most "endpoint" applications that emit or consume events.
 
 Protocol Bindings
 

--- a/pkg/binding/interfaces.go
+++ b/pkg/binding/interfaces.go
@@ -81,12 +81,29 @@ type Receiver interface {
 
 // Sender sends messages.
 type Sender interface {
-	// Send blocks till the message is sent or ctx expires.
+	// Send a message.
+	//
+	// Send returns when the "outbound" message has been sent. The Sender may
+	// still be expecting acknowledgment or holding other state for the message.
+	//
+	// m.Finish() is called when sending is finished: expected acknowledgments (or
+	// errors) have been received, the Sender is no longer holding any state for
+	// the message. m.Finish() may be called during or after Send().
 	//
 	// To support optimized forwading of structured-mode messages, Send()
 	// should use the encoding returned by m.Structured() if there is one.
 	// Otherwise m.Event() can be encoded as per the binding's rules.
 	Send(ctx context.Context, m Message) error
+}
+
+// Requester sends a message and receives a response
+//
+// Optional interface that may be implemented by protocols that support
+// request/response correlation.
+type Requester interface {
+	// Request sends m like Sender.Send() but also arranges to receive a response.
+	// The returned Receiver is used to receive the response.
+	Request(ctx context.Context, m Message) (Receiver, error)
 }
 
 // Closer is the common interface for things that can be closed

--- a/pkg/binding/message.go
+++ b/pkg/binding/message.go
@@ -58,3 +58,23 @@ func Structured(m Message, f format.Format) ([]byte, error) {
 	}
 	return f.Marshal(e)
 }
+
+type finishMessage struct {
+	Message
+	finish func(error)
+}
+
+func (m finishMessage) Finish(err error) error {
+	err2 := m.Message.Finish(err) // Finish original message first
+	if m.finish != nil {
+		m.finish(err) // Notify callback
+	}
+	return err2
+}
+
+// WithFinish returns a wrapper for m that calls finish() and
+// m.Finish() in its Finish().
+// Allows code to be notified when a message is Finished.
+func WithFinish(m Message, finish func(error)) Message {
+	return finishMessage{Message: m, finish: finish}
+}


### PR DESCRIPTION
Requester supports request/response pattern.

Async ack is provided by WithFinish() - Sender does async send by
default (depends on QoS and binding), WithFinish() allows the caller
to be notified when Finish() is called.

Also added ChanSender/ChanReceiver - useful for testing so might as well make
them exported.

Fixes #227

Signed-off-by: Alan Conway <aconway@redhat.com>