### PR TITLE
Remove receive/fn observable.

### DIFF
--- a/pkg/cloudevents/client/client.go
+++ b/pkg/cloudevents/client/client.go
@@ -129,13 +129,7 @@ func (c *ceClient) Receive(ctx context.Context, event cloudevents.Event, resp *c
 
 func (c *ceClient) obsReceive(ctx context.Context, event cloudevents.Event, resp *cloudevents.EventResponse) error {
 	if c.fn != nil {
-		ctx, rFn := observability.NewReporter(ctx, reportReceiveFn)
 		err := c.fn.invoke(ctx, event, resp)
-		if err != nil {
-			rFn.Error()
-		} else {
-			rFn.OK()
-		}
 
 		// Apply the defaulter chain to the outgoing event.
 		if err == nil && resp != nil && resp.Event != nil && len(c.eventDefaulterFns) > 0 {

--- a/pkg/cloudevents/client/observability.go
+++ b/pkg/cloudevents/client/observability.go
@@ -31,7 +31,6 @@ var _ observability.Observable = observed(0)
 const (
 	reportSend observed = iota
 	reportReceive
-	reportReceiveFn
 )
 
 // TraceName implements Observable.TraceName
@@ -41,8 +40,6 @@ func (o observed) TraceName() string {
 		return "client/send"
 	case reportReceive:
 		return "client/receive"
-	case reportReceiveFn:
-		return "client/receive/fn"
 	default:
 		return "client/unknown"
 	}
@@ -55,8 +52,6 @@ func (o observed) MethodName() string {
 		return "send"
 	case reportReceive:
 		return "receive"
-	case reportReceiveFn:
-		return "receive/fn"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
Very little work is done outside of receive/fn in the receive
observable making separate observables unnecessary.
