### PR TITLE
Rework panic out of the api.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ bazel-*
 # Others
 ## IDE-specific
 *.iml
-
+test/benchmark/http/results/
 tmp/
+

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/pkg/cloudevents/event.go
+++ b/pkg/cloudevents/event.go
@@ -13,11 +13,25 @@ type Event struct {
 	Data        interface{}
 	DataEncoded bool
 	DataBinary  bool
+	FieldErrors map[string]error
 }
 
 const (
 	defaultEventVersion = CloudEventsVersionV02
 )
+
+func (e *Event) fieldError(field string, err error) {
+	if e.FieldErrors == nil {
+		e.FieldErrors = make(map[string]error, 0)
+	}
+	e.FieldErrors[field] = err
+}
+
+func (e *Event) fieldOK(field string) {
+	if e.FieldErrors != nil {
+		delete(e.FieldErrors, field)
+	}
+}
 
 // New returns a new Event, an optional version can be passed to change the
 // default spec version from 0.2 to the provided version.
@@ -51,6 +65,16 @@ func (e Event) ExtensionAs(name string, obj interface{}) error {
 func (e Event) Validate() error {
 	if e.Context == nil {
 		return fmt.Errorf("every event conforming to the CloudEvents specification MUST include a context")
+	}
+
+	if e.FieldErrors != nil {
+		errs := make([]string, 0)
+		for f, e := range e.FieldErrors {
+			errs = append(errs, fmt.Sprintf("%q: %s,", f, e))
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("previous field errors: [%s]", strings.Join(errs, "\n"))
+		}
 	}
 
 	if err := e.Context.Validate(); err != nil {

--- a/pkg/cloudevents/event_interface.go
+++ b/pkg/cloudevents/event_interface.go
@@ -45,7 +45,8 @@ type EventReader interface {
 }
 
 // EventWriter is the interface for writing through an event onto attributes.
-// If an error is thrown by a sub-component, EventWriter panics.
+// If an error is thrown by a sub-component, EventWriter caches the error
+// internally and exposes errors with a call to event.Validate().
 type EventWriter interface {
 	// Context Attributes
 

--- a/pkg/cloudevents/event_reader_writer_test.go
+++ b/pkg/cloudevents/event_reader_writer_test.go
@@ -10,26 +10,29 @@ import (
 )
 
 type ReadWriteTest struct {
-	event   ce.Event
-	set     string
-	want    interface{}
-	wantErr string
+	event     ce.Event
+	set       string
+	want      interface{}
+	corrected interface{} // used in corrected tests.
+	wantErr   string
 }
 
 func TestEventRW_SpecVersion(t *testing.T) {
 	testCases := map[string]ReadWriteTest{
 		"empty v01": {
 			event:   ce.New(),
+			want:    "0.2",
 			set:     "0.1",
 			wantErr: "invalid version",
 		},
 		"empty v02": {
 			event: ce.New(),
-			set:   "0.2",
 			want:  "0.2",
+			set:   "0.2",
 		},
 		"empty v03": {
 			event:   ce.New(),
+			want:    "0.2",
 			set:     "0.3",
 			wantErr: "invalid version",
 		},
@@ -50,35 +53,32 @@ func TestEventRW_SpecVersion(t *testing.T) {
 		},
 		"invalid v01": {
 			event:   ce.New("0.1"),
+			want:    "0.1",
 			set:     "1.1",
 			wantErr: "invalid version",
 		},
 		"invalid v02": {
 			event:   ce.New("0.2"),
+			want:    "0.2",
 			set:     "1.2",
 			wantErr: "invalid version",
 		},
 		"invalid v03": {
 			event:   ce.New("0.3"),
+			want:    "0.3",
 			set:     "1.3",
 			wantErr: "invalid version",
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			tc.event.SetSpecVersion(tc.set)
 			got = tc.event.SpecVersion()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
 		})
 	}
 }
@@ -119,17 +119,12 @@ func TestEventRW_Type(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			tc.event.SetType(tc.set)
 			got = tc.event.Type()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
 		})
 	}
 }
@@ -170,17 +165,12 @@ func TestEventRW_ID(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			tc.event.SetID(tc.set)
 			got = tc.event.ID()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
 		})
 	}
 }
