### PR TITLE
Fixed #332

### DIFF
--- a/pkg/event/eventcontext_test.go
+++ b/pkg/event/eventcontext_test.go
@@ -4,71 +4,73 @@ import (
 	"testing"
 	"time"
 
-	event2 "github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/stretchr/testify/require"
 
-	"github.com/cloudevents/sdk-go/pkg/types"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/types"
 )
 
 func TestContextAsV01(t *testing.T) {
 	now := types.Timestamp{Time: time.Now()}
 
 	testCases := map[string]struct {
-		event event2.Event
-		want  *event2.EventContextV01
+		event event.Event
+		want  *event.EventContextV01
 	}{
 		"empty, no conversion": {
-			event: event2.Event{
-				Context: &event2.EventContextV01{},
+			event: event.Event{
+				Context: &event.EventContextV01{},
 			},
-			want: &event2.EventContextV01{
+			want: &event.EventContextV01{
 				CloudEventsVersion: "0.1",
 			},
 		},
 		"min v01, no conversion": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV01(),
 			},
 			want: MinEventContextV01(),
 		},
 		"full v01, no conversion": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV01(now),
 			},
 			want: FullEventContextV01(now),
 		},
 		"min v02 -> v01": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV02(),
 			},
 			want: MinEventContextV01(),
 		},
 		"full v02 -> v01": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV02(now),
 			},
 			want: FullEventContextV01(now),
 		},
 		"min v03 -> v01": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV03(),
 			},
 			want: MinEventContextV01(),
 		},
 		"full v03 -> v01": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV03(now),
 			},
 			want: FullEventContextV01(now),
 		},
 		"min v1 -> v01": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV1(),
 			},
 			want: MinEventContextV01(),
 		},
 		"full v1 -> v01": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV1(now),
 			},
 			want: FullEventContextV01(now),
@@ -90,62 +92,62 @@ func TestContextAsV02(t *testing.T) {
 	now := types.Timestamp{Time: time.Now()}
 
 	testCases := map[string]struct {
-		event event2.Event
-		want  *event2.EventContextV02
+		event event.Event
+		want  *event.EventContextV02
 	}{
 		"empty, no conversion": {
-			event: event2.Event{
-				Context: &event2.EventContextV02{},
+			event: event.Event{
+				Context: &event.EventContextV02{},
 			},
-			want: &event2.EventContextV02{
+			want: &event.EventContextV02{
 				SpecVersion: "0.2",
 			},
 		},
 		"min v01 -> v02": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV01(),
 			},
 			want: MinEventContextV02(),
 		},
 		"full v01 -> v02": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV01(now),
 			},
 			want: FullEventContextV02(now),
 		},
 		"min v02, no conversion": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV02(),
 			},
 			want: MinEventContextV02(),
 		},
 		"full v02, no conversion": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV02(now),
 			},
 			want: FullEventContextV02(now),
 		},
 		"min v03 -> v02": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV03(),
 			},
 			want: MinEventContextV02(),
 		},
 		"full v03 -> v02": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV03(now),
 			},
 			want: FullEventContextV02(now),
 		},
 
 		"min v1 -> v02": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV1(),
 			},
 			want: MinEventContextV02(),
 		},
 		"full v1 -> v02": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV1(now),
 			},
 			want: FullEventContextV02(now),
@@ -167,61 +169,61 @@ func TestContextAsV03(t *testing.T) {
 	now := types.Timestamp{Time: time.Now()}
 
 	testCases := map[string]struct {
-		event event2.Event
-		want  *event2.EventContextV03
+		event event.Event
+		want  *event.EventContextV03
 	}{
 		"empty, no conversion": {
-			event: event2.Event{
-				Context: &event2.EventContextV03{},
+			event: event.Event{
+				Context: &event.EventContextV03{},
 			},
-			want: &event2.EventContextV03{
+			want: &event.EventContextV03{
 				SpecVersion: "0.3",
 			},
 		},
 		"min v01 -> v03": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV01(),
 			},
 			want: MinEventContextV03(),
 		},
 		"full v01 -> v03": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV01(now),
 			},
 			want: FullEventContextV03(now),
 		},
 		"min v02 -> v03": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV02(),
 			},
 			want: MinEventContextV03(),
 		},
 		"full v02 -> v03": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV02(now),
 			},
 			want: FullEventContextV03(now),
 		},
 		"min v03, no conversion": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV03(),
 			},
 			want: MinEventContextV03(),
 		},
 		"full v03, no conversion": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV03(now),
 			},
 			want: FullEventContextV03(now),
 		},
 		"min v1 -> v03": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV1(),
 			},
 			want: MinEventContextV03(),
 		},
 		"full v1 -> v03": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV1(now),
 			},
 			want: FullEventContextV03(now),
