### PR TITLE
Add SetContextHeaders setter.

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -147,4 +147,5 @@ var (
 
 	HTTPTransportContextFrom = http.TransportContextFrom
 	ContextWithHeader        = http.ContextWithHeader
+	SetContextHeaders        = http.SetContextHeaders
 )

--- a/pkg/cloudevents/transport/http/context.go
+++ b/pkg/cloudevents/transport/http/context.go
@@ -180,6 +180,11 @@ func HeaderFrom(ctx context.Context) http.Header {
 	return ch
 }
 
+// SetContextHeader sets the context's headers replacing any headers currently in context.
+func SetContextHeaders(ctx context.Context, headers http.Header) context.Context {
+	return context.WithValue(ctx, headerKey, headers)
+}
+
 // Opaque key type used to store long poll target.
 type longPollTargetKeyType struct{}
 

--- a/pkg/cloudevents/transport/http/context_test.go
+++ b/pkg/cloudevents/transport/http/context_test.go
@@ -268,3 +268,48 @@ func TestAttendToHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestSetHeaders(t *testing.T) {
+	testCases := map[string]struct {
+		initial nethttp.Header
+		want    nethttp.Header
+	}{
+		"nil": {
+			want: nethttp.Header{},
+		},
+		"no initial": {
+			want: func() nethttp.Header {
+				h := nethttp.Header{}
+				h.Set("unit", "test header")
+				h.Set("testing", "header unit")
+				return h
+			}(),
+		},
+		"with initial": {
+			initial: func() nethttp.Header {
+				h := nethttp.Header{}
+				h.Set("unit", "test header")
+				h.Set("testing", "header unit")
+				return h
+			}(),
+			want: func() nethttp.Header {
+				h := nethttp.Header{}
+				h.Set("new", "test header")
+				h.Set("testing", "header unit")
+				return h
+			}(),
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			ctx := context.TODO()
+			ctx = http.SetContextHeaders(ctx, tc.initial)
+			ctx = http.SetContextHeaders(ctx, tc.want)
+			got := http.HeaderFrom(ctx)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected (-want, +got) = %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
It is occasionally useful to set new headers while discarding headers
that were set for a previous request. See for example
https://github.com/knative/eventing/issues/1953.