@@ -205,33 +195,81 @@ func TestEventRW_Source(t *testing.T) {
 		"invalid v01": {
 			event:   ce.New("0.1"),
 			set:     "%",
+			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"invalid v02": {
 			event:   ce.New("0.2"),
 			set:     "%",
+			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"invalid v03": {
 			event:   ce.New("0.3"),
 			set:     "%",
+			want:    "",
 			wantErr: "invalid URL escape",
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			tc.event.SetSource(tc.set)
 			got = tc.event.Source()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
+		})
+	}
+}
+
+// Set will be split on pipe, set1|set2
+func TestEventRW_Corrected_Source(t *testing.T) {
+	testCases := map[string]ReadWriteTest{
+		"corrected v01": {
+			event:     ce.New("0.1"),
+			set:       "%|http://good",
+			want:      "",
+			corrected: "http://good",
+			wantErr:   "invalid URL escape",
+		},
+		"corrected v02": {
+			event:     ce.New("0.2"),
+			set:       "%|http://good",
+			want:      "",
+			corrected: "http://good",
+			wantErr:   "invalid URL escape",
+		},
+		"corrected v03": {
+			event:     ce.New("0.3"),
+			set:       "%|http://good",
+			want:      "",
+			corrected: "http://good",
+			wantErr:   "invalid URL escape",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			var got interface{}
+			var err error
+
+			// Split set on pipe.
+			set := strings.Split(tc.set, "|")
+
+			// Set
+
+			tc.event.SetSource(set[0])
+			got = tc.event.Source()
+			err = tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
+
+			// Correct
+
+			tc.event.SetSource(set[1])
+			got = tc.event.Source()
+			err = tc.event.Validate()
+			validateReaderWriterCorrected(t, tc, got, err)
 		})
 	}
 }
@@ -296,17 +334,12 @@ func TestEventRW_Subject(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			tc.event.SetSubject(tc.set)
 			got = tc.event.Subject()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
 		})
 	}
 }
@@ -358,14 +391,6 @@ func TestEventRW_Time(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			if tc.set == "now" {
 				tc.event.SetTime(now) // pull now from outer test.
@@ -373,6 +398,9 @@ func TestEventRW_Time(t *testing.T) {
 				tc.event.SetTime(time.Time{}) // pull now from outer test.
 			}
 			got = tc.event.Time()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
 		})
 	}
 }
@@ -397,16 +425,19 @@ func TestEventRW_SchemaURL(t *testing.T) {
 		"invalid v01": {
 			event:   ce.New("0.1"),
 			set:     "%",
+			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"invalid v02": {
 			event:   ce.New("0.2"),
 			set:     "%",
+			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"invalid v03": {
 			event:   ce.New("0.3"),
 			set:     "%",
+			want:    "",
 			wantErr: "invalid URL escape",
 		},
 		"nilled v01": {
@@ -437,17 +468,12 @@ func TestEventRW_SchemaURL(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			tc.event.SetDataSchema(tc.set)
 			got = tc.event.DataSchema()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
 		})
 	}
 }
@@ -512,17 +538,12 @@ func TestEventRW_DataContentType(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			tc.event.SetDataContentType(tc.set)
 			got = tc.event.DataContentType()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
 		})
 	}
 }
@@ -602,17 +623,12 @@ func TestEventRW_DataContentEncoding(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			var got interface{}
-			defer func() {
-				var err error
-				r := recover()
-				if r != nil {
-					err = r.(error)
-				}
-				validateReaderWriter(t, tc, got, err)
-			}()
 
 			tc.event.SetDataContentEncoding(tc.set)
 			got = tc.event.DeprecatedDataContentEncoding()
+
+			err := tc.event.Validate()
+			validateReaderWriter(t, tc, got, err)
 		})
 	}
 }