@@ -243,61 +245,61 @@ func TestContextAsV1(t *testing.T) {
 	now := types.Timestamp{Time: time.Now()}
 
 	testCases := map[string]struct {
-		event event2.Event
-		want  *event2.EventContextV1
+		event event.Event
+		want  *event.EventContextV1
 	}{
 		"empty, no conversion": {
-			event: event2.Event{
-				Context: &event2.EventContextV1{},
+			event: event.Event{
+				Context: &event.EventContextV1{},
 			},
-			want: &event2.EventContextV1{
+			want: &event.EventContextV1{
 				SpecVersion: "1.0",
 			},
 		},
 		"min v01 -> v1": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV01(),
 			},
 			want: MinEventContextV1(),
 		},
 		"full v01 -> v1": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV01(now),
 			},
 			want: FullEventContextV1(now),
 		},
 		"min v02 -> v1": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV02(),
 			},
 			want: MinEventContextV1(),
 		},
 		"full v02 -> v1": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV02(now),
 			},
 			want: FullEventContextV1(now),
 		},
 		"min v03 -> v1": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV03(),
 			},
 			want: MinEventContextV1(),
 		},
 		"full v03 -> v1": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV03(now),
 			},
 			want: FullEventContextV1(now),
 		},
 		"min v1, no conversion": {
-			event: event2.Event{
+			event: event.Event{
 				Context: MinEventContextV1(),
 			},
 			want: MinEventContextV1(),
 		},
 		"full v1, no conversion": {
-			event: event2.Event{
+			event: event.Event{
 				Context: FullEventContextV1(now),
 			},
 			want: FullEventContextV1(now),
@@ -311,6 +313,43 @@ func TestContextAsV1(t *testing.T) {
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected (-want, +got) = %v", diff)
 			}
+		})
+	}
+}
+
+func TestEventContextClone(t *testing.T) {
+	tests := []struct {
+		name    string
+		context event.EventContext
+	}{
+		{
+			name:    "v0.1",
+			context: FullEventContextV01(types.Timestamp{Time: time.Now()}),
+		},
+		{
+			name:    "v0.2",
+			context: FullEventContextV02(types.Timestamp{Time: time.Now()}),
+		},
+		{
+			name:    "v0.3",
+			context: FullEventContextV03(types.Timestamp{Time: time.Now()}),
+		},
+		{
+			name:    "v1.0",
+			context: FullEventContextV1(types.Timestamp{Time: time.Now()}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			initial := test.context
+			require.NoError(t, initial.SetExtension("aaa", "bbb"))
+
+			clone := initial.Clone()
+			require.NoError(t, clone.SetExtension("aaa", "ccc"))
+
+			val, err := initial.GetExtension("aaa")
+			require.NoError(t, err)
+			require.Equal(t, "bbb", val)
 		})
 	}
 }

