### PR TITLE
Fix extensions encoding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,16 +14,15 @@ jobs:
       - restore_cache:
           keys:
             - gomod-cache-{{ checksum "go.sum" }}
-
-      - run:
-          name: "Enforce Go Formatted Code"
-          command: "! go fmt ./... 2>&1 | read"
-      - run:
-          name: "Run go vet"
-          command: go vet ./...
       - run:
           name: "Check modules via go tidy"
           command: go mod tidy && git diff --exit-code go.{mod,sum}
+      - run:
+          name: "Enforce Go Formatted Code"
+          command: "! GO111MODULE=off go fmt ./... 2>&1 | read" # Avoid any dependency resolution
+      - run:
+          name: "Run go vet"
+          command: go vet ./...
       - run:
           name: Run unit tests
           command: |

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nats-io/nats-server/v2 v2.1.2
 	github.com/nats-io/nats.go v1.9.1
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.22.0
 	go.uber.org/atomic v1.4.0 // indirect

--- a/pkg/binding/test/events.go
+++ b/pkg/binding/test/events.go
@@ -31,16 +31,16 @@ func FullEvent() ce.Event {
 			DataSchema:      &schema,
 			DataContentType: strptr("text/json"),
 			Subject:         strptr("topic"),
-			Extensions: map[string]interface{}{
-				"exbool":   true,
-				"exint":    int32(42),
-				"exstring": "exstring",
-				"exbinary": []byte{0, 1, 2, 3},
-				"exurl":    source,
-				"extime":   timestamp.Time,
-			},
 		}.AsV1(),
 	}
+
+	e.SetExtension("exbool", true)
+	e.SetExtension("exint", 42)
+	e.SetExtension("exstring", "exstring")
+	e.SetExtension("exbinary", []byte{0, 1, 2, 3})
+	e.SetExtension("exurl", source)
+	e.SetExtension("extime", timestamp)
+
 	if err := e.SetData("hello"); err != nil {
 		panic(err)
 	}

--- a/pkg/bindings/amqp/amqp_test.go
+++ b/pkg/bindings/amqp/amqp_test.go
@@ -70,6 +70,7 @@ func exurl(e ce.Event) ce.Event {
 	if s, _ := types.Format(e.Extensions()["exurl"]); s != "" {
 		e.SetExtension("exurl", s)
 	}
+
 	return e
 }
 

--- a/pkg/bindings/amqp/encode.go
+++ b/pkg/bindings/amqp/encode.go
@@ -1,14 +1,13 @@
 package amqp
 
 import (
-	"net/url"
+	"pack.ag/amqp"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/format"
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
 	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"pack.ag/amqp"
 )
 
 // NewStruct returns a new structured amqp.Message
@@ -53,8 +52,14 @@ func NewBinary(e ce.Event) (*amqp.Message, error) {
 			return m, err
 		}
 		switch t := v.(type) {
-		case *url.URL: // Use string form of URLs.
+		case types.URI: // Use string form of URLs.
 			v = t.String()
+		case types.URIRef:
+			v = t.String()
+		case types.URLRef:
+			v = t.String()
+		case types.Timestamp:
+			v = t.Time
 		case int32: // Use AMQP long for Integer as per CE spec.
 			v = int64(t)
 		}

--- a/pkg/cloudevents/event_marshal.go
+++ b/pkg/cloudevents/event_marshal.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	errors2 "github.com/pkg/errors"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 )
 
@@ -222,11 +224,17 @@ func (e *Event) JsonDecodeV02(body []byte, raw map[string]json.RawMessage) error
 
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
+		ec.Extensions = extensions
 		for k, v := range raw {
 			k = strings.ToLower(k)
-			extensions[k] = v
+			var tmp interface{}
+			if err := json.Unmarshal(v, &tmp); err != nil {
+				return err
+			}
+			if err := ec.SetExtension(k, tmp); err != nil {
+				return errors2.Wrap(err, "Cannot set extension with key "+k)
+			}
 		}
-		ec.Extensions = extensions
 	}
 
 	e.Context = &ec
@@ -263,11 +271,17 @@ func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error
 
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
+		ec.Extensions = extensions
 		for k, v := range raw {
 			k = strings.ToLower(k)
-			extensions[k] = v
+			var tmp interface{}
+			if err := json.Unmarshal(v, &tmp); err != nil {
+				return err
+			}
+			if err := ec.SetExtension(k, tmp); err != nil {
+				return errors2.Wrap(err, "Cannot set extension with key "+k)
+			}
 		}
-		ec.Extensions = extensions
 	}
 
 	e.Context = &ec
@@ -312,15 +326,17 @@ func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error 
 
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
+		ec.Extensions = extensions
 		for k, v := range raw {
 			k = strings.ToLower(k)
-			var tmp string
+			var tmp interface{}
 			if err := json.Unmarshal(v, &tmp); err != nil {
 				return err
 			}
-			extensions[k] = tmp
+			if err := ec.SetExtension(k, tmp); err != nil {
+				return errors2.Wrap(err, "Cannot set extension with key "+k)
+			}
 		}
