### PR TITLE
Separate trace handling from Observable.

### DIFF
--- a/cmd/samples/stats/main.go
+++ b/cmd/samples/stats/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/json"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/xml"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
@@ -34,9 +33,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
-
-	// Uncomment the following to see that tracing can be disabled.
-	observability.EnableTracing(false)
 
 	go mainSender()
 	go mainMetrics()

--- a/pkg/binding/example_using_test.go
+++ b/pkg/binding/example_using_test.go
@@ -14,7 +14,7 @@ const count = 3 // Example ends after this many events.
 
 // The sender uses the cloudevents.Client API, not the transport APIs directly.
 func runSender(w io.Writer) error {
-	c, err := client.New(NewExTransport(nil, w))
+	c, err := client.New(NewExTransport(nil, w), client.WithoutTracePropagation())
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func runReceiver(r io.Reader) error {
 		}
 		return nil
 	}
-	c, err := client.New(NewExTransport(r, nil))
+	c, err := client.New(NewExTransport(r, nil), client.WithoutTracePropagation())
 	if err != nil {
 		return err
 	}

--- a/pkg/cloudevents/datacodec/json/observability.go
+++ b/pkg/cloudevents/datacodec/json/observability.go
@@ -33,18 +33,6 @@ const (
 	reportDecode
 )
 
