### PR TITLE
WIP: Copying messages for multicast

### DIFF
--- a/pkg/binding/copy_message.go
+++ b/pkg/binding/copy_message.go
@@ -1,0 +1,26 @@
+package binding
+
+// CopyMessage reads m once and creates an in-memory copy using EventMessage or
+// StructMessage depending on the encoding of m.  The returned copy is not
+// dependent on any transport and can be read many times.
+//
+// NOTE: Calling Finish() on the returned message calls m.Finish()
+func CopyMessage(m Message) (Message, error) {
+	// Try structured first, it's cheaper.
+	sm := StructMessage{}
+	err := m.Structured(&sm)
+	switch err {
+	case nil:
+		return &sm, nil
+	case ErrNotStructured:
+		break
+	default:
+		return nil, err
+	}
+	em := EventMessage{}
+	err = m.Event(&em)
+	if err != nil {
+		return nil, err
+	}
+	return WithFinish(em, func(err error) { _ = m.Finish(err) }), nil
+}

--- a/pkg/binding/event_message.go
+++ b/pkg/binding/event_message.go
@@ -1,15 +1,71 @@
 package binding
 
-import ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+import (
+	"bytes"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+)
+
+var specs = spec.New()
 
 // EventMessage type-converts a cloudevents.Event object to implement Message.
 // This allows local cloudevents.Event objects to be sent directly via Sender.Send()
 //     s.Send(ctx, binding.EventMessage(e))
 type EventMessage ce.Event
 
