### PR TITLE
ack support for http longpull

### DIFF
--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -301,8 +301,6 @@ func (t *Transport) StartReceiver(ctx context.Context) error {
 	t.reMu.Lock()
 	defer t.reMu.Unlock()
 
-	// TODO： 第一步，先捕获 ERROR
-
 	if t.LongPollReq != nil {
 		go func() { _ = t.longPollStart(ctx) }()
 	}

--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -23,6 +23,8 @@ import (
 
 // Transport adheres to transport.Transport.
 var _ transport.Transport = (*Transport)(nil)
+var longPullLastAckID string
+
 
 const (
 	// DefaultShutdownTimeout defines the default timeout given to the http.Server when calling Shutdown.
@@ -299,6 +301,8 @@ func (t *Transport) StartReceiver(ctx context.Context) error {
 	t.reMu.Lock()
 	defer t.reMu.Unlock()
 
+	// TODO： 第一步，先捕获 ERROR
+
 	if t.LongPollReq != nil {
 		go func() { _ = t.longPollStart(ctx) }()
 	}
@@ -386,6 +390,11 @@ func (t *Transport) longPollStart(ctx context.Context) error {
 
 	go func(ch chan<- Message) {
 		for {
+			if longPullLastAckID != "" {
+				req.Header.Set("Last-Ack-Id", longPullLastAckID)
+			} else {
+				req.Header.Del("Last-Ack-Id")
+			}
 			if resp, err := t.LongPollClient.Do(req); err != nil {
 				logger.Errorw("long poll request returned error", err)
 				uErr := err.(*url.Error)
@@ -434,6 +443,17 @@ func (t *Transport) longPollStart(ctx context.Context) error {
 				// TODO: deliver event.
 				if _, err := t.invokeReceiver(ctx, *event); err != nil {
 					logger.Errorw("could not invoke receiver event", zap.Error(err))
+				} else {
+					var ackIDHasSet bool
+					if ackID, err := event.Context.GetExtension("ack-id"); err == nil {
+						if s, ok := ackID.(string); ok {
+							longPullLastAckID = s
+							ackIDHasSet = true
+						}
+					}
+					if !ackIDHasSet {
+						longPullLastAckID = ""
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# The http long pull does not support ack Strategy

So Here is my solution like "EventSource"

```
+-------------------+                            +-----------------+
|                   |                            |                 |
|                   |                            |                 |
| Long Pull Server  |                            |      Client     |
|                   |                            |                 |
|                   |                            |                 |
+--------+----------+                            +-------+---------+
         |                                               |
         <-----------------------------------------------+
         |                                               |
         +-------------------+ ACK ID +----------------->+
         |                                               |
         <----------------+ Last-ACK-ID +----------------+
         |                                               |
         +---------------------------------------------->+
         |                                               |
         |                                               |
+--------+----------+                           +--------+---------+
|                   |                           |                  |
|                   |                           |                  |
| Long Pull Server  |                           |      Client      |
|                   |                           |                  |
|                   |                           |                  |
+-------------------+                           +------------------+
```

The long pull server send `ack-id` if the message need ack, the client will and the `Last-ACK-ID` header in next pull
