### PR TITLE
WIP: Defaulting to V 1.0

### DIFF
--- a/pkg/binding/example_using_test.go
+++ b/pkg/binding/example_using_test.go
@@ -99,7 +99,7 @@ func Example_using() {
 	// Output:
 	// Validation: valid
 	// Context Attributes,
-	//   specversion: 0.2
+	//   specversion: 1.0
 	//   type: example.com/event
 	//   source: example.com/source
 	//   id: 0
@@ -108,7 +108,7 @@ func Example_using() {
 	//
 	// Validation: valid
 	// Context Attributes,
-	//   specversion: 0.2
+	//   specversion: 1.0
 	//   type: example.com/event
 	//   source: example.com/source
 	//   id: 1
@@ -117,7 +117,7 @@ func Example_using() {
 	//
 	// Validation: valid
 	// Context Attributes,
-	//   specversion: 0.2
+	//   specversion: 1.0
 	//   type: example.com/event
 	//   source: example.com/source
 	//   id: 2

--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -16,7 +16,7 @@ type Event struct {
 }
 
 const (
-	defaultEventVersion = CloudEventsVersionV02
+	defaultEventVersion = CloudEventsVersionV1
 )
 
 // New returns a new Event, an optional version can be passed to change the

--- a/pkg/cloudevents/event_reader_writer_test.go
+++ b/pkg/cloudevents/event_reader_writer_test.go
@@ -26,12 +26,17 @@ func TestEventRW_SpecVersion(t *testing.T) {
 		"empty v02": {
 			event: ce.New(),
 			set:   "0.2",
-			want:  "0.2",
+			wantErr: "invalid version",
 		},
 		"empty v03": {
 			event:   ce.New(),
 			set:     "0.3",
 			wantErr: "invalid version",
+		},
+		"empty v1": {
+			event: ce.New(),
+			set:   "1.0",
+			want:  "1.0",
 		},
 		"v01": {
 			event: ce.New("0.1"),
@@ -48,6 +53,11 @@ func TestEventRW_SpecVersion(t *testing.T) {
 			set:   "0.3",
 			want:  "0.3",
 		},
+		"v1": {
+			event: ce.New("1.0"),
+			set:   "1.0",
+			want:  "1.0",
+		},
 		"invalid v01": {
 			event:   ce.New("0.1"),
 			set:     "1.1",
@@ -60,6 +70,11 @@ func TestEventRW_SpecVersion(t *testing.T) {
 		},
 		"invalid v03": {
 			event:   ce.New("0.3"),
+			set:     "1.3",
+			wantErr: "invalid version",
+		},
+		"invalid v1": {
+			event:   ce.New("1.0"),
 			set:     "1.3",
 			wantErr: "invalid version",
 		},

--- a/test/http/conversion_v02_test.go
+++ b/test/http/conversion_v02_test.go
@@ -8,20 +8,20 @@ import (
 	"github.com/cloudevents/sdk-go"
 )
 
-func TestClientConversion_v02(t *testing.T) {
+func TestClientConversion_v1(t *testing.T) {
 	now := time.Now()
 
 	testCases := ConversionTestCases{
-		"Conversion v0.2": {
+		"Conversion v1.0": {
 			now:       now,
 			convertFn: UnitTestConvert,
 			data:      map[string]string{"hello": "unittest"},
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					ID:     "321-CBA",
 					Type:   "io.cloudevents.conversion.http.post",
-					Source: *cloudevents.ParseURLRef("github.com/cloudevents/test/http/conversion"),
-				}.AsV02(),
+					Source: *cloudevents.ParseURIRef("github.com/cloudevents/test/http/conversion"),
+				}.AsV1(),
 				Data: map[string]string{"hello": "unittest"},
 			},
 			asSent: &TapValidation{


### PR DESCRIPTION
Now that we have a release of 1.0  we should start defaulting to 1.0, instead of 0.2 
(not sure why 0.2 was choosen as the default for this SDK)

But moving forward, towards a 2.x version of the lib, we should not continue defaulting to an older, premature, release of this SDK (and the spec) 