-func (m EventMessage) Event(builder EventEncoder) error   { return builder.SetEvent(ce.Event(m)) }
-func (m EventMessage) Structured(StructuredEncoder) error { return ErrNotStructured }
-func (m EventMessage) Binary(BinaryEncoder) error         { return ErrNotBinary }
-func (EventMessage) Finish(error) error                   { return nil }
+func (m EventMessage) Event(builder EventEncoder) error {
+	return builder.SetEvent(ce.Event(m))
+}
+
+func (m EventMessage) Structured(StructuredEncoder) error {
+	return ErrNotStructured
+}
+
+func (m EventMessage) Binary(b BinaryEncoder) (err error) {
+	c := m.Context
+	var sv spec.Version
+	sv, err = specs.Version(c.GetSpecVersion())
+	if err != nil {
+		return err
+	}
+	set := func(k spec.Kind, v interface{}) {
+		if err == nil {
+			attr := sv.AttributeFromKind(k)
+			if attr != nil {
+				err = b.SetAttribute(attr, v)
+			}
+		}
+	}
+	set(spec.SpecVersion, c.GetSpecVersion())
+	set(spec.Type, c.GetType())
+	set(spec.Source, c.GetSource())
+	set(spec.Subject, c.GetSubject())
+	set(spec.ID, c.GetID())
+	set(spec.Time, c.GetTime())
+	set(spec.DataSchema, c.GetDataSchema())
+	set(spec.DataContentType, c.GetDataContentType())
+
+	for k, v := range c.GetExtensions() {
+		if err == nil {
+			err = b.SetExtension(k, v)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	body, err := (*ce.Event)(&m).DataBytes()
+	if err == nil && len(body) > 0 {
+		return b.SetData(bytes.NewReader(body))
+	}
+	return err
+}
+
+func (EventMessage) Finish(error) error { return nil }
+
+func (m *EventMessage) SetEvent(e ce.Event) error {
+	*m = EventMessage(e)
+	return nil
+}
 
 var _ Message = (*EventMessage)(nil) // Test it conforms to the interface

--- a/pkg/binding/format/format.go
+++ b/pkg/binding/format/format.go
@@ -24,6 +24,14 @@ type Format interface {
 	Unmarshal([]byte, *ce.Event) error
 }
 
+// UnknownFormat allows an event with an unknown format string to be forwarded,
+// but Marshal() and Unmarshal will always fail.
+type UnknownFormat string
+
+func (uf UnknownFormat) MediaType() string                 { return string(uf) }
+func (uf UnknownFormat) Marshal(ce.Event) ([]byte, error)  { return nil, unknown(uf.MediaType()) }
+func (uf UnknownFormat) Unmarshal([]byte, *ce.Event) error { return unknown(uf.MediaType()) }
+
 // Prefix for event-format media types.
 const Prefix = "application/cloudevents"
 

--- a/pkg/binding/struct_message.go
+++ b/pkg/binding/struct_message.go
@@ -1,0 +1,49 @@
+package binding
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+)
+
+// StructMessage implements a structured-mode message as a simple struct.
+type StructMessage struct {
+	Format format.Format
+	Bytes  []byte
+}
+
+// Event unmarshals the formatted event.
+func (m *StructMessage) Event(enc EventEncoder) error {
+	var e ce.Event
+	err := m.Format.Unmarshal(m.Bytes, &e)
+	if err != nil {
+		return err
+	}
+	return enc.SetEvent(e)
+}
+
+// Structured copies structured data to a StructuredEncoder
+func (m *StructMessage) Structured(enc StructuredEncoder) error {
+	return enc.SetStructuredEvent(m.Format, bytes.NewReader(m.Bytes))
+}
+
+// Binary returns ErrNotBinary
+func (m StructMessage) Binary(enc BinaryEncoder) error { return ErrNotBinary }
+
+func (*StructMessage) Finish(error) error { return nil }
+
+func (m *StructMessage) SetStructuredEvent(format format.Format, event io.Reader) error {
+	b, err := ioutil.ReadAll(event)
+	if err != nil {
+		return err
+	}
+	m.Format = format
+	m.Bytes = b
+	return nil
+}
+
+var _ Message = (*StructMessage)(nil)           // Test it conforms to the interface
+var _ StructuredEncoder = (*StructMessage)(nil) // Test it conforms to the interface

--- a/pkg/binding/test/test_test.go
+++ b/pkg/binding/test/test_test.go
@@ -36,7 +36,7 @@ func (d dummySR) Receive(ctx context.Context) (binding.Message, error)    { retu
 
 func TestSendReceive(t *testing.T) {
 	sr := make(dummySR)
-	var allIn []binding.Message
+	allIn := []binding.Message{}
 	for _, e := range test.Events() {
 		allIn = append(allIn, binding.EventMessage(e))
 	}

--- a/pkg/binding/to_event.go
+++ b/pkg/binding/to_event.go
@@ -20,10 +20,10 @@ import (
 // * nil, false, true, err if message was binary but error happened during translation
 // * nil, false, false, err if message was event but error happened during translation
 // * nil, false, false, err in other cases
-func ToEvent(message Message, factories ...TransformerFactory) (ce.Event, bool, bool, error) {
-	e := cloudevents.NewEvent()
+func ToEvent(message Message, factories ...TransformerFactory) (e ce.Event, wasStructured bool, wasBinary bool, err error) {
+	e = cloudevents.NewEvent()
 	encoder := &messageToEventBuilder{event: &e}
-	wasStructured, wasBinary, err := Translate(
+	wasStructured, wasBinary, err = Translate(
 		message,
 		func() StructuredEncoder {
 			return encoder

--- a/pkg/binding/to_event_test.go
+++ b/pkg/binding/to_event_test.go
@@ -19,7 +19,7 @@ type toEventTestCase struct {
 }
 
 func TestToEvent(t *testing.T) {
-	var tests []toEventTestCase
+	tests := []toEventTestCase{}
 
 	for _, v := range test.Events() {
 		tests = append(tests, []toEventTestCase{
@@ -68,6 +68,7 @@ func TestToEvent(t *testing.T) {
 		}...)
 	}
 	for _, tt := range tests {
+		tt := tt // Don't use range variable in Run() scope
 		t.Run(tt.name, func(t *testing.T) {
 			got, isStructured, isBinary, err := binding.ToEvent(tt.message)
 			require.NoError(t, err)

--- a/pkg/binding/transcoder/version_test.go
+++ b/pkg/binding/transcoder/version_test.go
@@ -59,6 +59,7 @@ func TestVersionTranscoder(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt // Don't use range variable inside scope
 		factory := Version(spec.V1)
 		t.Run(tt.name, func(t *testing.T) {
 			e, _, _, err := binding.ToEvent(tt.message, factory)


### PR DESCRIPTION
Copy messages for multicast

StructMessage and EventMessage are intended to be full implementations of the
Message interface that are independent of any transport and can be used to hold
a copy of a message in memory independently of the life of an incoming transport
message (e.g. for multicast, queuing etc.) CopyMessage copies an incoming
Message, the copy can be read many times and is independent of the original
message lifecycle (e.g. you might Finish() the original before you're done
multicasting the copy depending on policy)

They are a lot like your MockXMessages but they are not mocks, they're complete
Message implementations. Possibly there's some code overlap that can be cleaned up.

Please review the code carefully. I like what you've done to reduce copying but
there was a lot to take in, so this is a bit rushed.

One question: I intended for 2 types of message representation - Binary and
Structured. Message.Event() and EventMessage were really just implementations of
Binary encoding - not meant to be a third representation. I think you could drop
Message.Event() now that you have ToEvent(Message) so bindings only have to
implement the methods Structured() and Binary().

Signed-off-by: Alan Conway <aconway@redhat.com>