-		ec.Extensions = extensions
 	}
 
 	e.Context = &ec

--- a/pkg/cloudevents/event_marshal_test.go
+++ b/pkg/cloudevents/event_marshal_test.go
@@ -24,14 +24,17 @@ func TestMarshal(t *testing.T) {
 	now := types.Timestamp{Time: time.Now().UTC()}
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
+	sourceV1 := &types.URIRef{URL: *sourceUrl}
 
 	schemaUrl, _ := url.Parse("http://example.com/schema")
 	schema := &types.URLRef{URL: *schemaUrl}
+	schemaV1 := &types.URI{URL: *schemaUrl}
 
 	testCases := map[string]struct {
-		event   cloudevents.Event
-		want    []byte
-		wantErr *string
+		event           cloudevents.Event
+		eventExtensions map[string]interface{}
+		want            []byte
+		wantErr         *string
 	}{
 		"empty struct": {
 			event:   cloudevents.Event{},
@@ -47,18 +50,19 @@ func TestMarshal(t *testing.T) {
 					EventID:          "ABC-123",
 					EventTime:        &now,
 					ContentType:      cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"ex1": 42,
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV01(),
 				Data: DataExample{
 					AnInt:   42,
 					AString: "testing",
 				},
+			},
+			eventExtensions: map[string]interface{}{
+				"exbool":   true,
+				"exint":    int32(42),
+				"exstring": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    source,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"cloudEventsVersion": "0.1",
@@ -72,11 +76,12 @@ func TestMarshal(t *testing.T) {
 				"eventType":        "com.example.test",
 				"eventTypeVersion": "version1",
 				"extensions": map[string]interface{}{
-					"ex1": 42,
-					"ex2": "testing",
-					"ex3": map[string]interface{}{
-						"an": "inner key",
-					},
+					"exbool":   true,
+					"exint":    42,
+					"exstring": "exstring",
+					"exbinary": "AAECAw==",
+					"exurl":    "http://example.com/source",
+					"extime":   now.Format(time.RFC3339Nano),
 				},
 				"schemaURL": "http://example.com/schema",
 				"source":    "http://example.com/source",
@@ -91,18 +96,19 @@ func TestMarshal(t *testing.T) {
 					ID:          "ABC-123",
 					Time:        &now,
 					ContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"ex1": 42,
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV02(),
 				Data: DataExample{
 					AnInt:   42,
 					AString: "testing",
 				},
+			},
+			eventExtensions: map[string]interface{}{
+				"exbool":   true,
+				"exint":    int32(42),
+				"exstring": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    source,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"specversion": "0.2",
@@ -111,14 +117,15 @@ func TestMarshal(t *testing.T) {
 					"a": 42,
 					"b": "testing",
 				},
-				"id":   "ABC-123",
-				"time": now.Format(time.RFC3339Nano),
-				"type": "com.example.test",
-				"ex1":  42,
-				"ex2":  "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
+				"id":        "ABC-123",
+				"time":      now.Format(time.RFC3339Nano),
+				"type":      "com.example.test",
+				"exbool":    true,
+				"exint":     42,
+				"exstring":  "exstring",
+				"exbinary":  "AAECAw==",
+				"exurl":     "http://example.com/source",
+				"extime":    now.Format(time.RFC3339Nano),
 				"schemaurl": "http://example.com/schema",
 				"source":    "http://example.com/source",
 			}),
@@ -132,18 +139,19 @@ func TestMarshal(t *testing.T) {
 					ID:          "ABC-123",
 					Time:        &now,
 					ContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"eX1": 42,
-						"Ex2": "testing",
-						"EX3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV02(),
 				Data: DataExample{
 					AnInt:   42,
 					AString: "testing",
 				},
+			},
+			eventExtensions: map[string]interface{}{
+				"exBool":   true,
+				"Exint":    int32(42),
+				"EXSTRING": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    source,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"specversion": "0.2",
@@ -152,14 +160,15 @@ func TestMarshal(t *testing.T) {
 					"a": 42,
 					"b": "testing",
 				},
-				"id":   "ABC-123",
-				"time": now.Format(time.RFC3339Nano),
-				"type": "com.example.test",
-				"ex1":  42,
-				"ex2":  "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
+				"id":        "ABC-123",
+				"time":      now.Format(time.RFC3339Nano),
+				"type":      "com.example.test",
+				"exbool":    true,
+				"exint":     42,
+				"exstring":  "exstring",
+				"exbinary":  "AAECAw==",
+				"exurl":     "http://example.com/source",
+				"extime":    now.Format(time.RFC3339Nano),
 				"schemaurl": "http://example.com/schema",
 				"source":    "http://example.com/source",
 			}),
@@ -173,18 +182,19 @@ func TestMarshal(t *testing.T) {
 					ID:              "ABC-123",
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"ex1": 42,
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV03(),
 				Data: DataExample{
 					AnInt:   42,
 					AString: "testing",
 				},
+			},
+			eventExtensions: map[string]interface{}{
+				"exbool":   true,
+				"exint":    int32(42),
+				"exstring": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    source,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"specversion":     "0.3",
@@ -193,14 +203,15 @@ func TestMarshal(t *testing.T) {
 					"a": 42,
 					"b": "testing",
 				},
-				"id":   "ABC-123",
-				"time": now.Format(time.RFC3339Nano),
-				"type": "com.example.test",
-				"ex1":  42,
-				"ex2":  "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
+				"id":        "ABC-123",
+				"time":      now.Format(time.RFC3339Nano),
+				"type":      "com.example.test",
+				"exbool":    true,
+				"exint":     42,
+				"exstring":  "exstring",
+				"exbinary":  "AAECAw==",
+				"exurl":     "http://example.com/source",
+				"extime":    now.Format(time.RFC3339Nano),
 				"schemaurl": "http://example.com/schema",
 				"source":    "http://example.com/source",
 			}),
@@ -214,14 +225,15 @@ func TestMarshal(t *testing.T) {
 					ID:              "ABC-123",
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"ex1": 42,
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV03(),
+			},
+			eventExtensions: map[string]interface{}{
+				"exbool":   true,
+				"exint":    int32(42),
+				"exstring": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    source,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"specversion":     "0.3",
@@ -229,13 +241,14 @@ func TestMarshal(t *testing.T) {
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
-				"ex1":             42,
-				"ex2":             "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
-				"schemaurl": "http://example.com/schema",
-				"source":    "http://example.com/source",
+				"exbool":          true,
+				"exint":           42,
+				"exstring":        "exstring",
+				"exbinary":        "AAECAw==",
+				"exurl":           "http://example.com/source",
+				"extime":          now.Format(time.RFC3339Nano),
+				"schemaurl":       "http://example.com/schema",
+				"source":          "http://example.com/source",
 			}),
 		},
 		"string data v0.3": {
@@ -247,15 +260,16 @@ func TestMarshal(t *testing.T) {
 					ID:              "ABC-123",
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"ex1": 42,
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV03(),
 				Data: "This is a string.",
+			},
+			eventExtensions: map[string]interface{}{
+				"exbool":   true,
+				"exint":    int32(42),
+				"exstring": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    source,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"specversion":     "0.3",
@@ -264,114 +278,38 @@ func TestMarshal(t *testing.T) {
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
-				"ex1":             42,
-				"ex2":             "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
-				"schemaurl": "http://example.com/schema",
-				"source":    "http://example.com/source",
-			}),
-		},
-	}
-	for n, tc := range testCases {
-		t.Run(n, func(t *testing.T) {
-
-			gotBytes, err := json.Marshal(tc.event)
-
-			if tc.wantErr != nil || err != nil {
-				if diff := cmp.Diff(*tc.wantErr, err.Error()); diff != "" {
-					t.Errorf("unexpected error (-want, +got) = %v", diff)
-				}
-				return
-			}
-
-			// so we can understand the diff, turn bytes to strings
-			want := string(tc.want)
-			got := string(gotBytes)
-
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("unexpected event (-want, +got) = %v", diff)
-			}
-		})
-	}
-}
-
-func TestMarshalv1(t *testing.T) {
-	now := types.Timestamp{Time: time.Now().UTC()}
-	sourceUrl, _ := url.Parse("http://example.com/source")
-	source := &types.URIRef{URL: *sourceUrl}
-
-	schemaUrl, _ := url.Parse("http://example.com/schema")
-	schema := &types.URI{URL: *schemaUrl}
-
-	testCases := map[string]struct {
-		event   cloudevents.Event
-		want    []byte
-		wantErr *string
-	}{
-		"v1.0 cased extensions": {
-			event: cloudevents.Event{
-				Context: cloudevents.EventContextV1{
-					Type:            "com.example.test",
-					Source:          *source,
-					DataSchema:      schema,
-					ID:              "ABC-123",
-					Time:            &now,
-					DataContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"eX1": 42,
-						"Ex2": "testing",
-						"EX3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
-				}.AsV1(),
-				Data: DataExample{
-					AnInt:   42,
-					AString: "testing",
-				},
-			},
-			want: toBytes(map[string]interface{}{
-				"specversion":     "1.0",
-				"datacontenttype": "application/json",
-				"data": map[string]interface{}{
-					"a": 42,
-					"b": "testing",
-				},
-				"id":   "ABC-123",
-				"time": now.Format(time.RFC3339Nano),
-				"type": "com.example.test",
-				"ex1":  42,
-				"ex2":  "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
-				"dataschema": "http://example.com/schema",
-				"source":     "http://example.com/source",
+				"exbool":          true,
+				"exint":           42,
+				"exstring":        "exstring",
+				"exbinary":        "AAECAw==",
+				"exurl":           "http://example.com/source",
+				"extime":          now.Format(time.RFC3339Nano),
+				"schemaurl":       "http://example.com/schema",
+				"source":          "http://example.com/source",
 			}),
 		},
 		"struct data v1.0": {
 			event: cloudevents.Event{
 				Context: cloudevents.EventContextV1{
 					Type:            "com.example.test",
-					Source:          *source,
-					DataSchema:      schema,
+					Source:          *sourceV1,
+					DataSchema:      schemaV1,
 					ID:              "ABC-123",
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"ex1": 42,
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV1(),
 				Data: DataExample{
 					AnInt:   42,
 					AString: "testing",
 				},
+			},
+			eventExtensions: map[string]interface{}{
+				"exbool":   true,
+				"exint":    int32(42),
+				"exstring": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    sourceV1,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"specversion":     "1.0",
@@ -380,14 +318,15 @@ func TestMarshalv1(t *testing.T) {
 					"a": 42,
 					"b": "testing",
 				},
-				"id":   "ABC-123",
-				"time": now.Format(time.RFC3339Nano),
-				"type": "com.example.test",
-				"ex1":  42,
-				"ex2":  "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
+				"id":         "ABC-123",
+				"time":       now.Format(time.RFC3339Nano),
+				"type":       "com.example.test",
+				"exbool":     true,
+				"exint":      42,
+				"exstring":   "exstring",
+				"exbinary":   "AAECAw==",
+				"exurl":      "http://example.com/source",
+				"extime":     now.Format(time.RFC3339Nano),
 				"dataschema": "http://example.com/schema",
 				"source":     "http://example.com/source",
 			}),
@@ -396,19 +335,20 @@ func TestMarshalv1(t *testing.T) {
 			event: cloudevents.Event{
 				Context: cloudevents.EventContextV1{
 					Type:            "com.example.test",
-					Source:          *source,
-					DataSchema:      schema,
+					Source:          *sourceV1,
+					DataSchema:      schemaV1,
 					ID:              "ABC-123",
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"ex1": 42,
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV1(),
+			},
+			eventExtensions: map[string]interface{}{
+				"exbool":   true,
+				"exint":    int32(42),
+				"exstring": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    sourceV1,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"specversion":     "1.0",
@@ -416,33 +356,35 @@ func TestMarshalv1(t *testing.T) {
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
-				"ex1":             42,
-				"ex2":             "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
-				"dataschema": "http://example.com/schema",
-				"source":     "http://example.com/source",
+				"exbool":          true,
+				"exint":           42,
+				"exstring":        "exstring",
+				"exbinary":        "AAECAw==",
+				"exurl":           "http://example.com/source",
+				"extime":          now.Format(time.RFC3339Nano),
+				"dataschema":      "http://example.com/schema",
+				"source":          "http://example.com/source",
 			}),
 		},
 		"string data v1.0": {
 			event: cloudevents.Event{
 				Context: cloudevents.EventContextV1{
 					Type:            "com.example.test",
-					Source:          *source,
-					DataSchema:      schema,
+					Source:          *sourceV1,
+					DataSchema:      schemaV1,
 					ID:              "ABC-123",
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
-					Extensions: map[string]interface{}{
-						"ex1": 42,
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
-					},
 				}.AsV1(),
 				Data: "This is a string.",
+			},
+			eventExtensions: map[string]interface{}{
+				"exbool":   true,
+				"exint":    int32(42),
+				"exstring": "exstring",
+				"exbinary": []byte{0, 1, 2, 3},
+				"exurl":    sourceV1,
+				"extime":   &now,
 			},
 			want: toBytes(map[string]interface{}{
 				"specversion":     "1.0",
@@ -451,20 +393,27 @@ func TestMarshalv1(t *testing.T) {
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
-				"ex1":             42,
-				"ex2":             "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
-				"dataschema": "http://example.com/schema",
-				"source":     "http://example.com/source",
+				"exbool":          true,
+				"exint":           42,
+				"exstring":        "exstring",
+				"exbinary":        "AAECAw==",
+				"exurl":           "http://example.com/source",
+				"extime":          now.Format(time.RFC3339Nano),
+				"dataschema":      "http://example.com/schema",
+				"source":          "http://example.com/source",
 			}),
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 
-			gotBytes, err := json.Marshal(tc.event)
+			event := tc.event
+
+			for k, v := range tc.eventExtensions {
+				event.SetExtension(k, v)
+			}
+
+			gotBytes, err := json.Marshal(event)
 
 			if tc.wantErr != nil || err != nil {
 				if diff := cmp.Diff(*tc.wantErr, err.Error()); diff != "" {
@@ -488,9 +437,11 @@ func TestUnmarshal(t *testing.T) {
 	now := types.Timestamp{Time: time.Now().UTC()}
 	sourceUrl, _ := url.Parse("http://example.com/source")
 	source := &types.URLRef{URL: *sourceUrl}
+	sourceV1 := &types.URIRef{URL: *sourceUrl}
 
 	schemaUrl, _ := url.Parse("http://example.com/schema")
 	schema := &types.URLRef{URL: *schemaUrl}
+	schemaV1 := &types.URI{URL: *schemaUrl}
 
 	testCases := map[string]struct {
 		body    []byte
@@ -510,11 +461,12 @@ func TestUnmarshal(t *testing.T) {
 				"eventType":        "com.example.test",
 				"eventTypeVersion": "version1",
 				"extensions": map[string]interface{}{
-					"ex1": 42,
-					"ex2": "testing",
-					"ex3": map[string]interface{}{
-						"an": "inner key",
-					},
+					"exbool":   true,
+					"exint":    42,
+					"exstring": "exstring",
+					"exbinary": "AAECAw==",
+					"exurl":    "http://example.com/source",
+					"extime":   now.Format(time.RFC3339Nano),
 				},
 				"schemaURL": "http://example.com/schema",
 				"source":    "http://example.com/source",
@@ -529,11 +481,13 @@ func TestUnmarshal(t *testing.T) {
 					EventTime:        &now,
 					ContentType:      cloudevents.StringOfApplicationJSON(),
 					Extensions: map[string]interface{}{
-						"ex1": float64(42), // json auto-creates float64 from int.
-						"ex2": "testing",
-						"ex3": map[string]interface{}{
-							"an": "inner key",
-						},
+						"exbool":   true, // Boolean should be preserved
+						"exint":    float64(42),
+						"exstring": "exstring",
+						// Since byte, url and time are encoded as string, the unmarshal should just convert them to string
+						"exbinary": "AAECAw==",
+						"exurl":    "http://example.com/source",
+						"extime":   now.Format(time.RFC3339Nano),
 					},
 				}.AsV01(),
 				Data: toBytes(DataExample{
@@ -551,14 +505,15 @@ func TestUnmarshal(t *testing.T) {
 					"a": 42,
 					"b": "testing",
 				},
-				"id":   "ABC-123",
-				"time": now.Format(time.RFC3339Nano),
-				"type": "com.example.test",
-				"ex1":  42,
-				"ex2":  "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
+				"id":        "ABC-123",
+				"time":      now.Format(time.RFC3339Nano),
+				"type":      "com.example.test",
+				"exbool":    true,
+				"exint":     42,
+				"exstring":  "exstring",
+				"exbinary":  "AAECAw==",
+				"exurl":     "http://example.com/source",
+				"extime":    now.Format(time.RFC3339Nano),
 				"schemaurl": "http://example.com/schema",
 				"source":    "http://example.com/source",
 			}),
@@ -571,11 +526,13 @@ func TestUnmarshal(t *testing.T) {
 					Time:        &now,
 					ContentType: cloudevents.StringOfApplicationJSON(),
 					Extensions: map[string]interface{}{
-						"ex1": toRawMessage(float64(42)),
-						"ex2": toRawMessage("testing"),
-						"ex3": toRawMessage(map[string]interface{}{
-							"an": "inner key",
-						}),
+						"exbool":   true, // Boolean should be preserved
+						"exint":    float64(42),
+						"exstring": "exstring",
+						// Since byte, url and time are encoded as string, the unmarshal should just convert them to string
+						"exbinary": "AAECAw==",
+						"exurl":    "http://example.com/source",
+						"extime":   now.Format(time.RFC3339Nano),
 					},
 				}.AsV02(),
 				Data: toBytes(DataExample{
@@ -593,14 +550,15 @@ func TestUnmarshal(t *testing.T) {
 					"a": 42,
 					"b": "testing",
 				},
-				"id":   "ABC-123",
-				"time": now.Format(time.RFC3339Nano),
-				"type": "com.example.test",
-				"ex1":  42,
-				"ex2":  "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
+				"id":        "ABC-123",
+				"time":      now.Format(time.RFC3339Nano),
+				"type":      "com.example.test",
+				"exbool":    true,
+				"exint":     42,
+				"exstring":  "exstring",
+				"exbinary":  "AAECAw==",
+				"exurl":     "http://example.com/source",
+				"extime":    now.Format(time.RFC3339Nano),
 				"schemaurl": "http://example.com/schema",
 				"source":    "http://example.com/source",
 			}),
@@ -613,11 +571,13 @@ func TestUnmarshal(t *testing.T) {
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
 					Extensions: map[string]interface{}{
-						"ex1": toRawMessage(float64(42)),
-						"ex2": toRawMessage("testing"),
-						"ex3": toRawMessage(map[string]interface{}{
-							"an": "inner key",
-						}),
+						"exbool":   true, // Boolean should be preserved
+						"exint":    int32(42),
+						"exstring": "exstring",
+						// Since byte, url and time are encoded as string, the unmarshal should just convert them to string
+						"exbinary": "AAECAw==",
+						"exurl":    "http://example.com/source",
+						"extime":   now.Format(time.RFC3339Nano),
 					},
 				}.AsV03(),
 				Data: toBytes(DataExample{
@@ -635,13 +595,14 @@ func TestUnmarshal(t *testing.T) {
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
-				"ex1":             42,
-				"ex2":             "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
-				"schemaurl": "http://example.com/schema",
-				"source":    "http://example.com/source",
+				"exbool":          true,
+				"exint":           42,
+				"exstring":        "exstring",
+				"exbinary":        "AAECAw==",
+				"exurl":           "http://example.com/source",
+				"extime":          now.Format(time.RFC3339Nano),
+				"schemaurl":       "http://example.com/schema",
+				"source":          "http://example.com/source",
 			}),
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV03{
@@ -652,11 +613,13 @@ func TestUnmarshal(t *testing.T) {
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
 					Extensions: map[string]interface{}{
-						"ex1": toRawMessage(float64(42)),
-						"ex2": toRawMessage("testing"),
-						"ex3": toRawMessage(map[string]interface{}{
-							"an": "inner key",
-						}),
+						"exbool":   true, // Boolean should be preserved
+						"exint":    int32(42),
+						"exstring": "exstring",
+						// Since byte, url and time are encoded as string, the unmarshal should just convert them to string
+						"exbinary": "AAECAw==",
+						"exurl":    "http://example.com/source",
+						"extime":   now.Format(time.RFC3339Nano),
 					},
 				}.AsV03(),
 				Data:        toBytes("This is a string."),
@@ -670,13 +633,14 @@ func TestUnmarshal(t *testing.T) {
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
-				"ex1":             42,
-				"ex2":             "testing",
-				"ex3": map[string]interface{}{
-					"an": "inner key",
-				},
-				"schemaurl": "http://example.com/schema",
-				"source":    "http://example.com/source",
+				"exbool":          true,
+				"exint":           42,
+				"exstring":        "exstring",
+				"exbinary":        "AAECAw==",
+				"exurl":           "http://example.com/source",
+				"extime":          now.Format(time.RFC3339Nano),
+				"schemaurl":       "http://example.com/schema",
+				"source":          "http://example.com/source",
 			}),
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV03{
@@ -687,13 +651,135 @@ func TestUnmarshal(t *testing.T) {
 					Time:            &now,
 					DataContentType: cloudevents.StringOfApplicationJSON(),
 					Extensions: map[string]interface{}{
-						"ex1": toRawMessage(float64(42)),
-						"ex2": toRawMessage("testing"),
-						"ex3": toRawMessage(map[string]interface{}{
-							"an": "inner key",
-						}),
+						"exbool":   true, // Boolean should be preserved
+						"exint":    int32(42),
+						"exstring": "exstring",
+						// Since byte, url and time are encoded as string, the unmarshal should just convert them to string
+						"exbinary": "AAECAw==",
+						"exurl":    "http://example.com/source",
+						"extime":   now.Format(time.RFC3339Nano),
 					},
 				}.AsV03(),
+			},
+		},
+		"struct data v1.0": {
+			body: toBytes(map[string]interface{}{
+				"specversion":     "1.0",
+				"datacontenttype": "application/json",
+				"data": map[string]interface{}{
+					"a": 42,
+					"b": "testing",
+				},
+				"id":         "ABC-123",
+				"time":       now.Format(time.RFC3339Nano),
+				"type":       "com.example.test",
+				"exbool":     true,
+				"exint":      42,
+				"exstring":   "exstring",
+				"exbinary":   "AAECAw==",
+				"exurl":      "http://example.com/source",
+				"extime":     now.Format(time.RFC3339Nano),
+				"dataschema": "http://example.com/schema",
+				"source":     "http://example.com/source",
+			}),
+			want: &cloudevents.Event{
+				Context: cloudevents.EventContextV1{
+					Type:            "com.example.test",
+					Source:          *sourceV1,
+					DataSchema:      schemaV1,
+					ID:              "ABC-123",
+					Time:            &now,
+					DataContentType: cloudevents.StringOfApplicationJSON(),
+					Extensions: map[string]interface{}{
+						"exbool":   true, // Boolean should be preserved
+						"exint":    int32(42),
+						"exstring": "exstring",
+						// Since byte, url and time are encoded as string, the unmarshal should just convert them to string
+						"exbinary": "AAECAw==",
+						"exurl":    "http://example.com/source",
+						"extime":   now.Format(time.RFC3339Nano),
+					},
+				}.AsV1(),
+				Data: toBytes(DataExample{
+					AnInt:   42,
+					AString: "testing",
+				}),
+				DataEncoded: true,
+			},
+		},
+		"string data v1.0": {
+			body: toBytes(map[string]interface{}{
+				"specversion":     "1.0",
+				"datacontenttype": "application/json",
+				"data":            "This is a string.",
+				"id":              "ABC-123",
+				"time":            now.Format(time.RFC3339Nano),
+				"type":            "com.example.test",
+				"exbool":          true,
+				"exint":           42,
+				"exstring":        "exstring",
+				"exbinary":        "AAECAw==",
+				"exurl":           "http://example.com/source",
+				"extime":          now.Format(time.RFC3339Nano),
+				"dataschema":      "http://example.com/schema",
+				"source":          "http://example.com/source",
+			}),
+			want: &cloudevents.Event{
+				Context: cloudevents.EventContextV1{
+					Type:            "com.example.test",
+					Source:          *sourceV1,
+					DataSchema:      schemaV1,
+					ID:              "ABC-123",
+					Time:            &now,
+					DataContentType: cloudevents.StringOfApplicationJSON(),
+					Extensions: map[string]interface{}{
+						"exbool":   true, // Boolean should be preserved
+						"exint":    int32(42),
+						"exstring": "exstring",
+						// Since byte, url and time are encoded as string, the unmarshal should just convert them to string
+						"exbinary": "AAECAw==",
+						"exurl":    "http://example.com/source",
+						"extime":   now.Format(time.RFC3339Nano),
+					},
+				}.AsV1(),
+				Data:        toBytes("This is a string."),
+				DataEncoded: true,
+			},
+		},
+		"nil data v1.0": {
+			body: toBytes(map[string]interface{}{
+				"specversion":     "1.0",
+				"datacontenttype": "application/json",
+				"id":              "ABC-123",
+				"time":            now.Format(time.RFC3339Nano),
+				"type":            "com.example.test",
+				"exbool":          true,
+				"exint":           42,
+				"exstring":        "exstring",
+				"exbinary":        "AAECAw==",
+				"exurl":           "http://example.com/source",
+				"extime":          now.Format(time.RFC3339Nano),
+				"dataschema":      "http://example.com/schema",
+				"source":          "http://example.com/source",
+			}),
+			want: &cloudevents.Event{
+				Context: cloudevents.EventContextV1{
+					Type:            "com.example.test",
+					Source:          *sourceV1,
+					DataSchema:      schemaV1,
+					ID:              "ABC-123",
+					Time:            &now,
+					DataContentType: cloudevents.StringOfApplicationJSON(),
+					Extensions: map[string]interface{}{
+						"exbool":   true, // Boolean should be preserved
+						"exint":    int32(42),
+						"exstring": "exstring",
+						// Since byte, url and time are encoded as string, the unmarshal should just convert them to string
+						"exbinary": "AAECAw==",
+						"exurl":    "http://example.com/source",
+						"extime":   now.Format(time.RFC3339Nano),
+					},
+				}.AsV1(),
 			},
 		},
 	}
@@ -723,8 +809,4 @@ func toBytes(body interface{}) []byte {
 		return []byte(fmt.Sprintf(`{"error":%q}`, err.Error()))
 	}
 	return b
-}
-
-func toRawMessage(body interface{}) json.RawMessage {
-	return toBytes(body)
 }

--- a/pkg/cloudevents/eventcontext.go
+++ b/pkg/cloudevents/eventcontext.go
@@ -79,6 +79,8 @@ type EventContextWriter interface {
 	// SetExtension sets the given interface onto the extension attributes
 	// determined by the provided name.
 	//
+	// This function fails in V1 if the name doesn't respect the regex ^[a-zA-Z0-9]+$
+	//
 	// Package ./types documents the types that are allowed as extension values.
 	SetExtension(string, interface{}) error
 }

--- a/pkg/cloudevents/eventcontext_v1.go
+++ b/pkg/cloudevents/eventcontext_v1.go
@@ -73,8 +73,9 @@ func (ec EventContextV1) ExtensionAs(name string, obj interface{}) error {
 }
 
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
+// This function fails if the name doesn't respect the regex ^[a-zA-Z0-9]+$
 func (ec *EventContextV1) SetExtension(name string, value interface{}) error {
-	if !IsAlphaNumericLowercaseLetters(name) {
+	if !IsAlphaNumeric(name) {
 		return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set")
 	}
 

--- a/pkg/cloudevents/extensions.go
+++ b/pkg/cloudevents/extensions.go
@@ -27,4 +27,4 @@ func caseInsensitiveSearch(key string, space map[string]interface{}) (interface{
 	return nil, false
 }
 
-var IsAlphaNumericLowercaseLetters = regexp.MustCompile(`^[a-z0-9]+$`).MatchString
+var IsAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString

--- a/pkg/cloudevents/transport/http/codec_v02_test.go
+++ b/pkg/cloudevents/transport/http/codec_v02_test.go
@@ -2,7 +2,6 @@ package http_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/url"
 	"testing"
 	"time"
@@ -366,7 +365,7 @@ func TestCodecV02_Decode(t *testing.T) {
 					ContentType: cloudevents.StringOfApplicationJSON(),
 					Source:      *source,
 					Extensions: map[string]interface{}{
-						"test": json.RawMessage(`"extended"`),
+						"test": "extended",
 					},
 				},
 				Data: toBytes(map[string]interface{}{

--- a/pkg/cloudevents/transport/http/codec_v03_test.go
+++ b/pkg/cloudevents/transport/http/codec_v03_test.go
@@ -2,7 +2,6 @@ package http_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/url"
 	"testing"
 	"time"
@@ -513,7 +512,7 @@ func TestCodecV03_Decode(t *testing.T) {
 					Source:          *source,
 					Subject:         &subject,
 					Extensions: map[string]interface{}{
-						"test": json.RawMessage(`"extended"`),
+						"test": "extended",
 					},
 				}.AsV03(),
 				Data: toBytes(map[string]interface{}{
@@ -554,7 +553,7 @@ func TestCodecV03_Decode(t *testing.T) {
 					Source:              *source,
 					Subject:             &subject,
 					Extensions: map[string]interface{}{
-						"test": json.RawMessage(`"extended"`),
+						"test": "extended",
 					},
 				}.AsV03(),
 				Data:        []byte(`"eyJoZWxsbyI6IndvcmxkIn0="`), // TODO: structured comes in quoted. Unquote?

--- a/pkg/cloudevents/transport/nats/codec_v02_test.go
+++ b/pkg/cloudevents/transport/nats/codec_v02_test.go
@@ -2,7 +2,6 @@ package nats_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/url"
 	"testing"
 	"time"
@@ -236,7 +235,7 @@ func TestCodecV02_Decode(t *testing.T) {
 					ContentType: cloudevents.StringOfApplicationJSON(),
 					Source:      *source,
 					Extensions: map[string]interface{}{
-						"test": json.RawMessage(`"extended"`),
+						"test": "extended",
 					},
 				},
 				Data: toBytes(map[string]interface{}{

--- a/pkg/cloudevents/transport/nats/codec_v03_test.go
+++ b/pkg/cloudevents/transport/nats/codec_v03_test.go
@@ -2,15 +2,15 @@ package nats_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/url"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/nats"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestCodecV03_Encode(t *testing.T) {
@@ -236,7 +236,7 @@ func TestCodecV03_Decode(t *testing.T) {
 					DataContentType: cloudevents.StringOfApplicationJSON(),
 					Source:          *source,
 					Extensions: map[string]interface{}{
-						"test": json.RawMessage(`"extended"`),
+						"test": "extended",
 					},
 				},
 				Data: toBytes(map[string]interface{}{

--- a/pkg/cloudevents/transport/nats/options_test.go
+++ b/pkg/cloudevents/transport/nats/options_test.go
@@ -59,7 +59,7 @@ func TestWithConnOptions(t *testing.T) {
 
 	srv, err := natsd.NewServer(&natsd.Options{Port: -1})
 	if err != nil {
-		t.Errorf("could not start nats server: %w", err)
+		t.Errorf("could not start nats server: %s", err)
 	}
 	go srv.Start()
 	defer srv.Shutdown()
@@ -70,7 +70,7 @@ func TestWithConnOptions(t *testing.T) {
 
 	tr, err := New(srv.Addr().String(), "testing", WithConnOptions(opts...))
 	if err != nil {
-		t.Errorf("connection failed: %w", err)
+		t.Errorf("connection failed: %s", err)
 	}
 
 	if !tr.Conn.Opts.NoRandomize {

--- a/pkg/cloudevents/transport/pubsub/codec_v03_test.go
+++ b/pkg/cloudevents/transport/pubsub/codec_v03_test.go
@@ -2,7 +2,6 @@ package pubsub_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/url"
 	"testing"
 	"time"
@@ -254,7 +253,7 @@ func TestCodecV03_Decode(t *testing.T) {
 					DataContentType: cloudevents.StringOfApplicationJSON(),
 					Source:          *source,
 					Extensions: map[string]interface{}{
-						"test": json.RawMessage(`"extended"`),
+						"test": "extended",
 					},
 				},
 				Data: toBytes(map[string]interface{}{

--- a/test/http/loopback_setters_test.go
+++ b/test/http/loopback_setters_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -543,7 +542,7 @@ func TestClientLoopback_setters_structured_json_base64(t *testing.T) {
 						Source:      *cloudevents.ParseURLRef("/unit/test/client"),
 						ContentType: cloudevents.StringOfApplicationJSON(),
 						Extensions: map[string]interface{}{
-							"datacontentencoding": json.RawMessage(`"base64"`),
+							"datacontentencoding": "base64",
 						},
 					}.AsV02(),
 					Data: map[string]string{"unittest": "response"},


### PR DESCRIPTION
Fixes #273 

## Breaking changes

* Now extension map doesn't contain (and should not contain anymore) `net.URL` & `time.Time` (and pointers). **Users that wants to modify this map manually should keep in mind these changes**
* Unmarshalled extension types from json are now coherent between different spec versions (they are always unmarshalled as go types)