### PR TITLE
Enable a binding.Message to be consumed more times

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/nats-io/nats.go v1.9.1
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
+	github.com/valyala/bytebufferpool v1.0.0
 	go.opencensus.io v0.22.0
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/pkg/binding/acks_before_finish_message.go
+++ b/pkg/binding/acks_before_finish_message.go
@@ -1,0 +1,23 @@
+package binding
+
+import "sync/atomic"
+
+type acksMessage struct {
+	Message
+	requiredAcks int32
+}
+
+func (m *acksMessage) Finish(err error) error {
+	remainingAcks := atomic.AddInt32(&m.requiredAcks, -1)
+	if remainingAcks == 0 {
+		return m.Message.Finish(err)
+	}
+	return nil
+}
+
+// WithAcksBeforeFinish returns a wrapper for m that calls m.Finish()
+// only after the specified number of acks are received.
+// Use it when you need to route a Message to more Sender instances
+func WithAcksBeforeFinish(m Message, requiredAcks int) Message {
+	return &acksMessage{Message: m, requiredAcks: int32(requiredAcks)}
+}

--- a/pkg/binding/acks_before_finish_message_test.go
+++ b/pkg/binding/acks_before_finish_message_test.go
@@ -1,0 +1,46 @@
+package binding
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+)
+
+func TestWithAcksBeforeFinish(t *testing.T) {
+	var testEvent = cloudevents.Event{
+		Data:        []byte(`"data"`),
+		DataEncoded: true,
+		Context: cloudevents.EventContextV1{
+			DataContentType: cloudevents.StringOfApplicationJSON(),
+			Source:          types.URIRef{URL: url.URL{Path: "source"}},
+			ID:              "id",
+			Type:            "type"}.AsV1(),
+	}
+
+	finishCalled := false
+	finishMessage := WithFinish(EventMessage(testEvent), func(err error) {
+		finishCalled = true
+	})
+
+	wg := sync.WaitGroup{}
+
+	messageToTest := WithAcksBeforeFinish(finishMessage, 1000)
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func(m Message) {
+			ch := make(chan Message, 1)
+			assert.NoError(t, ChanSender(ch).Send(context.Background(), m))
+			<-ch
+			wg.Done()
+		}(messageToTest)
+	}
+
+	wg.Wait()
+	assert.True(t, finishCalled)
+}

