### PR TITLE
Clone event context before setting the distributed tracing extension

### DIFF
--- a/pkg/binding/transport_test.go
+++ b/pkg/binding/transport_test.go
@@ -17,7 +17,7 @@ func TestTransportSend(t *testing.T) {
 	transport := binding.NewTransportAdapter(binding.ChanSender(messageChannel), binding.ChanReceiver(messageChannel), nil)
 	ev := test.MinEvent()
 
-	c, err := client.New(transport)
+	c, err := client.New(transport, client.WithoutTracePropagation())
 	require.NoError(t, err)
 
 	_, _, err = c.Send(context.Background(), ev)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -122,6 +122,7 @@ func (c *ceClient) obsSend(ctx context.Context, event event.Event) (context.Cont
 	// Set distributed tracing extension.
 	if !c.disableTracePropagation {
 		if span := trace.FromContext(ctx); span != nil {
+			event.Context = event.Context.Clone()
 			if err := extensions.FromSpanContext(span.SpanContext()).AddTracingAttributes(event.Context); err != nil {
 				return ctx, nil, fmt.Errorf("error setting distributed tracing extension: %w", err)
 			}


### PR DESCRIPTION
This prevents the client from mutating the caller's copy of the event
allowing for sharing across multiple clients.

Fixes #350 