### PR TITLE
Fixed Attribute.Name()

### DIFF
--- a/pkg/binding/spec/attributes.go
+++ b/pkg/binding/spec/attributes.go
@@ -46,6 +46,8 @@ func (k Kind) IsRequired() bool { return k < DataContentType }
 // The attribute name is specific to a Version.
 type Attribute interface {
 	Kind() Kind
+	// Name of the attribute with respect to the current spec Version() with prefix
+	PrefixedName() string
 	// Name of the attribute with respect to the current spec Version()
 	Name() string
 	// Version of the spec that this attribute belongs to

--- a/pkg/binding/spec/attributes_test.go
+++ b/pkg/binding/spec/attributes_test.go
@@ -15,7 +15,7 @@ func TestAttributes03(t *testing.T) {
 	assert.NoError(err)
 	subject := v.Attribute("x:subject")
 	assert.Equal(spec.Subject, subject.Kind())
-	assert.Equal("x:subject", subject.Name())
+	assert.Equal("x:subject", subject.PrefixedName())
 
 	c := v.NewContext()
 	assert.Equal("0.3", c.GetSpecVersion())

--- a/pkg/binding/spec/spec.go
+++ b/pkg/binding/spec/spec.go
@@ -80,8 +80,9 @@ type attribute struct {
 	version Version
 }
 
-func (a *attribute) Name() string     { return a.name }
-func (a *attribute) Version() Version { return a.version }
+func (a *attribute) PrefixedName() string { return a.version.Prefix() + a.name }
+func (a *attribute) Name() string         { return a.name }
+func (a *attribute) Version() Version     { return a.version }
 
 type version struct {
 	prefix  string
@@ -142,10 +143,9 @@ func newVersion(
 		attrs:   make([]Attribute, len(attrs)),
 	}
 	for i, a := range attrs {
-		a.name = prefix + a.name
 		a.version = v
 		v.attrs[i] = a
-		v.attrMap[strings.ToLower(a.name)] = a
+		v.attrMap[strings.ToLower(a.PrefixedName())] = a
 	}
 	return v
 }

--- a/pkg/binding/test/test.go
+++ b/pkg/binding/test/test.go
@@ -93,7 +93,7 @@ func AssertEventContextEquals(t *testing.T, want cloudevents.EventContext, have 
 	require.Equal(t, wantVersion, haveVersion)
 
 	for _, a := range wantVersion.Attributes() {
-		require.Equal(t, a.Get(want), a.Get(have), "Attribute %s does not match: %v != %v", a.Name(), a.Get(want), a.Get(have))
+		require.Equal(t, a.Get(want), a.Get(have), "Attribute %s does not match: %v != %v", a.PrefixedName(), a.Get(want), a.Get(have))
 	}
 
 	require.Equal(t, want.GetExtensions(), have.GetExtensions(), "Extensions")


### PR DESCRIPTION
Now `Attribute.Name()` returns the attribute name in the specific spec version, while `Attribute.PrefixedName()` returns the prefix plus the attribute name

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>