### PR TITLE
Fix: defeat http.Client memory leak

### DIFF
--- a/pkg/cloudevents/transport/http/transport.go
+++ b/pkg/cloudevents/transport/http/transport.go
@@ -170,7 +170,9 @@ func (t *Transport) Send(ctx context.Context, event cloudevents.Event) (context.
 func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (context.Context, *cloudevents.Event, error) {
 	if t.Client == nil {
 		t.crMu.Lock()
-		t.Client = &http.Client{}
+		if t.Client == nil {
+			t.Client = &http.Client{}
+		}
 		t.crMu.Unlock()
 	}
 


### PR DESCRIPTION
u should check t.Client is nil or not again in mutex lock