-// TraceName implements Observable.TraceName
-func (o observed) TraceName() string {
-	switch o {
-	case reportEncode:
-		return "datacodec/json/encode"
-	case reportDecode:
-		return "datacodec/json/decode"
-	default:
-		return "datacodec/json/unknown"
-	}
-}
-
 // MethodName implements Observable.MethodName
 func (o observed) MethodName() string {
 	switch o {

--- a/pkg/cloudevents/datacodec/observability.go
+++ b/pkg/cloudevents/datacodec/observability.go
@@ -33,18 +33,6 @@ const (
 	reportDecode
 )
 
-// TraceName implements Observable.TraceName
-func (o observed) TraceName() string {
-	switch o {
-	case reportEncode:
-		return "datacodec/encode"
-	case reportDecode:
-		return "datacodec/decode"
-	default:
-		return "datacodec/unknown"
-	}
-}
-
 // MethodName implements Observable.MethodName
 func (o observed) MethodName() string {
 	switch o {

--- a/pkg/cloudevents/datacodec/xml/observability.go
+++ b/pkg/cloudevents/datacodec/xml/observability.go
@@ -33,18 +33,6 @@ const (
 	reportDecode
 )
 
-// TraceName implements Observable.TraceName
-func (o observed) TraceName() string {
-	switch o {
-	case reportEncode:
-		return "datacodec/xml/encode"
-	case reportDecode:
-		return "datacodec/xml/decode"
-	default:
-		return "datacodec/xml/unknown"
-	}
-}
-
 // MethodName implements Observable.MethodName
 func (o observed) MethodName() string {
 	switch o {

--- a/pkg/cloudevents/event_observability.go
+++ b/pkg/cloudevents/event_observability.go
@@ -38,18 +38,6 @@ const (
 	reportUnmarshal
 )
 
-// TraceName implements Observable.TraceName
-func (o observed) TraceName() string {
-	switch o {
-	case reportMarshal:
-		return "cloudevents/event/marshaljson"
-	case reportUnmarshal:
-		return "cloudevents/event/unmarshaljson"
-	default:
-		return "cloudevents/event/unknwown"
-	}
-}
-
 // MethodName implements Observable.MethodName
 func (o observed) MethodName() string {
 	switch o {
@@ -77,11 +65,6 @@ type eventJSONObserved struct {
 
 // Adheres to Observable
 var _ observability.Observable = (*eventJSONObserved)(nil)
-
-// TraceName implements Observable.TraceName
-func (c eventJSONObserved) TraceName() string {
-	return fmt.Sprintf("%s/%s", c.o.TraceName(), c.v)
-}
 
 // MethodName implements Observable.MethodName
 func (c eventJSONObserved) MethodName() string {

--- a/pkg/cloudevents/observability/observer.go
+++ b/pkg/cloudevents/observability/observer.go
@@ -7,20 +7,18 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
-	"go.opencensus.io/trace"
 )
 
 // Observable represents the the customization used by the Reporter for a given
 // measurement and trace for a single method.
 type Observable interface {
-	TraceName() string
 	MethodName() string
 	LatencyMs() *stats.Float64Measure
 }
 
-// Reporter represents a running latency counter and trace span. When Error or
-// OK are called, the latency is calculated and the trace space is ended. Error
-// or OK are only allowed to be called once.
+// Reporter represents a running latency counter. When Error or OK are
+// called, the latency is calculated. Error or OK are only allowed to
+// be called once.
 type Reporter interface {
 	Error()
 	OK()
@@ -28,7 +26,6 @@ type Reporter interface {
 
 type reporter struct {
 	ctx   context.Context
-	span  *trace.Span
 	on    Observable
 	start time.Time
 	once  sync.Once
@@ -39,55 +36,14 @@ func LatencyTags() []tag.Key {
 	return []tag.Key{KeyMethod, KeyResult}
 }
 
-var (
-	// Tracing is disabled by default. It is very useful for profiling an
-	// application.
-	tracingEnabled = false
-)
+// Deprecated. Tracing is always enabled.
+func EnableTracing(enabled bool) {}
 
-// EnableTracing allows control over if tracing is enabled for the sdk.
-// Default is false. This applies to all of the
-// `github.com/cloudevents/sdk-go/...` package.
-func EnableTracing(enabled bool) {
-	tracingEnabled = enabled
-}
-
-// NewReporter creates and returns a reporter wrapping the provided Observable,
-// and injects a trace span into the context.
+// NewReporter creates and returns a reporter wrapping the provided Observable.
 func NewReporter(ctx context.Context, on Observable) (context.Context, Reporter) {
-	var span *trace.Span
-	if tracingEnabled {
-		ctx, span = trace.StartSpan(ctx, on.TraceName())
-	}
 	r := &reporter{
 		ctx:   ctx,
 		on:    on,
-		span:  span,
-		start: time.Now(),
-	}
-	r.tagMethod()
-	return ctx, r
-}
-
-// NewReporter creates and returns a reporter wrapping the provided Observable,
-// and injects a trace span with the given remote parent into the context.
-func NewReporterWithRemoteParent(ctx context.Context, on Observable, parent trace.SpanContext) (context.Context, Reporter) {
-	var span *trace.Span
-	transportSpan := trace.FromContext(ctx)
-	ctx, span = trace.StartSpanWithRemoteParent(ctx, on.TraceName(), parent)
-	if transportSpan != nil {
-		// Add link to the transport trace.
-		transportSc := transportSpan.SpanContext()
-		span.AddLink(trace.Link{
-			TraceID: transportSc.TraceID,
-			SpanID:  transportSc.SpanID,
-			Type:    trace.LinkTypeParent,
-		})
-	}
-	r := &reporter{
-		ctx:   ctx,
-		on:    on,
-		span:  span,
 		start: time.Now(),
 	}
 	r.tagMethod()
@@ -105,9 +61,6 @@ func (r *reporter) tagMethod() {
 func (r *reporter) record() {
 	ms := float64(time.Since(r.start) / time.Millisecond)
 	stats.Record(r.ctx, r.on.LatencyMs().M(ms))
-	if r.span != nil {
-		r.span.End()
-	}
 }
 
 // Error records the result as an error.

--- a/pkg/cloudevents/transport/http/observability.go
+++ b/pkg/cloudevents/transport/http/observability.go
@@ -41,24 +41,6 @@ const (
 	reportDecode
 )
 
-// TraceName implements Observable.TraceName
-func (o observed) TraceName() string {
-	switch o {
-	case reportSend:
-		return "transport/http/send"
-	case reportReceive:
-		return "transport/http/receive"
-	case reportServeHTTP:
-		return "transport/http/servehttp"
-	case reportEncode:
-		return "transport/http/encode"
-	case reportDecode:
-		return "transport/http/decode"
-	default:
-		return "transport/http/unknown"
-	}
-}
-
 // MethodName implements Observable.MethodName
 func (o observed) MethodName() string {
 	switch o {
@@ -92,11 +74,6 @@ type CodecObserved struct {
 
 // Adheres to Observable
 var _ observability.Observable = (*CodecObserved)(nil)
-
-// TraceName implements Observable.TraceName
-func (c CodecObserved) TraceName() string {
-	return fmt.Sprintf("%s/%s", c.o.TraceName(), c.c)
-}
 
 // MethodName implements Observable.MethodName
 func (c CodecObserved) MethodName() string {

--- a/test/http/direct.go
+++ b/test/http/direct.go
@@ -50,6 +50,7 @@ func ClientDirect(t *testing.T, tc DirectTapTest, topts ...cehttp.Option) {
 	ce, err := cloudevents.NewClient(
 		transport,
 		cloudevents.WithEventDefaulter(AlwaysThen(tc.now)),
+		cloudevents.WithoutTracePropagation(),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/test/http/loopback.go
+++ b/test/http/loopback.go
@@ -62,6 +62,7 @@ func ClientLoopback(t *testing.T, tc TapTest, topts ...cehttp.Option) {
 	ce, err := cloudevents.NewClient(
 		transport,
 		cloudevents.WithEventDefaulter(AlwaysThen(tc.now)),
+		cloudevents.WithoutTracePropagation(),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/test/http/middleware.go
+++ b/test/http/middleware.go
@@ -32,6 +32,7 @@ func ClientMiddleware(t *testing.T, tc TapTest, topts ...cehttp.Option) {
 	ce, err := cloudevents.NewClient(
 		transport,
 		cloudevents.WithEventDefaulter(AlwaysThen(tc.now)),
+		cloudevents.WithoutTracePropagation(),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This allows trace spans to be created with a different granularity
than that of Observable metrics. In particular, this commit replaces
the nested send / receive spans into a single send and receive span
created in the client. In addition, this removes spans from the encode / decode reporters which are
created without access to context making them unable to attach tracing
data to the active trace. With the reduced granularity of emitted
spans, it should now be appropriate to always enable trace
handling. As such, the EnableTracing function has been marked as
deprecated and will have no effect.

The client send and receive spans have been renamed with the prefix
"cloudevents" in order to distinguish them from send and receive spans
created by other libraries. Additionally these spans are annotated
with cloud event attributes from handled events.