### PR TITLE
Fixing PubSub Codec to only support v1 string extensions 

### DIFF
--- a/pkg/cloudevents/transport/pubsub/codec_test.go
+++ b/pkg/cloudevents/transport/pubsub/codec_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+const (
+	prefix = "ce-"
+)
+
 func strptr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
- v1 should support string extensions. In the pubsub codec, we had some legacy code from 0.3, which supported maps, and other types as well.
- This caused a panic when using it from a receive adapter code, trying to decode a "int64" extension: 
panic: cannot convert 1.57947362937361e+15 to int32: out of range

Signed-off-by: Nacho Cano <nachoacano@gmail.com>