### PR TITLE
Replace the HTTP transport Client field with unexported transport field.

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -142,6 +142,7 @@ var (
 	WithMiddleware           = http.WithMiddleware
 	WithLongPollTarget       = http.WithLongPollTarget
 	WithListener             = http.WithListener
+	WithHTTPTransport        = http.WithHTTPTransport
 
 	// HTTP Context
 

--- a/cmd/samples/http/sender-with-custom-client/main.go
+++ b/cmd/samples/http/sender-with-custom-client/main.go
@@ -72,11 +72,6 @@ func _main(args []string, env envConfig) int {
 
 	tlsConfig.BuildNameToCertificate()
 
-	// Creating client with TLS and custom configuration
-	client := &http.Client{
-		Transport: &http.Transport{TLSClientConfig: tlsConfig},
-	}
-
 	seq := 0
 	for _, dataContentType := range []string{"application/json", "application/xml"} {
 		for _, encoding := range []cloudevents.HTTPEncoding{cloudevents.HTTPBinaryV03, cloudevents.HTTPStructuredV03} {
@@ -84,10 +79,10 @@ func _main(args []string, env envConfig) int {
 			t, err := cloudevents.NewHTTPTransport(
 				cloudevents.WithTarget(env.Target),
 				cloudevents.WithEncoding(encoding),
+				// Use custom transport
+				cloudevents.WithHTTPTransport(&http.Transport{TLSClientConfig: tlsConfig}),
 			)
 
-			// Using the custom client
-			t.Client = client
 			if err != nil {
 				log.Printf("failed to create transport, %v", err)
 				return 1

--- a/pkg/cloudevents/transport/http/options.go
+++ b/pkg/cloudevents/transport/http/options.go
@@ -264,3 +264,11 @@ func WithLongPollTarget(targetUrl string) Option {
 		return fmt.Errorf("http long poll target option was empty string")
 	}
 }
+
+// WithHTTPTransport sets the HTTP client transport.
+func WithHTTPTransport(httpTransport nethttp.RoundTripper) Option {
+	return func(t *Transport) error {
+		t.transport = httpTransport
+		return nil
+	}
+}

--- a/pkg/cloudevents/transport/http/transport_test.go
+++ b/pkg/cloudevents/transport/http/transport_test.go
@@ -63,18 +63,17 @@ func doConcurrently(concurrency int, duration time.Duration, fn task) error {
 // An example of how to make a stable client under sustained
 // concurrency sending to a single host
 func makeStableClient(addr string) (*cehttp.Transport, error) {
-	ceClient, err := cehttp.New(cehttp.WithTarget(addr))
-	if err != nil {
-		return nil, err
-	}
 	netHTTPTransport := &http.Transport{
 		MaxIdleConnsPerHost: 1000,
 		MaxConnsPerHost:     5000,
 	}
-	netHTTPClient := &http.Client{
-		Transport: netHTTPTransport,
+	ceClient, err := cehttp.New(
+		cehttp.WithTarget(addr),
+		cehttp.WithHTTPTransport(netHTTPTransport),
+	)
+	if err != nil {
+		return nil, err
 	}
-	ceClient.Client = netHTTPClient
 	return ceClient, nil
 }
 

--- a/test/benchmark/http/http_mock.go
+++ b/test/benchmark/http/http_mock.go
@@ -37,19 +37,21 @@ func MockedSender(options ...http.SenderOptionFunc) binding.Sender {
 }
 
 func MockedClient() (cloudevents.Client, *cehttp.Transport) {
-	t, err := cehttp.New(cehttp.WithTarget("http://localhost"))
-
-	if err != nil {
-		panic(err)
-	}
-
-	t.Client = NewTestClient(func(req *nethttp.Request) *nethttp.Response {
+	mockTransport := RoundTripFunc(func(req *nethttp.Request) *nethttp.Response {
 		return &nethttp.Response{
 			StatusCode: 202,
 			Header:     make(nethttp.Header),
 			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
 		}
 	})
+	t, err := cehttp.New(
+		cehttp.WithTarget("http://localhost"),
+		cehttp.WithHTTPTransport(mockTransport),
+	)
+
+	if err != nil {
+		panic(err)
+	}
 
 	client, err := cloudevents.NewClient(t)
 


### PR DESCRIPTION
Add a new HTTP option which allows setting the HTTP transport while
keeping the field unexported for improved safety. This change will allow
the internal HTTP client to be constructed with additional middleware
if needed, for example, for trace propagation.