### PR TITLE
Default HTTP Codec to V1

### DIFF
--- a/pkg/cloudevents/transport/http/codec.go
+++ b/pkg/cloudevents/transport/http/codec.go
@@ -37,8 +37,6 @@ var _ transport.Codec = (*Codec)(nil)
 
 func (c *Codec) loadCodec(encoding Encoding) (transport.Codec, error) {
 	switch encoding {
-	case Default:
-		fallthrough
 	case BinaryV01, StructuredV01:
 		c._v01.Do(func() {
 			c.v01 = &CodecV01{DefaultEncoding: c.Encoding}
@@ -54,7 +52,7 @@ func (c *Codec) loadCodec(encoding Encoding) (transport.Codec, error) {
 			c.v03 = &CodecV03{DefaultEncoding: c.Encoding}
 		})
 		return c.v03, nil
-	case BinaryV1, StructuredV1, BatchedV1:
+	case BinaryV1, StructuredV1, BatchedV1, Default:
 		c._v1.Do(func() {
 			c.v1 = &CodecV1{DefaultEncoding: c.Encoding}
 		})


### PR DESCRIPTION
If a selection strategy is not chosen, the HTTP transport will chose a default codec to use regardless of the version of the event being sent. This changes the version of the default codec from 0.1 to 1.0.

See also #297.