@@ -621,9 +637,6 @@ func validateReaderWriter(t *testing.T, tc ReadWriteTest, got interface{}, err e
 	var gotErr string
 	if err != nil {
 		gotErr = err.Error()
-		if tc.wantErr == "" {
-			t.Errorf("unexpected no error, got %q", gotErr)
-		}
 	}
 	if tc.wantErr != "" {
 		if !strings.Contains(gotErr, tc.wantErr) {
@@ -631,6 +644,21 @@ func validateReaderWriter(t *testing.T, tc ReadWriteTest, got interface{}, err e
 		}
 	}
 	if diff := cmp.Diff(tc.want, got); diff != "" {
+		t.Errorf("unexpected (-want, +got) = %v", diff)
+	}
+}
+
+func validateReaderWriterCorrected(t *testing.T, tc ReadWriteTest, got interface{}, err error) {
+	var gotErr string
+	if err != nil {
+		gotErr = err.Error()
+	}
+	if tc.wantErr != "" {
+		if strings.Contains(gotErr, tc.wantErr) {
+			t.Errorf("unexpected error, expected to NOT contain %q, got: %q ", tc.wantErr, gotErr)
+		}
+	}
+	if diff := cmp.Diff(tc.corrected, got); diff != "" {
 		t.Errorf("unexpected (-want, +got) = %v", diff)
 	}
 }

--- a/pkg/cloudevents/event_writer.go
+++ b/pkg/cloudevents/event_writer.go
@@ -20,75 +20,97 @@ func (e *Event) SetSpecVersion(v string) {
 		case CloudEventsVersionV1:
 			e.Context = EventContextV1{}.AsV1()
 		default:
-			panic(fmt.Errorf("a valid spec version is required: [%s, %s, %s, %s]",
+			e.fieldError("specversion", fmt.Errorf("a valid spec version is required: [%s, %s, %s, %s]",
 				CloudEventsVersionV01, CloudEventsVersionV02, CloudEventsVersionV03, CloudEventsVersionV1))
+			return
 		}
+		e.fieldOK("specversion")
 		return
 	}
 	if err := e.Context.SetSpecVersion(v); err != nil {
-		panic(err)
+		e.fieldError("specversion", err)
+	} else {
+		e.fieldOK("specversion")
 	}
 }
 
 // SetType implements EventWriter.SetType
 func (e *Event) SetType(t string) {
 	if err := e.Context.SetType(t); err != nil {
-		panic(err)
+		e.fieldError("type", err)
+	} else {
+		e.fieldOK("type")
 	}
 }
 
 // SetSource implements EventWriter.SetSource
 func (e *Event) SetSource(s string) {
 	if err := e.Context.SetSource(s); err != nil {
-		panic(err)
+		e.fieldError("source", err)
+	} else {
+		e.fieldOK("source")
 	}
 }
 
 // SetSubject implements EventWriter.SetSubject
 func (e *Event) SetSubject(s string) {
 	if err := e.Context.SetSubject(s); err != nil {
-		panic(err)
+		e.fieldError("subject", err)
+	} else {
+		e.fieldOK("subject")
 	}
 }
 
 // SetID implements EventWriter.SetID
 func (e *Event) SetID(id string) {
 	if err := e.Context.SetID(id); err != nil {
-		panic(err)
+		e.fieldError("id", err)
+	} else {
+		e.fieldOK("id")
 	}
 }
 
 // SetTime implements EventWriter.SetTime
 func (e *Event) SetTime(t time.Time) {
 	if err := e.Context.SetTime(t); err != nil {
-		panic(err)
+		e.fieldError("time", err)
+	} else {
+		e.fieldOK("time")
 	}
 }
 
 // SetDataSchema implements EventWriter.SetDataSchema
 func (e *Event) SetDataSchema(s string) {
 	if err := e.Context.SetDataSchema(s); err != nil {
-		panic(err)
+		e.fieldError("dataschema", err)
+	} else {
+		e.fieldOK("dataschema")
 	}
 }
 
 // SetDataContentType implements EventWriter.SetDataContentType
 func (e *Event) SetDataContentType(ct string) {
 	if err := e.Context.SetDataContentType(ct); err != nil {
-		panic(err)
+		e.fieldError("datacontenttype", err)
+	} else {
+		e.fieldOK("datacontenttype")
 	}
 }
 
 // DeprecatedSetDataContentEncoding implements EventWriter.DeprecatedSetDataContentEncoding
 func (e *Event) SetDataContentEncoding(enc string) {
 	if err := e.Context.DeprecatedSetDataContentEncoding(enc); err != nil {
-		panic(err)
+		e.fieldError("datacontentencoding", err)
+	} else {
+		e.fieldOK("datacontentencoding")
 	}
 }
 
 // SetExtension implements EventWriter.SetExtension
 func (e *Event) SetExtension(name string, obj interface{}) {
 	if err := e.Context.SetExtension(name, obj); err != nil {
-		panic(err)
+		e.fieldError("extension:"+name, err)
+	} else {
+		e.fieldOK("extension:" + name)
 	}
 }


### PR DESCRIPTION
fixes: https://github.com/cloudevents/sdk-go/issues/290

Before the SDK would panic on the builder like methods for setting fields on the event as it constructed if there was a clear syntactic violation. 

This change moves the bubbling of those errors for when they call event.Validate(), the errors are assembled and sent as a single error.

A user can clear an error if they `event.Set<Field>(correctedValue)` again on the same field. 