--- a/pkg/event/eventcontext_v01.go
+++ b/pkg/event/eventcontext_v01.go
@@ -76,7 +76,21 @@ func (ec *EventContextV01) SetExtension(name string, value interface{}) error {
 
 // Clone implements EventContextConverter.Clone
 func (ec EventContextV01) Clone() EventContext {
-	return ec.AsV01()
+	ev01 := ec.AsV01()
+	ev01.Extensions = ev01.cloneExtensions()
+	return ev01
+}
+
+func (ec *EventContextV01) cloneExtensions() map[string]interface{} {
+	old := ec.Extensions
+	if old == nil {
+		return nil
+	}
+	new := make(map[string]interface{}, len(ec.Extensions))
+	for k, v := range old {
+		new[k] = v
+	}
+	return new
 }
 
 // AsV01 implements EventContextConverter.AsV01

--- a/pkg/event/eventcontext_v02.go
+++ b/pkg/event/eventcontext_v02.go
@@ -85,7 +85,21 @@ func (ec *EventContextV02) SetExtension(name string, value interface{}) error {
 
 // Clone implements EventContextConverter.Clone
 func (ec EventContextV02) Clone() EventContext {
-	return ec.AsV02()
+	ec02 := ec.AsV02()
+	ec02.Extensions = ec02.cloneExtensions()
+	return ec02
+}
+
+func (ec *EventContextV02) cloneExtensions() map[string]interface{} {
+	old := ec.Extensions
+	if old == nil {
+		return nil
+	}
+	new := make(map[string]interface{}, len(ec.Extensions))
+	for k, v := range old {
+		new[k] = v
+	}
+	return new
 }
 
 // AsV01 implements EventContextConverter.AsV01

--- a/pkg/event/eventcontext_v03.go
+++ b/pkg/event/eventcontext_v03.go
@@ -94,7 +94,21 @@ func (ec *EventContextV03) SetExtension(name string, value interface{}) error {
 
 // Clone implements EventContextConverter.Clone
 func (ec EventContextV03) Clone() EventContext {
-	return ec.AsV03()
+	ec03 := ec.AsV03()
+	ec03.Extensions = ec03.cloneExtensions()
+	return ec03
+}
+
+func (ec *EventContextV03) cloneExtensions() map[string]interface{} {
+	old := ec.Extensions
+	if old == nil {
+		return nil
+	}
+	new := make(map[string]interface{}, len(ec.Extensions))
+	for k, v := range old {
+		new[k] = v
+	}
+	return new
 }
 
 // AsV01 implements EventContextConverter.AsV01

--- a/pkg/event/eventcontext_v1.go
+++ b/pkg/event/eventcontext_v1.go
@@ -97,7 +97,21 @@ func (ec *EventContextV1) SetExtension(name string, value interface{}) error {
 
 // Clone implements EventContextConverter.Clone
 func (ec EventContextV1) Clone() EventContext {
-	return ec.AsV1()
+	ec1 := ec.AsV1()
+	ec1.Extensions = ec1.cloneExtensions()
+	return ec1
+}
+
+func (ec *EventContextV1) cloneExtensions() map[string]interface{} {
+	old := ec.Extensions
+	if old == nil {
+		return nil
+	}
+	new := make(map[string]interface{}, len(ec.Extensions))
+	for k, v := range old {
+		new[k] = v
+	}
+	return new
 }
 
 // AsV01 implements EventContextConverter.AsV01

--- a/pkg/event/eventcontext_v1_test.go
+++ b/pkg/event/eventcontext_v1_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/pkg/event"
-
-	"github.com/cloudevents/sdk-go/pkg/types"
 	"github.com/google/go-cmp/cmp"
+
+	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 )
 
 func TestValidateV1(t *testing.T) {

--- a/pkg/event/eventcontext_v1_test.go
+++ b/pkg/event/eventcontext_v1_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	ce "github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/types"
 )
 
 func TestValidateV1(t *testing.T) {

--- a/test/http/direct_v1_test.go
+++ b/test/http/direct_v1_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 )
 
 func TestSenderReceiver_binary_v01(t *testing.T) {
@@ -88,7 +89,7 @@ func TestSenderReceiver_structured_v01(t *testing.T) {
 				Header: map[string][]string{
 					"content-type": {"application/cloudevents+json"},
 				},
-				Body:          fmt.Sprintf(`{"data":{"hello":"unittest"},"id":"ABC-123","source":"/unit/test/client","specversion":"1.0","subject":"resource","time":%q,"type":"unit.test.client.sent"}`, now.UTC().Format(time.RFC3339Nano)),
+				Body:          fmt.Sprintf(`{"data":{"hello":"unittest"},"id":"ABC-123","source":"/unit/test/client","specversion":"1.0","subject":"resource","time":%q,"type":"unit.test.client.sent"}`, types.FormatTime(now.UTC())),
 				ContentLength: 182,
 			},
 		},

--- a/test/http/direct_v1_test.go
+++ b/test/http/direct_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/cloudevents/sdk-go"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/cloudevents/sdk-go/pkg/types"
 )
 
 func TestSenderReceiver_binary_v01(t *testing.T) {


### PR DESCRIPTION
Fixed #332, now the `Clone()` method copies the extensions map

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>