--- a/pkg/binding/interfaces.go
+++ b/pkg/binding/interfaces.go
@@ -33,6 +33,8 @@ import (
 // to a Sender, they may not be implemented by all Message instances. A Sender should
 // try each method of interest and fall back to Event(EventEncoder) if none are supported.
 //
+// The message should be "consumable" several times, meaning that its methods to visit it can be called several times.
+//
 type Message interface {
 	// Structured transfers a structured-mode event to a StructuredEncoder.
 	// Returns ErrNotStructured if message is not in structured mode.

--- a/pkg/binding/interfaces.go
+++ b/pkg/binding/interfaces.go
@@ -84,13 +84,26 @@ var ErrNotStructured = errors.New("message is not in structured mode")
 // ErrNotBinary returned by Message.Binary for non-binary messages.
 var ErrNotBinary = errors.New("message is not in binary mode")
 
+// MessagePayload allows to read a message payload or as a byte array or as a reader
+// Message implementers must re
+type MessagePayloadReader interface {
+	// Returns true if the message payload is empty
+	IsEmpty() bool
+
+	// Returns the payload as a byte array, nil if IsEmpty() == true
+	Bytes() []byte
+
+	// Returns the payload as an io.Reader, nil if IsEmpty() == true
+	Reader() io.Reader
+}
+
 // StructuredEncoder should generate a new representation of the event starting from a structured message.
 //
 // Protocols that supports structured encoding should implement this interface to implement direct
 // structured -> structured transfer.
 type StructuredEncoder interface {
 	// Event receives an io.Reader for the whole event.
-	SetStructuredEvent(format format.Format, event io.Reader) error
+	SetStructuredEvent(format format.Format, event MessagePayloadReader) error
 }
 
 // BinaryEncoder should generate a new representation of the event starting from a binary message.
@@ -100,7 +113,7 @@ type StructuredEncoder interface {
 type BinaryEncoder interface {
 	// SetData receives an io.Reader for the data attribute.
 	// io.Reader could be empty, meaning that message payload is empty
-	SetData(data io.Reader) error
+	SetData(data MessagePayloadReader) error
 
 	// Set a standard attribute.
 	//

--- a/pkg/binding/mock_binary_message.go
+++ b/pkg/binding/mock_binary_message.go
@@ -2,6 +2,7 @@ package binding
 
 import (
 	"bytes"
+	"io"
 
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
@@ -74,7 +75,19 @@ func (bm *MockBinaryMessage) Binary(b BinaryEncoder) error {
 	if len(bm.Body) == 0 {
 		return nil
 	}
-	return b.SetData(bytes.NewReader(bm.Body))
+	return b.SetData(bm)
+}
+
+func (bm *MockBinaryMessage) IsEmpty() bool {
+	return bm.Body == nil
+}
+
+func (bm *MockBinaryMessage) Bytes() []byte {
+	return bm.Body
+}
+
+func (bm *MockBinaryMessage) Reader() io.Reader {
+	return bytes.NewReader(bm.Body)
 }
 
 func (bm *MockBinaryMessage) Finish(error) error { return nil }

--- a/pkg/binding/test/test.go
+++ b/pkg/binding/test/test.go
@@ -73,6 +73,9 @@ func SendReceive(t *testing.T, in binding.Message, s binding.Sender, r binding.R
 		out, recvErr := r.Receive(ctx)
 		require.NoError(t, recvErr)
 		outAssert(out)
+		// Check if out message can be consumed more than one time
+		outAssert(out)
+		outAssert(out)
 		finishErr := out.Finish(nil)
 		require.NoError(t, finishErr)
 	}()

--- a/pkg/binding/to_event.go
+++ b/pkg/binding/to_event.go
@@ -1,9 +1,6 @@
 package binding
 
 import (
-	"io"
-	"io/ioutil"
-
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/binding/format"
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
@@ -55,21 +52,12 @@ func (b *messageToEventBuilder) SetEvent(e ce.Event) error {
 	return nil
 }
 
-func (b *messageToEventBuilder) SetStructuredEvent(format format.Format, event io.Reader) error {
-	//TODO(slinkydeveloper) can we do pooling for this allocation?
-	val, err := ioutil.ReadAll(event)
-	if err != nil {
-		return err
-	}
-	return format.Unmarshal(val, b.event)
+func (b *messageToEventBuilder) SetStructuredEvent(format format.Format, event MessagePayloadReader) error {
+	return format.Unmarshal(event.Bytes(), b.event)
 }
 
-func (b *messageToEventBuilder) SetData(data io.Reader) error {
-	//TODO(slinkydeveloper) can we do pooling for this allocation?
-	val, err := ioutil.ReadAll(data)
-	if err != nil {
-		return err
-	}
+func (b *messageToEventBuilder) SetData(data MessagePayloadReader) error {
+	val := data.Bytes()
 	if len(val) != 0 {
 		return b.event.SetData(val)
 	}

--- a/pkg/binding/transcoder/version.go
+++ b/pkg/binding/transcoder/version.go
@@ -1,8 +1,6 @@
 package transcoder
 
 import (
-	"io"
-
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
 	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"

--- a/pkg/binding/transcoder/version.go
+++ b/pkg/binding/transcoder/version.go
@@ -34,7 +34,7 @@ type binaryVersionTransformer struct {
 	version  spec.Version
 }
 
-func (b binaryVersionTransformer) SetData(data io.Reader) error {
+func (b binaryVersionTransformer) SetData(data binding.MessagePayloadReader) error {
 	return b.delegate.SetData(data)
 }
 

--- a/pkg/bindings/amqp/binary_message_encoder.go
+++ b/pkg/bindings/amqp/binary_message_encoder.go
@@ -1,8 +1,6 @@
 package amqp
 
 import (
-	"io"
-	"io/ioutil"
 	"net/url"
 
 	"pack.ag/amqp"
@@ -23,12 +21,11 @@ func newBinaryMessageEncoder(amqpMessage *amqp.Message) *binaryMessageEncoder {
 	return &binaryMessageEncoder{amqpMessage: amqpMessage}
 }
 
-func (b *binaryMessageEncoder) SetData(reader io.Reader) error {
-	data, err := ioutil.ReadAll(reader)
-	if err != nil {
-		return err
+func (b *binaryMessageEncoder) SetData(reader binding.MessagePayloadReader) error {
+	if reader.IsEmpty() {
+		return nil
 	}
-	b.amqpMessage.Data = [][]byte{data}
+	b.amqpMessage.Data = [][]byte{reader.Bytes()}
 	return nil
 }
 

--- a/pkg/bindings/amqp/structured_message_encoder.go
+++ b/pkg/bindings/amqp/structured_message_encoder.go
@@ -1,9 +1,6 @@
 package amqp
 
 import (
-	"io"
-	"io/ioutil"
-
 	"pack.ag/amqp"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
@@ -16,12 +13,8 @@ type structuredMessageEncoder struct {
 
 var _ binding.StructuredEncoder = (*structuredMessageEncoder)(nil) // Test it conforms to the interface
 
-func (b *structuredMessageEncoder) SetStructuredEvent(format format.Format, event io.Reader) error {
-	val, err := ioutil.ReadAll(event)
-	if err != nil {
-		return err
-	}
-	b.amqpMessage.Data = [][]byte{val}
+func (b *structuredMessageEncoder) SetStructuredEvent(format format.Format, event binding.MessagePayloadReader) error {
+	b.amqpMessage.Data = [][]byte{event.Bytes()}
 	b.amqpMessage.Properties = &amqp.MessageProperties{ContentType: format.MediaType()}
 	return nil
 }

--- a/pkg/bindings/http/binary_message_encoder.go
+++ b/pkg/bindings/http/binary_message_encoder.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -16,8 +15,10 @@ type binaryMessageEncoder struct {
 
 var _ binding.BinaryEncoder = (*binaryMessageEncoder)(nil) // Test it conforms to the interface
 
-func (b *binaryMessageEncoder) SetData(reader io.Reader) error {
-	b.req.Body = ioutil.NopCloser(reader)
+func (b *binaryMessageEncoder) SetData(payload binding.MessagePayloadReader) error {
+	if !payload.IsEmpty() {
+		b.req.Body = ioutil.NopCloser(payload.Reader())
+	}
 	return nil
 }
 

--- a/pkg/bindings/http/structured_message_encoder.go
+++ b/pkg/bindings/http/structured_message_encoder.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -15,8 +14,8 @@ type structuredMessageEncoder struct {
 
 var _ binding.StructuredEncoder = (*structuredMessageEncoder)(nil) // Test it conforms to the interface
 
-func (b *structuredMessageEncoder) SetStructuredEvent(format format.Format, event io.Reader) error {
+func (b *structuredMessageEncoder) SetStructuredEvent(format format.Format, event binding.MessagePayloadReader) error {
 	b.req.Header.Set(ContentType, format.MediaType())
-	b.req.Body = ioutil.NopCloser(event)
+	b.req.Body = ioutil.NopCloser(event.Reader())
 	return nil
 }

--- a/test/benchmark/benchmark_case.go
+++ b/test/benchmark/benchmark_case.go
@@ -1,0 +1,28 @@
+package benchmark
+
+type BenchmarkCase struct {
+	PayloadSize   int
+	Parallelism   int
+	OutputSenders int
+}
+
+func GenerateAllBenchmarkCases(
+	payloadMin int,
+	payloadMax int,
+	parallelismMin int,
+	parallelismMax int,
+	outputSendersMin int,
+	outputSendersMax int,
+) []BenchmarkCase {
+	var cases []BenchmarkCase
+
+	for payload := payloadMin; payload <= payloadMax; payload *= 2 {
+		for parallelism := parallelismMin; parallelism <= parallelismMax; parallelism += 1 {
+			for outputSenders := outputSendersMin; outputSenders <= outputSendersMax; outputSenders += 1 {
+				cases = append(cases, BenchmarkCase{payload, parallelism, outputSenders})
+			}
+		}
+	}
+
+	return cases
+}

--- a/test/benchmark/benchmark_result.go
+++ b/test/benchmark/benchmark_result.go
@@ -1,0 +1,34 @@
+package benchmark
+
+import (
+	"encoding/csv"
+	"strconv"
+	"testing"
+)
+
+type BenchmarkResult struct {
+	BenchmarkCase
+	testing.BenchmarkResult
+}
+
+func (br *BenchmarkResult) record() []string {
+	return []string{
+		strconv.Itoa(br.Parallelism),
+		strconv.Itoa(br.PayloadSize),
+		strconv.Itoa(br.OutputSenders),
+		strconv.FormatInt(br.NsPerOp(), 10),
+		strconv.FormatInt(br.AllocedBytesPerOp(), 10),
+	}
+}
+
+type BenchmarkResults []BenchmarkResult
+
+func (br BenchmarkResults) WriteToCsv(writer *csv.Writer) error {
+	for _, i2 := range br {
+		err := writer.Write(i2.record())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/benchmark/http/3d_plot_allocs.gnuplot
+++ b/test/benchmark/http/3d_plot_allocs.gnuplot
@@ -1,0 +1,18 @@
+set datafile separator comma
+set datafile missing NaN
+set xlabel "Parallelism"
+set ylabel "Number of output senders"
+set zlabel "Memory Allocated/Ops"
+payload_size_kb=ARG1
+payload_size=payload_size_kb*1024
+
+print "Plotting with payload size ".payload_size.""
+
+splot "baseline-binary.csv" using 1:3:($2==payload_size?$5:1/0) title "Baseline Binary ".payload_size_kb."kb" with linespoint, \
+     "baseline-structured.csv" using 1:3:($2==payload_size?$5:1/0) title "Baseline Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-structured.csv" using 1:3:($2==payload_size?$5:1/0) title "Binding Structured to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-binary.csv" using 1:3:($2==payload_size?$5:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-structured.csv" using 1:3:($2==payload_size?$5:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-binary.csv" using 1:3:($2==payload_size?$5:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
+     "client.csv" using 1:3:($2==payload_size?$5:1/0) title "Client ".payload_size_kb."kb" with linespoint
+pause -1

--- a/test/benchmark/http/3d_plot_allocs.gnuplot
+++ b/test/benchmark/http/3d_plot_allocs.gnuplot
@@ -14,5 +14,6 @@ splot "baseline-binary.csv" using 1:3:($2==payload_size?$5:1/0) title "Baseline 
      "binding-structured-to-binary.csv" using 1:3:($2==payload_size?$5:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-structured.csv" using 1:3:($2==payload_size?$5:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-binary.csv" using 1:3:($2==payload_size?$5:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
-     "client.csv" using 1:3:($2==payload_size?$5:1/0) title "Client ".payload_size_kb."kb" with linespoint
+     "client-binary.csv" using 1:3:($2==payload_size?$5:1/0) title "Client Binary ".payload_size_kb."kb" with linespoint, \
+     "client-structured.csv" using 1:3:($2==payload_size?$5:1/0) title "Client Structured ".payload_size_kb."kb" with linespoint
 pause -1

--- a/test/benchmark/http/3d_plot_ns.gnuplot
+++ b/test/benchmark/http/3d_plot_ns.gnuplot
@@ -1,0 +1,18 @@
+set datafile separator comma
+set datafile missing NaN
+set xlabel "Parallelism"
+set ylabel "Number of output senders"
+set zlabel "Nanoseconds/Ops"
+payload_size_kb=ARG1
+payload_size=payload_size_kb*1024
+
+print "Plotting with payload size ".payload_size.""
+
+splot "baseline-binary.csv" using 1:3:($2==payload_size?$4:1/0) title "Baseline Binary ".payload_size_kb."kb" with linespoint, \
+     "baseline-structured.csv" using 1:3:($2==payload_size?$4:1/0) title "Baseline Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-structured.csv" using 1:3:($2==payload_size?$4:1/0) title "Binding Structured to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-binary.csv" using 1:3:($2==payload_size?$4:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-structured.csv" using 1:3:($2==payload_size?$4:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-binary.csv" using 1:3:($2==payload_size?$4:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
+     "client.csv" using 1:3:($2==payload_size?$4:1/0) title "Client ".payload_size_kb."kb" with linespoint
+pause -1

--- a/test/benchmark/http/3d_plot_ns.gnuplot
+++ b/test/benchmark/http/3d_plot_ns.gnuplot
@@ -14,5 +14,6 @@ splot "baseline-binary.csv" using 1:3:($2==payload_size?$4:1/0) title "Baseline 
      "binding-structured-to-binary.csv" using 1:3:($2==payload_size?$4:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-structured.csv" using 1:3:($2==payload_size?$4:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-binary.csv" using 1:3:($2==payload_size?$4:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
-     "client.csv" using 1:3:($2==payload_size?$4:1/0) title "Client ".payload_size_kb."kb" with linespoint
+     "client-binary.csv" using 1:3:($2==payload_size?$4:1/0) title "Client Binary ".payload_size_kb."kb" with linespoint, \
+     "client-structured.csv" using 1:3:($2==payload_size?$4:1/0) title "Client Structured ".payload_size_kb."kb" with linespoint
 pause -1

--- a/test/benchmark/http/http_mock.go
+++ b/test/benchmark/http/http_mock.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	nethttp "net/http"
+	"net/http/httptest"
+	"net/url"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/bindings/http"
+	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+)
+
+type RoundTripFunc func(req *nethttp.Request) *nethttp.Response
+
+func (f RoundTripFunc) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
+	return f(req), nil
+}
+
+func NewTestClient(fn RoundTripFunc) *nethttp.Client {
+	return &nethttp.Client{
+		Transport: RoundTripFunc(fn),
+	}
+}
+
+func MockedSender(options ...http.SenderOptionFunc) binding.Sender {
+	u, _ := url.Parse("http://localhost")
+	return http.NewSender(NewTestClient(func(req *nethttp.Request) *nethttp.Response {
+		return &nethttp.Response{
+			StatusCode: 202,
+			Header:     make(nethttp.Header),
+		}
+	}), u, options...)
+}
+
+func MockedClient() (cloudevents.Client, *cehttp.Transport) {
+	t, err := cehttp.New(cehttp.WithTarget("http://localhost"))
+
+	if err != nil {
+		panic(err)
+	}
+
+	t.Client = NewTestClient(func(req *nethttp.Request) *nethttp.Response {
+		return &nethttp.Response{
+			StatusCode: 202,
+			Header:     make(nethttp.Header),
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+		}
+	})
+
+	client, err := cloudevents.NewClient(t)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return client, t
+}
+
+func MockedBinaryRequest(body []byte) *nethttp.Request {
+	r := httptest.NewRequest("POST", "http://localhost:8080", bytes.NewBuffer(body))
+	r.Header.Add("Ce-id", "0")
+	r.Header.Add("Ce-subject", "sub")
+	r.Header.Add("Ce-specversion", "1.0")
+	r.Header.Add("Ce-type", "t")
+	r.Header.Add("Ce-source", "http://localhost")
+	r.Header.Add("Content-type", "text/plain")
+	return r
+}
+
+var (
+	eventBegin = []byte("{" +
+		"\"id\":0," +
+		"\"subject\":\"sub\"," +
+		"\"specversion\":\"1.0\"," +
+		"\"type\":\"t\"," +
+		"\"source\":\"http://localhost\"," +
+		"\"datacontenttype\":\"text/plain\"," +
+		"\"data\": \"")
+	eventEnd = []byte("\"}")
+)
+
+func MockedStructuredRequest(body []byte) *nethttp.Request {
+	r := httptest.NewRequest(
+		"POST",
+		"http://localhost:8080",
+		io.MultiReader(bytes.NewReader(eventBegin), bytes.NewBuffer(body), bytes.NewReader(eventEnd)),
+	)
+	r.Header.Add("Content-type", cloudevents.ApplicationCloudEventsJSON)
+	return r
+}

--- a/test/benchmark/http/http_mock.go
+++ b/test/benchmark/http/http_mock.go
@@ -73,7 +73,7 @@ func MockedBinaryRequest(body []byte) *nethttp.Request {
 
 var (
 	eventBegin = []byte("{" +
-		"\"id\":0," +
+		"\"id\":\"0\"," +
 		"\"subject\":\"sub\"," +
 		"\"specversion\":\"1.0\"," +
 		"\"type\":\"t\"," +

--- a/test/benchmark/http/main.go
+++ b/test/benchmark/http/main.go
@@ -64,26 +64,43 @@ func benchmarkBaseline(cases []benchmark.BenchmarkCase, requestFactory func([]by
 	return results
 }
 
-func pipeLoop(r *http.Receiver, endCtx context.Context, outputSenders int, opts ...http.SenderOptionFunc) {
+func pipeLoopDirect(r *http.Receiver, endCtx context.Context, opts ...http.SenderOptionFunc) {
 	s := MockedSender(opts...)
 	var err error
 	var m binding.Message
-	messageCtx := context.Background()
 	for err != io.EOF {
 		select {
-		case _, ok := <-endCtx.Done():
-			if !ok {
-				return
-			}
+		case <-endCtx.Done():
+			return
 		default:
-			m, err = r.Receive(messageCtx)
+			m, err = r.Receive(endCtx)
+			if err != nil || m == nil {
+				continue
+			}
+			_ = s.Send(context.Background(), m)
+		}
+	}
+}
+
+func pipeLoopMulti(r *http.Receiver, endCtx context.Context, outputSenders int, opts ...http.SenderOptionFunc) {
+	s := MockedSender(opts...)
+	var err error
+	var m binding.Message
+	for err != io.EOF {
+		select {
+		case <-endCtx.Done():
+			return
+		default:
+			m, err = r.Receive(endCtx)
 			if err != nil {
 				continue
 			}
-			//TODO multisend when implemented!
-			//Be aware that multisend implementation MUST finish the message AFTER all sends are completed,
-			//otherwise we cheat the results, because the time is calculated from the message received to Message.finish() call
-			_ = s.Send(messageCtx, m)
+			outputMessage := binding.WithAcksBeforeFinish(m, outputSenders)
+			for i := 0; i < outputSenders; i++ {
+				go func(m binding.Message) {
+					_ = s.Send(context.Background(), outputMessage)
+				}(outputMessage)
+			}
 		}
 	}
 }
@@ -100,7 +117,11 @@ func benchmarkReceiverSender(cases []benchmark.BenchmarkCase, requestFactory fun
 
 		// Spawn dispatchers
 		for i := 0; i < c.Parallelism; i++ {
-			go pipeLoop(receiver, ctx, c.OutputSenders, opts...)
+			if c.OutputSenders == 1 {
+				go pipeLoopDirect(receiver, ctx, opts...)
+			} else {
+				go pipeLoopMulti(receiver, ctx, c.OutputSenders, opts...)
+			}
 		}
 
 		buffer := make([]byte, c.PayloadSize)

--- a/test/benchmark/http/main.go
+++ b/test/benchmark/http/main.go
@@ -1,198 +1,190 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/csv"
 	"flag"
+	"fmt"
 	"io"
-	"io/ioutil"
+	"math/rand"
 	nethttp "net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"runtime"
 	"runtime/pprof"
-	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/bindings/http"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
-	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/test/benchmark"
 )
 
-type RoundTripFunc func(req *nethttp.Request) *nethttp.Response
+var letters = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-func (f RoundTripFunc) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
-	return f(req), nil
-}
-
-func NewTestClient(fn RoundTripFunc) *nethttp.Client {
-	return &nethttp.Client{
-		Transport: RoundTripFunc(fn),
+func fillRandom(buf []byte, r *rand.Rand) {
+	for i := 0; i < cap(buf); i++ {
+		buf[i] = letters[r.Intn(len(letters))]
 	}
-}
-
-func generateRandomValue(kb int, value byte) []byte {
-	length := 1024 * kb
-	b := make([]byte, length)
-	for i := 0; i < length; i++ {
-		b[i] = value
-	}
-	return b
-}
-
-func MockedSender() binding.Sender {
-	u, _ := url.Parse("http://localhost")
-	return http.NewSender(NewTestClient(func(req *nethttp.Request) *nethttp.Response {
-		return &nethttp.Response{
-			StatusCode: 202,
-			Header:     make(nethttp.Header),
-		}
-	}), u)
-}
-
-func MockedClient() (cloudevents.Client, *cehttp.Transport) {
-	t, err := cehttp.New(cehttp.WithTarget("http://localhost"))
-
-	if err != nil {
-		panic(err)
-	}
-
-	t.Client = NewTestClient(func(req *nethttp.Request) *nethttp.Response {
-		return &nethttp.Response{
-			StatusCode: 202,
-			Header:     make(nethttp.Header),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
-		}
-	})
-
-	client, err := cloudevents.NewClient(t)
-
-	if err != nil {
-		panic(err)
-	}
-
-	t.SetReceiver(transport.ReceiveFunc(func(ctx context.Context, e cloudevents.Event, er *cloudevents.EventResponse) error {
-		_, _, _ = client.Send(ctx, e)
-		er.RespondWith(202, nil)
-		return nil
-	}))
-
-	return client, t
-}
-
-func MockedRequest(body []byte) *nethttp.Request {
-	r := httptest.NewRequest("POST", "http://localhost:8080", bytes.NewBuffer(body))
-	r.Header.Add("Ce-id", "0")
-	r.Header.Add("Ce-subject", "sub")
-	r.Header.Add("Ce-specversion", "1.0")
-	r.Header.Add("Ce-type", "t")
-	r.Header.Add("Ce-source", "http://localhost")
-	r.Header.Add("Content-type", "text/plain")
-	return r
 }
 
 // Avoid DCE
 var W *httptest.ResponseRecorder
 var R *nethttp.Request
 
-type BenchResult struct {
-	parallelism   int
-	payloadSizeKb int
-	testing.BenchmarkResult
-}
+func benchmarkBaseline(cases []benchmark.BenchmarkCase, requestFactory func([]byte) *nethttp.Request) benchmark.BenchmarkResults {
+	var results benchmark.BenchmarkResults
+	r := rand.New(rand.NewSource(time.Now().Unix()))
 
-func runBench(do func(body []byte)) []BenchResult {
-	results := make([]BenchResult, 0)
-	for p := 1; p <= runtime.NumCPU(); p++ {
-		for k := 1; k <= 32; k *= 2 {
-			body := generateRandomValue(k, byte('a'))
-			r := testing.Benchmark(func(b *testing.B) {
-				b.SetParallelism(p)
-				b.RunParallel(func(pb *testing.PB) {
-					for pb.Next() {
-						do(body)
-					}
-				})
+	for _, c := range cases {
+		fmt.Printf("%+v\n", c)
+
+		buffer := make([]byte, c.PayloadSize)
+		fillRandom(buffer, r)
+
+		result := testing.Benchmark(func(b *testing.B) {
+			b.SetParallelism(c.Parallelism)
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					W = httptest.NewRecorder()
+					R = requestFactory(buffer)
+				}
 			})
-			results = append(results, BenchResult{p, k, r})
-		}
+		})
+		results = append(results, benchmark.BenchmarkResult{BenchmarkCase: c, BenchmarkResult: result})
 	}
+
 	return results
 }
 
-func benchmarkBaseline() []BenchResult {
-	return runBench(func(body []byte) {
-		W = httptest.NewRecorder()
-		R = MockedRequest(body)
-	})
+func pipeLoop(r *http.Receiver, endCtx context.Context, outputSenders int, opts ...http.SenderOptionFunc) {
+	s := MockedSender(opts...)
+	var err error
+	var m binding.Message
+	messageCtx := context.Background()
+	for err != io.EOF {
+		select {
+		case _, ok := <-endCtx.Done():
+			if !ok {
+				return
+			}
+		default:
+			m, err = r.Receive(messageCtx)
+			if err != nil {
+				continue
+			}
+			//TODO multisend when implemented!
+			//Be aware that multisend implementation MUST finish the message AFTER all sends are completed,
+			//otherwise we cheat the results, because the time is calculated from the message received to Message.finish() call
+			_ = s.Send(messageCtx, m)
+		}
+	}
 }
 
-func benchmarkReceiverSender() []BenchResult {
-	r := http.NewReceiver()
+func benchmarkReceiverSender(cases []benchmark.BenchmarkCase, requestFactory func([]byte) *nethttp.Request, opts ...http.SenderOptionFunc) benchmark.BenchmarkResults {
+	var results benchmark.BenchmarkResults
+	random := rand.New(rand.NewSource(time.Now().Unix()))
 
-	results := make([]BenchResult, 0)
-	for p := 1; p <= runtime.NumCPU(); p++ {
+	for _, c := range cases {
+		fmt.Printf("%+v\n", c)
+
 		ctx, cancel := context.WithCancel(context.TODO())
+		receiver := http.NewReceiver()
 
 		// Spawn dispatchers
-		for i := 0; i < p; i++ {
-			go func(r *http.Receiver) {
-				s := MockedSender()
-				var err error
-				var m binding.Message
-				messageCtx := context.Background()
-				for err != io.EOF {
-					select {
-					case _, ok := <-ctx.Done():
-						if !ok {
-							return
-						}
-					default:
-						m, err = r.Receive(messageCtx)
-						if err != nil {
-							continue
-						}
-						_ = s.Send(messageCtx, m)
-					}
-				}
-			}(r)
+		for i := 0; i < c.Parallelism; i++ {
+			go pipeLoop(receiver, ctx, c.OutputSenders, opts...)
 		}
 
-		for k := 1; k <= 32; k *= 2 {
-			body := generateRandomValue(k, byte('a'))
-			r := testing.Benchmark(func(b *testing.B) {
-				b.SetParallelism(p)
-				b.RunParallel(func(pb *testing.PB) {
-					for pb.Next() {
-						w := httptest.NewRecorder()
-						r.ServeHTTP(w, MockedRequest(body))
-					}
-				})
+		buffer := make([]byte, c.PayloadSize)
+		fillRandom(buffer, random)
+		runtime.GC()
+
+		result := testing.Benchmark(func(b *testing.B) {
+			b.SetParallelism(c.Parallelism)
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					w := httptest.NewRecorder()
+					receiver.ServeHTTP(w, requestFactory(buffer))
+				}
 			})
-			results = append(results, BenchResult{p, k, r})
-		}
+		})
+		results = append(results, benchmark.BenchmarkResult{BenchmarkCase: c, BenchmarkResult: result})
 
 		cancel()
+		runtime.GC()
 	}
+
 	return results
 }
 
-func benchmarkClient() []BenchResult {
-	_, mockedTransport := MockedClient()
-
-	return runBench(func(body []byte) {
-		w := httptest.NewRecorder()
-		mockedTransport.ServeHTTP(w, MockedRequest(body))
+func dispatchReceiver(clients []cloudevents.Client, outputSenders int) transport.Receiver {
+	return transport.ReceiveFunc(func(ctx context.Context, e cloudevents.Event, er *cloudevents.EventResponse) error {
+		var wg sync.WaitGroup
+		for i := 0; i < outputSenders; i++ {
+			wg.Add(1)
+			go func(client cloudevents.Client) {
+				_, _, _ = client.Send(ctx, e)
+				wg.Done()
+			}(clients[i])
+		}
+		wg.Wait()
+		er.RespondWith(200, nil)
+		return nil
 	})
+}
+
+func benchmarkClient(cases []benchmark.BenchmarkCase) benchmark.BenchmarkResults {
+	var results benchmark.BenchmarkResults
+	random := rand.New(rand.NewSource(time.Now().Unix()))
+
+	for _, c := range cases {
+		fmt.Printf("%+v\n", c)
+
+		_, mockedReceiverTransport := MockedClient()
+
+		senderClients := make([]cloudevents.Client, c.OutputSenders)
+		for i := 0; i < c.OutputSenders; i++ {
+			senderClients[i], _ = MockedClient()
+		}
+
+		mockedReceiverTransport.SetReceiver(dispatchReceiver(senderClients, c.OutputSenders))
+
+		buffer := make([]byte, c.PayloadSize)
+		fillRandom(buffer, random)
+		runtime.GC()
+
+		result := testing.Benchmark(func(b *testing.B) {
+			b.SetParallelism(c.Parallelism)
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					w := httptest.NewRecorder()
+					mockedReceiverTransport.ServeHTTP(w, MockedBinaryRequest(buffer))
+				}
+			})
+		})
+		results = append(results, benchmark.BenchmarkResult{BenchmarkCase: c, BenchmarkResult: result})
+
+		runtime.GC()
+	}
+
+	return results
 }
 
 var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to `file`")
 var memprofile = flag.String("memprofile", "", "write memory profile to `file`")
-var bench = flag.String("bench", "baseline", "[baseline, receiver-sender, client]")
+var bench = flag.String(
+	"bench",
+	"baseline-binary",
+	"[baseline-structured, baseline-binary, binding-structured-to-structured, binding-structured-to-binary, binding-binary-to-structured, binding-binary-to-binary, client]",
+)
+var out = flag.String("out", "out.csv", "Output file")
+var maxPayloadKb = flag.Int("max-payload", 32, "Max payload size")
+var maxParallelism = flag.Int("max-parallelism", runtime.NumCPU()*2, "Max parallelism")
+var maxOutputSenders = flag.Int("max-output-senders", 1, "Max output senders")
 
 func main() {
 	flag.Parse()
@@ -204,17 +196,40 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	var results []BenchResult
+	benchmarkCases := benchmark.GenerateAllBenchmarkCases(
+		1024,
+		1024*(*maxPayloadKb),
+		1,
+		*maxParallelism,
+		1,
+		*maxOutputSenders, //TODO to be increased when receiver-sender will support multi senders
+	)
+
+	var results benchmark.BenchmarkResults
+
+	fmt.Printf("--- Starting benchmark %s ---\n", *bench)
 
 	switch *bench {
-	case "baseline":
-		results = benchmarkBaseline()
+	case "baseline-structured":
+		results = benchmarkBaseline(benchmarkCases, MockedStructuredRequest)
 		break
-	case "receiver-sender":
-		results = benchmarkReceiverSender()
+	case "baseline-binary":
+		results = benchmarkBaseline(benchmarkCases, MockedBinaryRequest)
+		break
+	case "binding-structured-to-structured":
+		results = benchmarkReceiverSender(benchmarkCases, MockedStructuredRequest, http.ForceStructured())
+		break
+	case "binding-structured-to-binary":
+		results = benchmarkReceiverSender(benchmarkCases, MockedStructuredRequest, http.ForceBinary())
+		break
+	case "binding-binary-to-structured":
+		results = benchmarkReceiverSender(benchmarkCases, MockedBinaryRequest, http.ForceStructured())
+		break
+	case "binding-binary-to-binary":
+		results = benchmarkReceiverSender(benchmarkCases, MockedBinaryRequest, http.ForceBinary())
 		break
 	case "client":
-		results = benchmarkClient()
+		results = benchmarkClient(benchmarkCases)
 		break
 	default:
 		panic("Wrong bench flag")
@@ -229,16 +244,17 @@ func main() {
 		_ = pprof.WriteHeapProfile(f)
 	}
 
-	writer := csv.NewWriter(os.Stdout)
+	f, err := os.Create(*out)
+	if err != nil {
+		panic(fmt.Sprintf("Cannot open file %s: %v", *out, err))
+	}
+	defer f.Close()
+
+	writer := csv.NewWriter(f)
 	defer writer.Flush()
 
-	for _, res := range results {
-		_ = writer.Write([]string{
-			strconv.Itoa(res.parallelism),
-			strconv.Itoa(res.payloadSizeKb),
-			strconv.FormatInt(res.NsPerOp(), 10),
-			strconv.FormatInt(res.AllocedBytesPerOp(), 10),
-		})
+	err = results.WriteToCsv(writer)
+	if err != nil {
+		panic(err)
 	}
-
 }

--- a/test/benchmark/http/main.go
+++ b/test/benchmark/http/main.go
@@ -40,6 +40,10 @@ func benchmarkBaseline(cases []benchmark.BenchmarkCase, requestFactory func([]by
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	for _, c := range cases {
+		if c.OutputSenders > 1 {
+			// It doesn't make sense for this test
+			continue
+		}
 		fmt.Printf("%+v\n", c)
 
 		buffer := make([]byte, c.PayloadSize)
@@ -182,7 +186,7 @@ var bench = flag.String(
 	"[baseline-structured, baseline-binary, binding-structured-to-structured, binding-structured-to-binary, binding-binary-to-structured, binding-binary-to-binary, client]",
 )
 var out = flag.String("out", "out.csv", "Output file")
-var maxPayloadKb = flag.Int("max-payload", 32, "Max payload size")
+var maxPayloadKb = flag.Int("max-payload", 32, "Max payload size in kb")
 var maxParallelism = flag.Int("max-parallelism", runtime.NumCPU()*2, "Max parallelism")
 var maxOutputSenders = flag.Int("max-output-senders", 1, "Max output senders")
 

--- a/test/benchmark/http/plot_output_senders_allocs.gnuplot
+++ b/test/benchmark/http/plot_output_senders_allocs.gnuplot
@@ -14,5 +14,6 @@ plot "baseline-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0
      "binding-structured-to-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
-     "client.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Client ".payload_size_kb."kb" with linespoint
+     "client-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Client Binary ".payload_size_kb."kb" with linespoint, \
+     "client-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Client Structured ".payload_size_kb."kb" with linespoint
 pause -1

--- a/test/benchmark/http/plot_output_senders_allocs.gnuplot
+++ b/test/benchmark/http/plot_output_senders_allocs.gnuplot
@@ -1,0 +1,18 @@
+set datafile separator comma
+set datafile missing NaN
+set xlabel "Number of output senders"
+set ylabel "Memory Allocated/Ops"
+payload_size_kb=ARG1
+payload_size=payload_size_kb*1024
+parallelism=(exist("ARG2") && ARG2 != ""?ARG2:1)
+
+print "Plotting with payload size ".payload_size." and parallelism ".parallelism.""
+
+plot "baseline-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Baseline Binary ".payload_size_kb."kb" with linespoint, \
+     "baseline-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Baseline Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Binding Structured to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
+     "client.csv" using 3:(($2==payload_size && $1==parallelism)?$5:1/0) title "Client ".payload_size_kb."kb" with linespoint
+pause -1

--- a/test/benchmark/http/plot_output_senders_ns.gnuplot
+++ b/test/benchmark/http/plot_output_senders_ns.gnuplot
@@ -1,0 +1,18 @@
+set datafile separator comma
+set datafile missing NaN
+set xlabel "Number of output senders"
+set ylabel "Nanoseconds/Ops"
+payload_size_kb=ARG1
+payload_size=payload_size_kb*1024
+parallelism=(exist("ARG2") && ARG2 != ""?ARG2:1)
+
+print "Plotting with payload size ".payload_size." and parallelism ".parallelism.""
+
+plot "baseline-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Baseline Binary ".payload_size_kb."kb" with linespoint, \
+     "baseline-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Baseline Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Binding Structured to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
+     "client.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Client ".payload_size_kb."kb" with linespoint
+pause -1

--- a/test/benchmark/http/plot_output_senders_ns.gnuplot
+++ b/test/benchmark/http/plot_output_senders_ns.gnuplot
@@ -14,5 +14,6 @@ plot "baseline-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0
      "binding-structured-to-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
-     "client.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Client ".payload_size_kb."kb" with linespoint
+     "client-binary.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Client Binary ".payload_size_kb."kb" with linespoint, \
+     "client-structured.csv" using 3:(($2==payload_size && $1==parallelism)?$4:1/0) title "Client Structured ".payload_size_kb."kb" with linespoint
 pause -1

--- a/test/benchmark/http/plot_parallelism_allocs.gnuplot
+++ b/test/benchmark/http/plot_parallelism_allocs.gnuplot
@@ -1,0 +1,18 @@
+set datafile separator comma
+set datafile missing NaN
+set xlabel "Parallelism"
+set ylabel "Memory Allocated/Ops"
+payload_size_kb=ARG1
+payload_size=payload_size_kb*1024
+output_senders=(exist("ARG2") && ARG2 != ""?ARG2:1)
+
+print "Plotting with payload size ".payload_size." and output_senders ".output_senders.""
+
+plot "baseline-binary.csv" using 1:(($2==payload_size && $3==output_senders)?$5:1/0) title "Baseline Binary ".payload_size_kb."kb" with linespoint, \
+     "baseline-structured.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Baseline Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-structured.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Binding Structured to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-binary.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-structured.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-binary.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
+     "client.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Client ".payload_size_kb."kb" with linespoint
+pause -1

--- a/test/benchmark/http/plot_parallelism_allocs.gnuplot
+++ b/test/benchmark/http/plot_parallelism_allocs.gnuplot
@@ -14,5 +14,6 @@ plot "baseline-binary.csv" using 1:(($2==payload_size && $3==output_senders)?$5:
      "binding-structured-to-binary.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-structured.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-binary.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
-     "client.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Client ".payload_size_kb."kb" with linespoint
+     "client-binary.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Client Binary ".payload_size_kb."kb" with linespoint, \
+     "client-structured.csv" using 1:($2==payload_size && $3==output_senders?$5:1/0) title "Client Structured ".payload_size_kb."kb" with linespoint
 pause -1

--- a/test/benchmark/http/plot_parallelism_ns.gnuplot
+++ b/test/benchmark/http/plot_parallelism_ns.gnuplot
@@ -14,5 +14,6 @@ plot "baseline-binary.csv" using 1:(($2==payload_size && $3==output_senders)?$4:
      "binding-structured-to-binary.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-structured.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
      "binding-binary-to-binary.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
-     "client.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Client ".payload_size_kb."kb" with linespoint
+     "client-binary.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Client Binary ".payload_size_kb."kb" with linespoint, \
+     "client-structured.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Client Structured ".payload_size_kb."kb" with linespoint
 pause -1

--- a/test/benchmark/http/plot_parallelism_ns.gnuplot
+++ b/test/benchmark/http/plot_parallelism_ns.gnuplot
@@ -2,6 +2,13 @@ set datafile separator comma
 set datafile missing NaN
 set xlabel "Parallelism"
 set ylabel "Nanoseconds/Ops"
-payload_size=ARG1
-plot "baseline.csv" using 1:($2==payload_size?$3:1/0) title "Baseline ".payload_size."kb" with linespoint, "receiver-sender.csv" using 1:($2==payload_size?$3:1/0) title "Receiver Sender ".payload_size."kb" with linespoint, "pipe.csv" using 1:($2==payload_size?$3:1/0) title "Pipe ".payload_size."kb" with linespoint, "client.csv" using 1:($2==payload_size?$3:1/0) title "Client ".payload_size."kb" with linespoint
+payload_size_kb=ARG1
+payload_size=payload_size_kb*1024
+plot "baseline-binary.csv" using 1:($2==payload_size?$4:1/0) title "Baseline Binary ".payload_size_kb."kb" with linespoint, \
+     "baseline-structured.csv" using 1:($2==payload_size?$4:1/0) title "Baseline Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-structured.csv" using 1:($2==payload_size?$4:1/0) title "Binding Structured to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-binary.csv" using 1:($2==payload_size?$4:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-structured.csv" using 1:($2==payload_size?$4:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-binary.csv" using 1:($2==payload_size?$4:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
+     "client.csv" using 1:($2==payload_size?$4:1/0) title "Client ".payload_size_kb."kb" with linespoint
 pause -1

--- a/test/benchmark/http/plot_parallelism_ns.gnuplot
+++ b/test/benchmark/http/plot_parallelism_ns.gnuplot
@@ -4,11 +4,15 @@ set xlabel "Parallelism"
 set ylabel "Nanoseconds/Ops"
 payload_size_kb=ARG1
 payload_size=payload_size_kb*1024
-plot "baseline-binary.csv" using 1:($2==payload_size?$4:1/0) title "Baseline Binary ".payload_size_kb."kb" with linespoint, \
-     "baseline-structured.csv" using 1:($2==payload_size?$4:1/0) title "Baseline Structured ".payload_size_kb."kb" with linespoint, \
-     "binding-structured-to-structured.csv" using 1:($2==payload_size?$4:1/0) title "Binding Structured to Structured ".payload_size_kb."kb" with linespoint, \
-     "binding-structured-to-binary.csv" using 1:($2==payload_size?$4:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
-     "binding-binary-to-structured.csv" using 1:($2==payload_size?$4:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
-     "binding-binary-to-binary.csv" using 1:($2==payload_size?$4:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
-     "client.csv" using 1:($2==payload_size?$4:1/0) title "Client ".payload_size_kb."kb" with linespoint
+output_senders=(exist("ARG2") && ARG2 != ""?ARG2:1)
+
+print "Plotting with payload size ".payload_size." and output_senders ".output_senders.""
+
+plot "baseline-binary.csv" using 1:(($2==payload_size && $3==output_senders)?$4:1/0) title "Baseline Binary ".payload_size_kb."kb" with linespoint, \
+     "baseline-structured.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Baseline Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-structured.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Binding Structured to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-structured-to-binary.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Binding Structured to Binary ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-structured.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Binding Binary to Structured ".payload_size_kb."kb" with linespoint, \
+     "binding-binary-to-binary.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Binding Binary to Binary ".payload_size_kb."kb" with linespoint, \
+     "client.csv" using 1:($2==payload_size && $3==output_senders?$4:1/0) title "Client ".payload_size_kb."kb" with linespoint
 pause -1

--- a/test/benchmark/http/run_revision.sh
+++ b/test/benchmark/http/run_revision.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -e
+
+RUNNABLE_NAME="http-bench"
+
+function usage {
+   echo "Usage: $0 [--cpu-profile] [--mem-profile] [--max-parallelism n] [--max-payload n] [--max-output-senders n] [git_revision]"
+   exit 1
+}
+
+ADDITIONAL_ARGS=""
+
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+    -c|--cpu-profile)
+      CPU_PROFILE="1"
+      shift
+      ;;
+    -m|--mem-profile)
+      MEM_PROFILE="1"
+      shift
+      ;;
+    --max-parallelism)
+      ADDITIONAL_ARGS="$ADDITIONAL_ARGS --max-parallelism $2"
+      shift 2
+      ;;
+    --max-payload)
+      ADDITIONAL_ARGS="$ADDITIONAL_ARGS --max-payload $2"
+      shift 2
+      ;;
+    --max-output-senders)
+      ADDITIONAL_ARGS="$ADDITIONAL_ARGS --max-output-senders $2"
+      shift 2
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+eval set -- "$PARAMS"
+
+REVISION=$1
+if [ ! -z "$REVISION" ]
+then
+      git checkout "$REVISION"
+else
+      REVISION=results
+fi
+
+go build -o $RUNNABLE_NAME -v github.com/cloudevents/sdk-go/test/benchmark/http
+
+mkdir -p "$REVISION"
+
+BENCHS=(
+  "baseline-structured"
+  "baseline-binary"
+  "binding-structured-to-structured"
+  "binding-structured-to-binary"
+  "binding-binary-to-structured"
+  "binding-binary-to-binary"
+  "client"
+)
+
+for i in "${BENCHS[@]}"; do
+    ./$RUNNABLE_NAME --bench="$i" \
+    ${MEM_PROFILE+-memprofile $REVISION/$i-mem.pprof} \
+    ${CPU_PROFILE+-cpuprofile $REVISION/$i-cpu.pprof} \
+    $ADDITIONAL_ARGS \
+    --out="$REVISION/$i.csv"
+done
+
+rm $RUNNABLE_NAME

--- a/test/benchmark/http/run_revision.sh
+++ b/test/benchmark/http/run_revision.sh
@@ -72,7 +72,8 @@ BENCHS=(
   "binding-structured-to-binary"
   "binding-binary-to-structured"
   "binding-binary-to-binary"
-  "client"
+  "client-binary"
+  "client-structured"
 )
 
 for i in "${BENCHS[@]}"; do

--- a/test/benchmark/http/run_revision_bench.sh
+++ b/test/benchmark/http/run_revision_bench.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+REVISION=$1
+
+git checkout "$REVISION"
+go build -v main.go
+
+mkdir "$REVISION"
+
+echo "Running baseline"
+./main --bench=baseline > "$REVISION/baseline.csv"
+
+echo "Running receiver sender"
+./main --bench=receiver-sender > "$REVISION/receiver-sender.csv"
+
+echo "Running client"
+./main --bench=client > "$REVISION/client.csv"
+
+rm main

--- a/test/benchmark/http/run_revision_profiling.sh
+++ b/test/benchmark/http/run_revision_profiling.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+REVISION=$1
+
+git checkout "$REVISION"
+go build -v main.go
+
+mkdir "$REVISION"
+
+echo "Running baseline"
+./main --bench=baseline -memprofile $REVISION/baseline_mem.pprof -cpuprofile $REVISION/baseline_cpu.pprof
+
+echo "Running receiver sender"
+./main --bench=receiver-sender -memprofile $REVISION/receiver_sender_mem.pprof -cpuprofile $REVISION/receiver_sender_cpu.pprof
+
+echo "Running client"
+./main --bench=client -memprofile $REVISION/client_mem.pprof -cpuprofile $REVISION/client_cpu.pprof
+
+rm main


### PR DESCRIPTION
Fix #280 #281

## Reading binding.Message several times

With https://github.com/cloudevents/sdk-go/pull/270, every binding.Message can be consumed only one time, meaning that after the message is visited one time with the various `Encoder`s, it can't be visited again.

This PR allows a Message to be consumed several times. It re-enforces and document that behaviour, implementing it in `bindings/http.Message`, buffering the request body. To efficiently implement the buffering phase [it uses memory pooling](https://github.com/valyala/bytebufferpool). This obviously introduces a performance regression but allows retries and broadcasting the message.

Master 8Kb & 32Kb:

![8](https://user-images.githubusercontent.com/6706544/72446369-babf6300-37b3-11ea-9498-67da317188e8.png)

![32](https://user-images.githubusercontent.com/6706544/72446405-ca3eac00-37b3-11ea-9bc6-92e00646c134.png)

This PR **without** Memory pooling 8Kb & 32Kb:

![8](https://user-images.githubusercontent.com/6706544/72446455-e7737a80-37b3-11ea-9289-dfed7647b35f.png)

![32](https://user-images.githubusercontent.com/6706544/72446457-e93d3e00-37b3-11ea-8c65-48cc1d577cd4.png)

This PR **with** memory pooling 8Kb & 32Kb:

![8](https://user-images.githubusercontent.com/6706544/72446487-f65a2d00-37b3-11ea-88b7-c2ec6f42778b.png)

![32](https://user-images.githubusercontent.com/6706544/72446489-f78b5a00-37b3-11ea-86f2-33746239b523.png)

## Let more `binding.Sender` to process the message

By contract `Sender.Finish()` **must** invoke `Message.Finish(error)`. To allow different `Sender`s to process the `Message` without prematurely _finishing_ it, this PR includes `WithAcksBeforeFinish()` method to decorate the `Message` instance to invoke `Finish` only after N acks are invoked. (Note: only the last error is take in account for calling the final `Finish`)

## Extra

This PR also adds two scripts to simplify benchmark execution across different git revisions.