### PR TITLE
Reworked the binding.Message interface

### DIFF
--- a/pkg/binding/binary_writer.go
+++ b/pkg/binding/binary_writer.go
@@ -7,13 +7,13 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
 )
 
-// BinaryEncoder is used to visit a binary Message and generate a new representation.
+// BinaryWriter is used to visit a binary Message and generate a new representation.
 //
 // Protocols that supports binary encoding should implement this interface to implement direct
 // binary to binary encoding and event to binary encoding.
 //
-// Start() and End() methods are invoked every time this BinaryEncoder implementation is used to visit a Message
-type BinaryEncoder interface {
+// Start() and End() methods are invoked every time this BinaryWriter implementation is used to visit a Message
+type BinaryWriter interface {
 	// Method invoked at the beginning of the visit. Useful to perform initial memory allocations
 	Start(ctx context.Context) error
 

--- a/pkg/binding/buffering/binary_buffer_message.go
+++ b/pkg/binding/buffering/binary_buffer_message.go
@@ -35,7 +35,7 @@ func (m *binaryBufferedMessage) GetParent() binding.Message {
 	return nil
 }
 
-func (m *binaryBufferedMessage) Encoding() binding.Encoding {
+func (m *binaryBufferedMessage) ReadEncoding() binding.Encoding {
 	return binding.EncodingBinary
 }
 

--- a/pkg/binding/buffering/binary_buffer_message.go
+++ b/pkg/binding/buffering/binary_buffer_message.go
@@ -39,11 +39,11 @@ func (m *binaryBufferedMessage) Encoding() binding.Encoding {
 	return binding.EncodingBinary
 }
 
-func (m *binaryBufferedMessage) Structured(context.Context, binding.StructuredEncoder) error {
+func (m *binaryBufferedMessage) ReadStructured(context.Context, binding.StructuredWriter) error {
 	return binding.ErrNotStructured
 }
 
-func (m *binaryBufferedMessage) Binary(ctx context.Context, b binding.BinaryEncoder) (err error) {
+func (m *binaryBufferedMessage) ReadBinary(ctx context.Context, b binding.BinaryWriter) (err error) {
 	err = b.Start(ctx)
 	if err != nil {
 		return
@@ -103,4 +103,4 @@ func (b *binaryBufferedMessage) SetExtension(name string, value interface{}) err
 }
 
 var _ binding.Message = (*binaryBufferedMessage)(nil) // Test it conforms to the interface
-var _ binding.BinaryEncoder = (*binaryBufferedMessage)(nil)
+var _ binding.BinaryWriter = (*binaryBufferedMessage)(nil)

--- a/pkg/binding/buffering/copy_message.go
+++ b/pkg/binding/buffering/copy_message.go
@@ -22,7 +22,7 @@ func BufferMessage(ctx context.Context, m binding.Message, transformers binding.
 // When the copy can be forgot, the copied message must be finished with Finish() message to release the memory.
 // transformers can be nil and this function guarantees that they are invoked only once during the encoding process.
 func CopyMessage(ctx context.Context, m binding.Message, transformers binding.TransformerFactories) (binding.Message, error) {
-	originalMessageEncoding := m.Encoding()
+	originalMessageEncoding := m.ReadEncoding()
 
 	if originalMessageEncoding == binding.EncodingUnknown {
 		return nil, binding.ErrUnknownEncoding

--- a/pkg/binding/buffering/copy_message.go
+++ b/pkg/binding/buffering/copy_message.go
@@ -38,7 +38,7 @@ func CopyMessage(ctx context.Context, m binding.Message, transformers binding.Tr
 	sm := structBufferedMessage{}
 	bm := binaryBufferedMessage{}
 
-	encoding, err := binding.RunDirectEncoding(ctx, m, &sm, &bm, transformers)
+	encoding, err := binding.DirectWrite(ctx, m, &sm, &bm, transformers)
 	if encoding == binding.EncodingStructured {
 		return &sm, err
 	} else if encoding == binding.EncodingBinary {

--- a/pkg/binding/buffering/copy_message_test.go
+++ b/pkg/binding/buffering/copy_message_test.go
@@ -76,7 +76,7 @@ func TestCopyMessage(t *testing.T) {
 			for i := 0; i < 3; i++ {
 				got, err := binding.ToEvent(context.Background(), cpy, nil)
 				assert.NoError(t, err)
-				require.Equal(t, tt.encoding, cpy.Encoding())
+				require.Equal(t, tt.encoding, cpy.ReadEncoding())
 				test.AssertEventEquals(t, test.ExToStr(t, tt.want), test.ExToStr(t, got))
 			}
 			require.NoError(t, cpy.Finish(nil))
@@ -93,7 +93,7 @@ func TestCopyMessage(t *testing.T) {
 			for i := 0; i < 3; i++ {
 				got, err := binding.ToEvent(context.Background(), cpy, nil)
 				assert.NoError(t, err)
-				require.Equal(t, tt.encoding, cpy.Encoding())
+				require.Equal(t, tt.encoding, cpy.ReadEncoding())
 				test.AssertEventEquals(t, test.ExToStr(t, tt.want), test.ExToStr(t, got))
 			}
 			require.NoError(t, cpy.Finish(nil))

--- a/pkg/binding/buffering/struct_buffer_message.go
+++ b/pkg/binding/buffering/struct_buffer_message.go
@@ -24,7 +24,7 @@ func (m *structBufferedMessage) GetParent() binding.Message {
 	return nil
 }
 
-func (m *structBufferedMessage) Encoding() binding.Encoding {
+func (m *structBufferedMessage) ReadEncoding() binding.Encoding {
 	return binding.EncodingStructured
 }
 

--- a/pkg/binding/buffering/struct_buffer_message.go
+++ b/pkg/binding/buffering/struct_buffer_message.go
@@ -28,13 +28,13 @@ func (m *structBufferedMessage) Encoding() binding.Encoding {
 	return binding.EncodingStructured
 }
 
-// Structured copies structured data to a StructuredEncoder
-func (m *structBufferedMessage) Structured(ctx context.Context, enc binding.StructuredEncoder) error {
+// Structured copies structured data to a StructuredWriter
+func (m *structBufferedMessage) ReadStructured(ctx context.Context, enc binding.StructuredWriter) error {
 	return enc.SetStructuredEvent(ctx, m.Format, bytes.NewReader(m.Bytes.B))
 }
 
 // Binary returns ErrNotBinary
-func (m structBufferedMessage) Binary(context.Context, binding.BinaryEncoder) error {
+func (m structBufferedMessage) ReadBinary(context.Context, binding.BinaryWriter) error {
 	return binding.ErrNotBinary
 }
 
@@ -53,5 +53,5 @@ func (m *structBufferedMessage) SetStructuredEvent(ctx context.Context, format f
 	return nil
 }
 
-var _ binding.Message = (*structBufferedMessage)(nil)           // Test it conforms to the interface
-var _ binding.StructuredEncoder = (*structBufferedMessage)(nil) // Test it conforms to the interface
+var _ binding.Message = (*structBufferedMessage)(nil)          // Test it conforms to the interface
+var _ binding.StructuredWriter = (*structBufferedMessage)(nil) // Test it conforms to the interface

--- a/pkg/binding/doc.go
+++ b/pkg/binding/doc.go
@@ -15,31 +15,36 @@ most "endpoint" applications that emit or consume events.
 
 Protocol Bindings
 
-A protocol binding usually implements a Message, a Sender and Receiver, a StructuredWriter and a BinaryWriter (depending on the supported encodings of the protocol) and an Write method.
+A protocol binding usually implements a Message, a Sender and Receiver, a StructuredWriter and a BinaryWriter (depending on the supported encodings of the protocol) and an Write[ProtocolMessage] method.
 
-Messages and Encoding
+Read and write events
 
-The core of this package is the Message interface. It defines the visitors for an
+The core of this package is the binding.Message interface.
+Through binding.MessageReader It defines how to read a protocol specific message for an
 encoded event in structured mode or binary mode.
-The entity who receives a protocol specific data structure representing a message (e.g. an HttpRequest) encapsulates it in a binding.Message implementation using a
-NewMessage method (e.g. http.NewMessage).
+The entity who receives a protocol specific data structure representing a message
+(e.g. an HttpRequest) encapsulates it in a binding.Message implementation using a NewMessage method (e.g. http.NewMessage).
 Then the entity that wants to send the binding.Message back on the wire,
 translates it back to the protocol specific data structure (e.g. a Kafka ConsumerMessage), using
-the visitors BinaryWriter and StructuredWriter specific to that protocol.
-Binding implementations exposes their visitors
-through a specific Write function (e.g. kafka.EncodeProducerMessage), in order to simplify the invocation of the
-encoding message.
+the writers BinaryWriter and StructuredWriter specific to that protocol.
+Binding implementations exposes their writers
+through a specific Write[ProtocolMessage] function (e.g. kafka.EncodeProducerMessage),
+in order to simplify the encoding process.
 
-The encoding process can be customized in order to mutate the final result with binding.TransformerFactory. A bunch of these are provided directly by the binding/transcoder module.
+The encoding process can be customized in order to mutate the final result with binding.TransformerFactory.
+A bunch of these are provided directly by the binding/transformer module.
 
 Usually binding.Message implementations can be encoded only one time, because the encoding process drain the message itself.
 In order to consume a message several times, the binding/buffering module provides several APIs to buffer the Message.
 
-A message can be converted to an event.Event using ToEvent method. An event.Event can be used as Message casting it to binding.EventMessage.
+A message can be converted to an event.Event using binding.ToEvent() method.
+An event.Event can be used as Message casting it to binding.EventMessage.
 
-In order to simplify the encoding process for each protocol, this package provide several utility methods like binding.Write and binding.DirectWrite. The binding.Write method tries to preserve the structured/binary encoding, in order to be as much efficient as possible.
+In order to simplify the encoding process for each protocol, this package provide several utility methods like binding.Write and binding.DirectWrite.
+The binding.Write method tries to preserve the structured/binary encoding, in order to be as much efficient as possible.
 
-Messages can be eventually wrapped to change their behaviours and binding their lifecycle, like the binding.FinishMessage. Every Message wrapper implements the MessageWrapper interface
+Messages can be eventually wrapped to change their behaviours and binding their lifecycle, like the binding.FinishMessage.
+Every Message wrapper implements the MessageWrapper interface
 
 Sender and Receiver
 

--- a/pkg/binding/doc.go
+++ b/pkg/binding/doc.go
@@ -15,7 +15,7 @@ most "endpoint" applications that emit or consume events.
 
 Protocol Bindings
 
-A protocol binding usually implements a Message, a Sender and Receiver, a StructuredEncoder and a BinaryEncoder (depending on the supported encodings of the protocol) and an Encode method.
+A protocol binding usually implements a Message, a Sender and Receiver, a StructuredWriter and a BinaryWriter (depending on the supported encodings of the protocol) and an Write method.
 
 Messages and Encoding
 
@@ -25,9 +25,9 @@ The entity who receives a protocol specific data structure representing a messag
 NewMessage method (e.g. http.NewMessage).
 Then the entity that wants to send the binding.Message back on the wire,
 translates it back to the protocol specific data structure (e.g. a Kafka ConsumerMessage), using
-the visitors BinaryEncoder and StructuredEncoder specific to that protocol.
+the visitors BinaryWriter and StructuredWriter specific to that protocol.
 Binding implementations exposes their visitors
-through a specific Encode function (e.g. kafka.EncodeProducerMessage), in order to simplify the invocation of the
+through a specific Write function (e.g. kafka.EncodeProducerMessage), in order to simplify the invocation of the
 encoding message.
 
 The encoding process can be customized in order to mutate the final result with binding.TransformerFactory. A bunch of these are provided directly by the binding/transcoder module.
@@ -37,7 +37,7 @@ In order to consume a message several times, the binding/buffering module provid
 
 A message can be converted to an event.Event using ToEvent method. An event.Event can be used as Message casting it to binding.EventMessage.
 
-In order to simplify the encoding process for each protocol, this package provide several utility methods like binding.Encode and binding.RunDirectEncoding. The binding.Encode method tries to preserve the structured/binary encoding, in order to be as much efficient as possible.
+In order to simplify the encoding process for each protocol, this package provide several utility methods like binding.Write and binding.DirectWrite. The binding.Write method tries to preserve the structured/binary encoding, in order to be as much efficient as possible.
 
 Messages can be eventually wrapped to change their behaviours and binding their lifecycle, like the binding.FinishMessage. Every Message wrapper implements the MessageWrapper interface
 
@@ -45,7 +45,7 @@ Sender and Receiver
 
 A Receiver receives protocol specific messages and wraps them to into binding.Message implementations.
 
-A Sender converts arbitrary Message implementations to a protocol-specific form using the protocol specific Encode method
+A Sender converts arbitrary Message implementations to a protocol-specific form using the protocol specific Write method
 and sends them.
 
 Message and ExactlyOnceMessage provide methods to allow acknowledgments to

--- a/pkg/binding/event_message.go
+++ b/pkg/binding/event_message.go
@@ -18,7 +18,7 @@ const (
 //     s.Send(ctx, binding.EventMessage(e))
 type EventMessage event.Event
 
-func (m EventMessage) Encoding() Encoding {
+func (m EventMessage) ReadEncoding() Encoding {
 	return EncodingEvent
 }
 

--- a/pkg/binding/event_message.go
+++ b/pkg/binding/event_message.go
@@ -22,7 +22,7 @@ func (m EventMessage) Encoding() Encoding {
 	return EncodingEvent
 }
 
-func (m EventMessage) Structured(ctx context.Context, builder StructuredEncoder) error {
+func (m EventMessage) ReadStructured(ctx context.Context, builder StructuredWriter) error {
 	f := GetOrDefaultFromCtx(ctx, FORMAT_EVENT_STRUCTURED, format.JSON).(format.Format)
 	b, err := f.Marshal(event.Event(m))
 	if err != nil {
@@ -31,12 +31,12 @@ func (m EventMessage) Structured(ctx context.Context, builder StructuredEncoder)
 	return builder.SetStructuredEvent(ctx, f, bytes.NewReader(b))
 }
 
-func (m EventMessage) Binary(ctx context.Context, b BinaryEncoder) (err error) {
+func (m EventMessage) ReadBinary(ctx context.Context, b BinaryWriter) (err error) {
 	err = b.Start(ctx)
 	if err != nil {
 		return err
 	}
-	err = eventContextToBinaryEncoder(m.Context, b)
+	err = eventContextToBinaryWriter(m.Context, b)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (m EventMessage) Binary(ctx context.Context, b BinaryEncoder) (err error) {
 	return b.End()
 }
 
-func eventContextToBinaryEncoder(c event.EventContext, b BinaryEncoder) (err error) {
+func eventContextToBinaryWriter(c event.EventContext, b BinaryWriter) (err error) {
 	// Pass all attributes
 	sv := spec.VS.Version(c.GetSpecVersion())
 	for _, a := range sv.Attributes() {

--- a/pkg/binding/event_message_test.go
+++ b/pkg/binding/event_message_test.go
@@ -38,7 +38,7 @@ func TestStructuredModeCustomFormat(t *testing.T) {
 	enc := test.MockStructuredMessage{}
 	message := binding.EventMessage(e)
 
-	err := message.Structured(ctx, &enc)
+	err := message.ReadStructured(ctx, &enc)
 	require.NoError(t, err)
 	require.Equal(t, &format, enc.Format)
 }

--- a/pkg/binding/example_implementing_test.go
+++ b/pkg/binding/example_implementing_test.go
@@ -20,7 +20,7 @@ func NewMessage(m json.RawMessage) binding.Message {
 	return ExMessage(m)
 }
 
-func (m ExMessage) Encoding() binding.Encoding {
+func (m ExMessage) ReadEncoding() binding.Encoding {
 	return binding.EncodingStructured
 }
 

--- a/pkg/binding/example_implementing_test.go
+++ b/pkg/binding/example_implementing_test.go
@@ -24,11 +24,11 @@ func (m ExMessage) Encoding() binding.Encoding {
 	return binding.EncodingStructured
 }
 
-func (m ExMessage) Structured(ctx context.Context, b binding.StructuredEncoder) error {
+func (m ExMessage) ReadStructured(ctx context.Context, b binding.StructuredWriter) error {
 	return b.SetStructuredEvent(ctx, format.JSON, bytes.NewReader(m))
 }
 
-func (m ExMessage) Binary(context.Context, binding.BinaryEncoder) error {
+func (m ExMessage) ReadBinary(context.Context, binding.BinaryWriter) error {
 	return binding.ErrNotBinary
 }
 
@@ -37,7 +37,7 @@ func (m ExMessage) Finish(error) error { return nil }
 var _ binding.Message = (*ExMessage)(nil)
 
 // ExSender sends by writing JSON encoded events to an io.Writer
-// ExSender implements directly StructuredEncoder in order to perform the conversion
+// ExSender implements directly StructuredWriter in order to perform the conversion
 type ExSender struct {
 	encoder      *json.Encoder
 	transformers binding.TransformerFactories
@@ -48,9 +48,9 @@ func NewExSender(w io.Writer, factories ...binding.TransformerFactory) binding.S
 }
 
 func (s *ExSender) Send(ctx context.Context, m binding.Message) error {
-	// Encode tries to perform the encoding directly, otherwise
+	// Write tries to perform the encoding directly, otherwise
 	// It fallbacks to converting to event.Event and then convert back to the provided encoders
-	_, err := binding.Encode(
+	_, err := binding.Write(
 		ctx,
 		m,
 		s,
@@ -74,7 +74,7 @@ func (s *ExSender) SetStructuredEvent(ctx context.Context, f format.Format, even
 }
 
 var _ binding.Sender = (*ExSender)(nil)
-var _ binding.StructuredEncoder = (*ExSender)(nil)
+var _ binding.StructuredWriter = (*ExSender)(nil)
 
 // ExReceiver receives by reading JSON encoded events from an io.Reader
 type ExReceiver struct{ decoder *json.Decoder }

--- a/pkg/binding/example_using_test.go
+++ b/pkg/binding/example_using_test.go
@@ -81,7 +81,7 @@ func runIntermediary(r io.Reader, w io.WriteCloser) error {
 // receive messages.  the transport.  Only the intermediary example
 // actually uses the transport APIs for efficiency and reliability in
 // forwarding events.
-func ExampleReceiver_using() {
+func Exampl_using() {
 	r1, w1 := io.Pipe() // The sender-to-intermediary pipe
 	r2, w2 := io.Pipe() // The intermediary-to-receiver pipe
 

--- a/pkg/binding/example_using_test.go
+++ b/pkg/binding/example_using_test.go
@@ -81,7 +81,7 @@ func runIntermediary(r io.Reader, w io.WriteCloser) error {
 // receive messages.  the transport.  Only the intermediary example
 // actually uses the transport APIs for efficiency and reliability in
 // forwarding events.
-func Example_using() {
+func ExampleReceiver_using() {
 	r1, w1 := io.Pipe() // The sender-to-intermediary pipe
 	r2, w2 := io.Pipe() // The intermediary-to-receiver pipe
 

--- a/pkg/binding/message.go
+++ b/pkg/binding/message.go
@@ -21,9 +21,9 @@ import "context"
 // The Message interface supports QoS 0 and 1, the ExactlyOnceMessage interface
 // supports QoS 2
 //
-// The Structured and Binary methods allows to perform an optimized encoding of a Message
+// The ReadStructured and ReadBinary methods allows to perform an optimized encoding of a Message
 // to a specific data structure. A Sender should try each method of interest and fall back to ToEvent() if none are supported.
-// For encoding a message, look at binding.Encode function.
+// For encoding a message, look at binding.Write function.
 //
 // Every binding.Message implementation must specify if the message can be accessed one or more times.
 //
@@ -33,7 +33,7 @@ type Message interface {
 	// The encoding should be preferably computed when the message is constructed.
 	Encoding() Encoding
 
-	// Structured transfers a structured-mode event to a StructuredEncoder.
+	// ReadStructured transfers a structured-mode event to a StructuredWriter.
 	// It must return ErrNotStructured if message is not in structured mode.
 	//
 	// Returns a different err if something wrong happened while trying to read the structured event.
@@ -41,9 +41,9 @@ type Message interface {
 	//
 	// This allows Senders to avoid re-encoding messages that are
 	// already in suitable structured form.
-	Structured(context.Context, StructuredEncoder) error
+	ReadStructured(context.Context, StructuredWriter) error
 
-	// Binary transfers a binary-mode event to an BinaryEncoder.
+	// ReadBinary transfers a binary-mode event to an BinaryWriter.
 	// It must return ErrNotBinary if message is not in binary mode.
 	//
 	// Returns a different err if something wrong happened while trying to read the binary event
@@ -51,7 +51,7 @@ type Message interface {
 	//
 	// This allows Senders to avoid re-encoding messages that are
 	// already in suitable binary form.
-	Binary(context.Context, BinaryEncoder) error
+	ReadBinary(context.Context, BinaryWriter) error
 
 	// Finish *must* be called when message from a Receiver can be forgotten by
 	// the receiver. A QoS 1 sender should not call Finish() until it gets an acknowledgment of

--- a/pkg/binding/structured_writer.go
+++ b/pkg/binding/structured_writer.go
@@ -7,11 +7,11 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/binding/format"
 )
 
-// StructuredEncoder is used to visit a structured Message and generate a new representation.
+// StructuredWriter is used to visit a structured Message and generate a new representation.
 //
 // Protocols that supports structured encoding should implement this interface to implement direct
 // structured to structured encoding and event to structured encoding.
-type StructuredEncoder interface {
+type StructuredWriter interface {
 	// Event receives an io.Reader for the whole event.
 	SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error
 }

--- a/pkg/binding/test/mock_binary_message.go
+++ b/pkg/binding/test/mock_binary_message.go
@@ -12,7 +12,7 @@ import (
 )
 
 // MockBinaryMessage implements a binary-mode message as a simple struct.
-// MockBinaryMessage implements both the binding.Message interface and the binding.BinaryEncoder
+// MockBinaryMessage implements both the binding.Message interface and the binding.BinaryWriter
 type MockBinaryMessage struct {
 	Metadata   map[spec.Attribute]interface{}
 	Extensions map[string]interface{}
@@ -48,11 +48,11 @@ func MustCreateMockBinaryMessage(e event.Event) binding.Message {
 	return &m
 }
 
-func (bm *MockBinaryMessage) Structured(context.Context, binding.StructuredEncoder) error {
+func (bm *MockBinaryMessage) ReadStructured(context.Context, binding.StructuredWriter) error {
 	return binding.ErrNotStructured
 }
 
-func (bm *MockBinaryMessage) Binary(ctx context.Context, b binding.BinaryEncoder) error {
+func (bm *MockBinaryMessage) ReadBinary(ctx context.Context, b binding.BinaryWriter) error {
 	err := b.Start(ctx)
 	if err != nil {
 		return err
@@ -110,4 +110,4 @@ func (bm *MockBinaryMessage) End() error {
 }
 
 var _ binding.Message = (*MockBinaryMessage)(nil)
-var _ binding.BinaryEncoder = (*MockBinaryMessage)(nil)
+var _ binding.BinaryWriter = (*MockBinaryMessage)(nil)

--- a/pkg/binding/test/mock_binary_message.go
+++ b/pkg/binding/test/mock_binary_message.go
@@ -78,7 +78,7 @@ func (bm *MockBinaryMessage) ReadBinary(ctx context.Context, b binding.BinaryWri
 	return b.End()
 }
 
-func (bm *MockBinaryMessage) Encoding() binding.Encoding {
+func (bm *MockBinaryMessage) ReadEncoding() binding.Encoding {
 	return binding.EncodingBinary
 }
 

--- a/pkg/binding/test/mock_structured_message.go
+++ b/pkg/binding/test/mock_structured_message.go
@@ -34,7 +34,7 @@ func (s *MockStructuredMessage) ReadBinary(context.Context, binding.BinaryWriter
 	return binding.ErrNotBinary
 }
 
-func (bm *MockStructuredMessage) Encoding() binding.Encoding {
+func (bm *MockStructuredMessage) ReadEncoding() binding.Encoding {
 	return binding.EncodingStructured
 }
 

--- a/pkg/binding/test/mock_structured_message.go
+++ b/pkg/binding/test/mock_structured_message.go
@@ -12,7 +12,7 @@ import (
 )
 
 // MockStructuredMessage implements a structured-mode message as a simple struct.
-// MockStructuredMessage implements both the binding.Message interface and the binding.StructuredEncoder
+// MockStructuredMessage implements both the binding.Message interface and the binding.StructuredWriter
 type MockStructuredMessage struct {
 	Format format.Format
 	Bytes  []byte
@@ -26,11 +26,11 @@ func MustCreateMockStructuredMessage(e event.Event) binding.Message {
 	}
 }
 
-func (s *MockStructuredMessage) Structured(ctx context.Context, b binding.StructuredEncoder) error {
+func (s *MockStructuredMessage) ReadStructured(ctx context.Context, b binding.StructuredWriter) error {
 	return b.SetStructuredEvent(ctx, s.Format, bytes.NewReader(s.Bytes))
 }
 
-func (s *MockStructuredMessage) Binary(context.Context, binding.BinaryEncoder) error {
+func (s *MockStructuredMessage) ReadBinary(context.Context, binding.BinaryWriter) error {
 	return binding.ErrNotBinary
 }
 
@@ -51,4 +51,4 @@ func (s *MockStructuredMessage) SetStructuredEvent(ctx context.Context, format f
 }
 
 var _ binding.Message = (*MockStructuredMessage)(nil)
-var _ binding.StructuredEncoder = (*MockStructuredMessage)(nil)
+var _ binding.StructuredWriter = (*MockStructuredMessage)(nil)

--- a/pkg/binding/test/transformer.go
+++ b/pkg/binding/test/transformer.go
@@ -26,7 +26,7 @@ func RunTransformerTests(t *testing.T, ctx context.Context, tests []TransformerT
 			mockStructured := MockStructuredMessage{}
 			mockBinary := MockBinaryMessage{}
 
-			enc, err := binding.Encode(ctx, tt.InputMessage, &mockStructured, &mockBinary, tt.Transformers)
+			enc, err := binding.Write(ctx, tt.InputMessage, &mockStructured, &mockBinary, tt.Transformers)
 			require.NoError(t, err)
 
 			var e event.Event

--- a/pkg/binding/to_event.go
+++ b/pkg/binding/to_event.go
@@ -41,7 +41,7 @@ func ToEvent(ctx context.Context, message Message, transformers TransformerFacto
 	}
 
 	encoder := &messageToEventBuilder{event: &e}
-	_, err = RunDirectEncoding(
+	_, err = DirectWrite(
 		context.TODO(),
 		message,
 		encoder,
@@ -59,8 +59,8 @@ type messageToEventBuilder struct {
 	event *event.Event
 }
 
-var _ StructuredEncoder = (*messageToEventBuilder)(nil)
-var _ BinaryEncoder = (*messageToEventBuilder)(nil)
+var _ StructuredWriter = (*messageToEventBuilder)(nil)
+var _ BinaryWriter = (*messageToEventBuilder)(nil)
 
 func (b *messageToEventBuilder) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
 	var buf bytes.Buffer

--- a/pkg/binding/to_event.go
+++ b/pkg/binding/to_event.go
@@ -19,10 +19,10 @@ var ErrCannotConvertToEvent = errors.New("cannot convert message to event")
 // This function returns the Event generated from the Message and the original encoding of the message or
 // an error that points the conversion error.
 // transformers can be nil and this function guarantees that they are invoked only once during the encoding process.
-func ToEvent(ctx context.Context, message Message, transformers TransformerFactories) (e event.Event, err error) {
+func ToEvent(ctx context.Context, message MessageReader, transformers TransformerFactories) (e event.Event, err error) {
 	e = event.New()
 
-	messageEncoding := message.Encoding()
+	messageEncoding := message.ReadEncoding()
 	if messageEncoding == EncodingEvent {
 		for m := message; m != nil; {
 			if em, ok := m.(EventMessage); ok {

--- a/pkg/binding/transformer.go
+++ b/pkg/binding/transformer.go
@@ -11,10 +11,10 @@ import (
 // returning nil to the respective factory method.
 type TransformerFactory interface {
 	// Can return nil if the transformation doesn't support structured encoding directly
-	StructuredTransformer(encoder StructuredEncoder) StructuredEncoder
+	StructuredTransformer(encoder StructuredWriter) StructuredWriter
 
 	// Can return nil if the transformation doesn't support binary encoding directly
-	BinaryTransformer(encoder BinaryEncoder) BinaryEncoder
+	BinaryTransformer(encoder BinaryWriter) BinaryWriter
 
 	// Can return nil if the transformation doesn't support events
 	EventTransformer() EventTransformer
@@ -23,7 +23,7 @@ type TransformerFactory interface {
 // Utility type alias to manage multiple TransformerFactory
 type TransformerFactories []TransformerFactory
 
-func (t TransformerFactories) StructuredTransformer(encoder StructuredEncoder) StructuredEncoder {
+func (t TransformerFactories) StructuredTransformer(encoder StructuredWriter) StructuredWriter {
 	if encoder == nil {
 		return nil
 	}
@@ -40,7 +40,7 @@ func (t TransformerFactories) StructuredTransformer(encoder StructuredEncoder) S
 	return res
 }
 
-func (t TransformerFactories) BinaryTransformer(encoder BinaryEncoder) BinaryEncoder {
+func (t TransformerFactories) BinaryTransformer(encoder BinaryWriter) BinaryWriter {
 	if encoder == nil {
 		return nil
 	}

--- a/pkg/binding/transformer/add_metadata.go
+++ b/pkg/binding/transformer/add_metadata.go
@@ -23,13 +23,13 @@ type setAttributeTranscoderFactory struct {
 	value         interface{}
 }
 
-func (a setAttributeTranscoderFactory) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (a setAttributeTranscoderFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil
 }
 
-func (a setAttributeTranscoderFactory) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
+func (a setAttributeTranscoderFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
 	return &setAttributeTransformer{
-		BinaryEncoder: encoder,
+		BinaryWriter:  encoder,
 		attributeKind: a.attributeKind,
 		value:         a.value,
 		found:         false,
@@ -54,16 +54,16 @@ type setExtensionTranscoderFactory struct {
 	value interface{}
 }
 
-func (a setExtensionTranscoderFactory) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (a setExtensionTranscoderFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil
 }
 
-func (a setExtensionTranscoderFactory) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
+func (a setExtensionTranscoderFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
 	return &setExtensionTransformer{
-		BinaryEncoder: encoder,
-		name:          a.name,
-		value:         a.value,
-		found:         false,
+		BinaryWriter: encoder,
+		name:         a.name,
+		value:        a.value,
+		found:        false,
 	}
 }
 
@@ -77,7 +77,7 @@ func (a setExtensionTranscoderFactory) EventTransformer() binding.EventTransform
 }
 
 type setAttributeTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	attributeKind spec.Kind
 	value         interface{}
 	version       spec.Version
@@ -89,21 +89,21 @@ func (b *setAttributeTransformer) SetAttribute(attribute spec.Attribute, value i
 		b.found = true
 	}
 	b.version = attribute.Version()
-	return b.BinaryEncoder.SetAttribute(attribute, value)
+	return b.BinaryWriter.SetAttribute(attribute, value)
 }
 
 func (b *setAttributeTransformer) End() error {
 	if !b.found {
-		err := b.BinaryEncoder.SetAttribute(b.version.AttributeFromKind(b.attributeKind), b.value)
+		err := b.BinaryWriter.SetAttribute(b.version.AttributeFromKind(b.attributeKind), b.value)
 		if err != nil {
 			return err
 		}
 	}
-	return b.BinaryEncoder.End()
+	return b.BinaryWriter.End()
 }
 
 type setExtensionTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	name  string
 	value interface{}
 	found bool
@@ -113,15 +113,15 @@ func (b *setExtensionTransformer) SetExtension(name string, value interface{}) e
 	if name == b.name {
 		b.found = true
 	}
-	return b.BinaryEncoder.SetExtension(name, value)
+	return b.BinaryWriter.SetExtension(name, value)
 }
 
 func (b *setExtensionTransformer) End() error {
 	if !b.found {
-		err := b.BinaryEncoder.SetExtension(b.name, b.value)
+		err := b.BinaryWriter.SetExtension(b.name, b.value)
 		if err != nil {
 			return err
 		}
 	}
-	return b.BinaryEncoder.End()
+	return b.BinaryWriter.End()
 }

--- a/pkg/binding/transformer/default_metadata.go
+++ b/pkg/binding/transformer/default_metadata.go
@@ -20,14 +20,14 @@ var (
 
 type addUUID struct{}
 
-func (a addUUID) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (a addUUID) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil
 }
 
-func (a addUUID) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
+func (a addUUID) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
 	return &addUUIDTransformer{
-		BinaryEncoder: encoder,
-		found:         false,
+		BinaryWriter: encoder,
+		found:        false,
 	}
 }
 
@@ -41,7 +41,7 @@ func (a addUUID) EventTransformer() binding.EventTransformer {
 }
 
 type addUUIDTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	version spec.Version
 	found   bool
 }
@@ -51,29 +51,29 @@ func (b *addUUIDTransformer) SetAttribute(attribute spec.Attribute, value interf
 		b.found = true
 	}
 	b.version = attribute.Version()
-	return b.BinaryEncoder.SetAttribute(attribute, value)
+	return b.BinaryWriter.SetAttribute(attribute, value)
 }
 
 func (b *addUUIDTransformer) End() error {
 	if !b.found {
-		err := b.BinaryEncoder.SetAttribute(b.version.AttributeFromKind(spec.ID), uuid.New().String())
+		err := b.BinaryWriter.SetAttribute(b.version.AttributeFromKind(spec.ID), uuid.New().String())
 		if err != nil {
 			return err
 		}
 	}
-	return b.BinaryEncoder.End()
+	return b.BinaryWriter.End()
 }
 
 type addTimeNow struct{}
 
-func (a addTimeNow) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (a addTimeNow) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil
 }
 
-func (a addTimeNow) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
+func (a addTimeNow) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
 	return &addTimeNowTransformer{
-		BinaryEncoder: encoder,
-		found:         false,
+		BinaryWriter: encoder,
+		found:        false,
 	}
 }
 
@@ -87,7 +87,7 @@ func (a addTimeNow) EventTransformer() binding.EventTransformer {
 }
 
 type addTimeNowTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	version spec.Version
 	found   bool
 }
@@ -97,15 +97,15 @@ func (b *addTimeNowTransformer) SetAttribute(attribute spec.Attribute, value int
 		b.found = true
 	}
 	b.version = attribute.Version()
-	return b.BinaryEncoder.SetAttribute(attribute, value)
+	return b.BinaryWriter.SetAttribute(attribute, value)
 }
 
 func (b *addTimeNowTransformer) End() error {
 	if !b.found {
-		err := b.BinaryEncoder.SetAttribute(b.version.AttributeFromKind(spec.Time), types.Timestamp{Time: time.Now()})
+		err := b.BinaryWriter.SetAttribute(b.version.AttributeFromKind(spec.Time), types.Timestamp{Time: time.Now()})
 		if err != nil {
 			return err
 		}
 	}
-	return b.BinaryEncoder.End()
+	return b.BinaryWriter.End()
 }

--- a/pkg/binding/transformer/delete_metadata.go
+++ b/pkg/binding/transformer/delete_metadata.go
@@ -22,13 +22,13 @@ type deleteAttributeTranscoderFactory struct {
 	attributeKind spec.Kind
 }
 
-func (a deleteAttributeTranscoderFactory) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (a deleteAttributeTranscoderFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil
 }
 
-func (a deleteAttributeTranscoderFactory) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
+func (a deleteAttributeTranscoderFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
 	return &deleteAttributeTransformer{
-		BinaryEncoder: encoder,
+		BinaryWriter:  encoder,
 		attributeKind: a.attributeKind,
 	}
 }
@@ -50,14 +50,14 @@ type deleteExtensionTranscoderFactory struct {
 	name string
 }
 
-func (a deleteExtensionTranscoderFactory) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (a deleteExtensionTranscoderFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil
 }
 
-func (a deleteExtensionTranscoderFactory) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
+func (a deleteExtensionTranscoderFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
 	return &deleteExtensionTransformer{
-		BinaryEncoder: encoder,
-		name:          a.name,
+		BinaryWriter: encoder,
+		name:         a.name,
 	}
 }
 
@@ -68,7 +68,7 @@ func (a deleteExtensionTranscoderFactory) EventTransformer() binding.EventTransf
 }
 
 type deleteAttributeTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	attributeKind spec.Kind
 }
 
@@ -76,11 +76,11 @@ func (b *deleteAttributeTransformer) SetAttribute(attribute spec.Attribute, valu
 	if attribute.Kind() == b.attributeKind {
 		return nil
 	}
-	return b.BinaryEncoder.SetAttribute(attribute, value)
+	return b.BinaryWriter.SetAttribute(attribute, value)
 }
 
 type deleteExtensionTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	name string
 }
 
@@ -88,5 +88,5 @@ func (b *deleteExtensionTransformer) SetExtension(name string, value interface{}
 	if b.name == name {
 		return nil
 	}
-	return b.BinaryEncoder.SetExtension(name, value)
+	return b.BinaryWriter.SetExtension(name, value)
 }

--- a/pkg/binding/transformer/update_metadata.go
+++ b/pkg/binding/transformer/update_metadata.go
@@ -23,13 +23,13 @@ type updateAttributeTranscoderFactory struct {
 	updater       func(interface{}) (interface{}, error)
 }
 
-func (a updateAttributeTranscoderFactory) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (a updateAttributeTranscoderFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil
 }
 
-func (a updateAttributeTranscoderFactory) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
+func (a updateAttributeTranscoderFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
 	return &updateAttributeTransformer{
-		BinaryEncoder: encoder,
+		BinaryWriter:  encoder,
 		attributeKind: a.attributeKind,
 		updater:       a.updater,
 	}
@@ -61,15 +61,15 @@ type updateExtensionTranscoderFactory struct {
 	updater func(interface{}) (interface{}, error)
 }
 
-func (a updateExtensionTranscoderFactory) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (a updateExtensionTranscoderFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil
 }
 
-func (a updateExtensionTranscoderFactory) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
+func (a updateExtensionTranscoderFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
 	return &updateExtensionTransformer{
-		BinaryEncoder: encoder,
-		name:          a.name,
-		updater:       a.updater,
+		BinaryWriter: encoder,
+		name:         a.name,
+		updater:      a.updater,
 	}
 }
 
@@ -87,7 +87,7 @@ func (a updateExtensionTranscoderFactory) EventTransformer() binding.EventTransf
 }
 
 type updateAttributeTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	attributeKind spec.Kind
 	updater       func(interface{}) (interface{}, error)
 }
@@ -99,15 +99,15 @@ func (b *updateAttributeTransformer) SetAttribute(attribute spec.Attribute, valu
 			return err
 		}
 		if newVal != nil {
-			return b.BinaryEncoder.SetAttribute(attribute, newVal)
+			return b.BinaryWriter.SetAttribute(attribute, newVal)
 		}
 		return nil
 	}
-	return b.BinaryEncoder.SetAttribute(attribute, value)
+	return b.BinaryWriter.SetAttribute(attribute, value)
 }
 
 type updateExtensionTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	name    string
 	updater func(interface{}) (interface{}, error)
 }
@@ -119,9 +119,9 @@ func (b *updateExtensionTransformer) SetExtension(name string, value interface{}
 			return err
 		}
 		if newVal != nil {
-			return b.BinaryEncoder.SetExtension(name, newVal)
+			return b.BinaryWriter.SetExtension(name, newVal)
 		}
 		return nil
 	}
-	return b.BinaryEncoder.SetExtension(name, value)
+	return b.BinaryWriter.SetExtension(name, value)
 }

--- a/pkg/binding/transformer/version.go
+++ b/pkg/binding/transformer/version.go
@@ -15,12 +15,12 @@ type versionTranscoderFactory struct {
 	version spec.Version
 }
 
-func (v versionTranscoderFactory) StructuredTransformer(binding.StructuredEncoder) binding.StructuredEncoder {
+func (v versionTranscoderFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
 	return nil // Not supported, must fallback to EventTransformer!
 }
 
-func (v versionTranscoderFactory) BinaryTransformer(encoder binding.BinaryEncoder) binding.BinaryEncoder {
-	return binaryVersionTransformer{BinaryEncoder: encoder, version: v.version}
+func (v versionTranscoderFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return binaryVersionTransformer{BinaryWriter: encoder, version: v.version}
 }
 
 func (v versionTranscoderFactory) EventTransformer() binding.EventTransformer {
@@ -31,14 +31,14 @@ func (v versionTranscoderFactory) EventTransformer() binding.EventTransformer {
 }
 
 type binaryVersionTransformer struct {
-	binding.BinaryEncoder
+	binding.BinaryWriter
 	version spec.Version
 }
 
 func (b binaryVersionTransformer) SetAttribute(attribute spec.Attribute, value interface{}) error {
 	if attribute.Kind() == spec.SpecVersion {
-		return b.BinaryEncoder.SetAttribute(b.version.AttributeFromKind(spec.SpecVersion), b.version.String())
+		return b.BinaryWriter.SetAttribute(b.version.AttributeFromKind(spec.SpecVersion), b.version.String())
 	}
 	attributeInDifferentVersion := b.version.AttributeFromKind(attribute.Kind())
-	return b.BinaryEncoder.SetAttribute(attributeInDifferentVersion, value)
+	return b.BinaryWriter.SetAttribute(attributeInDifferentVersion, value)
 }

--- a/pkg/binding/translate.go
+++ b/pkg/binding/translate.go
@@ -12,7 +12,7 @@ const (
 	PREFERRED_EVENT_ENCODING        = "PREFERRED_EVENT_ENCODING"
 )
 
-// Invokes the encoders. structuredEncoder and binaryEncoder could be nil if the protocol doesn't support it.
+// Invokes the encoders. structuredWriter and binaryWriter could be nil if the protocol doesn't support it.
 // transformers can be nil and this function guarantees that they are invoked only once during the encoding process.
 //
 // Returns:
@@ -21,21 +21,21 @@ const (
 // * EncodingStructured, err if message was structured but error happened during the encoding
 // * EncodingBinary, err if message was binary but error happened during the encoding
 // * EncodingUnknown, ErrUnknownEncoding if message is not a structured or a binary Message
-func RunDirectEncoding(
+func DirectWrite(
 	ctx context.Context,
 	message Message,
-	structuredEncoder StructuredEncoder,
-	binaryEncoder BinaryEncoder,
+	structuredWriter StructuredWriter,
+	binaryWriter BinaryWriter,
 	transformers TransformerFactories,
 ) (Encoding, error) {
-	if structuredEncoder != nil && !GetOrDefaultFromCtx(ctx, SKIP_DIRECT_STRUCTURED_ENCODING, false).(bool) {
+	if structuredWriter != nil && !GetOrDefaultFromCtx(ctx, SKIP_DIRECT_STRUCTURED_ENCODING, false).(bool) {
 		// Wrap the transformers in the structured builder
-		structuredEncoder = transformers.StructuredTransformer(structuredEncoder)
+		structuredWriter = transformers.StructuredTransformer(structuredWriter)
 
 		// StructuredTransformer could return nil if one of transcoders doesn't support
 		// direct structured transcoding
-		if structuredEncoder != nil {
-			if err := message.Structured(ctx, structuredEncoder); err == nil {
+		if structuredWriter != nil {
+			if err := message.ReadStructured(ctx, structuredWriter); err == nil {
 				return EncodingStructured, nil
 			} else if err != ErrNotStructured {
 				return EncodingStructured, err
@@ -43,10 +43,10 @@ func RunDirectEncoding(
 		}
 	}
 
-	if binaryEncoder != nil && !GetOrDefaultFromCtx(ctx, SKIP_DIRECT_BINARY_ENCODING, false).(bool) {
-		binaryEncoder = transformers.BinaryTransformer(binaryEncoder)
-		if binaryEncoder != nil {
-			if err := message.Binary(ctx, binaryEncoder); err == nil {
+	if binaryWriter != nil && !GetOrDefaultFromCtx(ctx, SKIP_DIRECT_BINARY_ENCODING, false).(bool) {
+		binaryWriter = transformers.BinaryTransformer(binaryWriter)
+		if binaryWriter != nil {
+			if err := message.ReadBinary(ctx, binaryWriter); err == nil {
 				return EncodingBinary, nil
 			} else if err != ErrNotBinary {
 				return EncodingBinary, err
@@ -58,7 +58,7 @@ func RunDirectEncoding(
 }
 
 // This is the full algorithm to encode a Message using transformers:
-// 1. It first tries direct encoding using RunDirectEncoding
+// 1. It first tries direct encoding using DirectWrite
 // 2. If no direct encoding is possible, it uses ToEvent to generate an Event representation
 // 3. From the Event, the message is encoded back to the provided structured or binary encoders
 // You can tweak the encoding process using the context decorators WithForceStructured, WithForceStructured, etc.
@@ -68,18 +68,18 @@ func RunDirectEncoding(
 // * EncodingBinary, nil if message is correctly encoded in binary encoding
 // * EncodingUnknown, ErrUnknownEncoding if message.Encoding() == EncodingUnknown
 // * _, err if error happened during the encoding
-func Encode(
+func Write(
 	ctx context.Context,
 	message Message,
-	structuredEncoder StructuredEncoder,
-	binaryEncoder BinaryEncoder,
+	structuredWriter StructuredWriter,
+	binaryWriter BinaryWriter,
 	transformers TransformerFactories,
 ) (Encoding, error) {
 	enc := message.Encoding()
 	var err error
 	// Skip direct encoding if the event is an event message
 	if enc != EncodingEvent {
-		enc, err = RunDirectEncoding(ctx, message, structuredEncoder, binaryEncoder, transformers)
+		enc, err = DirectWrite(ctx, message, structuredWriter, binaryWriter, transformers)
 		if enc != EncodingUnknown {
 			// Message directly encoded, nothing else to do here
 			return enc, err
@@ -95,18 +95,18 @@ func Encode(
 	message = EventMessage(e)
 
 	if GetOrDefaultFromCtx(ctx, PREFERRED_EVENT_ENCODING, EncodingBinary).(Encoding) == EncodingStructured {
-		if structuredEncoder != nil {
-			return EncodingStructured, message.Structured(ctx, structuredEncoder)
+		if structuredWriter != nil {
+			return EncodingStructured, message.ReadStructured(ctx, structuredWriter)
 		}
-		if binaryEncoder != nil {
-			return EncodingBinary, message.Binary(ctx, binaryEncoder)
+		if binaryWriter != nil {
+			return EncodingBinary, message.ReadBinary(ctx, binaryWriter)
 		}
 	} else {
-		if binaryEncoder != nil {
-			return EncodingBinary, message.Binary(ctx, binaryEncoder)
+		if binaryWriter != nil {
+			return EncodingBinary, message.ReadBinary(ctx, binaryWriter)
 		}
-		if structuredEncoder != nil {
-			return EncodingStructured, message.Structured(ctx, structuredEncoder)
+		if structuredWriter != nil {
+			return EncodingStructured, message.ReadStructured(ctx, structuredWriter)
 		}
 	}
 

--- a/pkg/binding/write.go
+++ b/pkg/binding/write.go
@@ -23,7 +23,7 @@ const (
 // * EncodingUnknown, ErrUnknownEncoding if message is not a structured or a binary Message
 func DirectWrite(
 	ctx context.Context,
-	message Message,
+	message MessageReader,
 	structuredWriter StructuredWriter,
 	binaryWriter BinaryWriter,
 	transformers TransformerFactories,
@@ -66,16 +66,16 @@ func DirectWrite(
 // Returns:
 // * EncodingStructured, nil if message is correctly encoded in structured encoding
 // * EncodingBinary, nil if message is correctly encoded in binary encoding
-// * EncodingUnknown, ErrUnknownEncoding if message.Encoding() == EncodingUnknown
+// * EncodingUnknown, ErrUnknownEncoding if message.ReadEncoding() == EncodingUnknown
 // * _, err if error happened during the encoding
 func Write(
 	ctx context.Context,
-	message Message,
+	message MessageReader,
 	structuredWriter StructuredWriter,
 	binaryWriter BinaryWriter,
 	transformers TransformerFactories,
 ) (Encoding, error) {
-	enc := message.Encoding()
+	enc := message.ReadEncoding()
 	var err error
 	// Skip direct encoding if the event is an event message
 	if enc != EncodingEvent {

--- a/pkg/bindings/amqp/message.go
+++ b/pkg/bindings/amqp/message.go
@@ -56,14 +56,14 @@ func (m *Message) Encoding() binding.Encoding {
 	return m.encoding
 }
 
-func (m *Message) Structured(ctx context.Context, encoder binding.StructuredEncoder) error {
+func (m *Message) ReadStructured(ctx context.Context, encoder binding.StructuredWriter) error {
 	if m.AMQP.Properties != nil && format.IsFormat(m.AMQP.Properties.ContentType) {
 		return encoder.SetStructuredEvent(ctx, format.Lookup(m.AMQP.Properties.ContentType), bytes.NewReader(m.AMQP.GetData()))
 	}
 	return binding.ErrNotStructured
 }
 
-func (m *Message) Binary(ctx context.Context, encoder binding.BinaryEncoder) error {
+func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) error {
 	if len(m.AMQP.ApplicationProperties) == 0 {
 		return errors.New("AMQP CloudEvents message has no application properties")
 	}

--- a/pkg/bindings/amqp/message.go
+++ b/pkg/bindings/amqp/message.go
@@ -52,7 +52,7 @@ func getSpecVersion(message *amqp.Message) spec.Version {
 	return nil
 }
 
-func (m *Message) Encoding() binding.Encoding {
+func (m *Message) ReadEncoding() binding.Encoding {
 	return m.encoding
 }
 

--- a/pkg/bindings/amqp/sender.go
+++ b/pkg/bindings/amqp/sender.go
@@ -22,7 +22,7 @@ func (s *sender) Send(ctx context.Context, in binding.Message) error {
 	}
 
 	var amqpMessage amqp.Message
-	err = EncodeAMQPMessage(ctx, in, &amqpMessage, s.transformers)
+	err = WriteAMQPMessage(ctx, in, &amqpMessage, s.transformers)
 	if err != nil {
 		return err
 	}

--- a/pkg/bindings/http/message.go
+++ b/pkg/bindings/http/message.go
@@ -69,7 +69,7 @@ func (m *Message) Encoding() binding.Encoding {
 	return binding.EncodingUnknown
 }
 
-func (m *Message) Structured(ctx context.Context, encoder binding.StructuredEncoder) error {
+func (m *Message) ReadStructured(ctx context.Context, encoder binding.StructuredWriter) error {
 	if m.format == nil {
 		return binding.ErrNotStructured
 	} else {
@@ -77,7 +77,7 @@ func (m *Message) Structured(ctx context.Context, encoder binding.StructuredEnco
 	}
 }
 
-func (m *Message) Binary(ctx context.Context, encoder binding.BinaryEncoder) error {
+func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) error {
 	if m.version == nil {
 		return binding.ErrNotBinary
 	}

--- a/pkg/bindings/http/message.go
+++ b/pkg/bindings/http/message.go
@@ -59,7 +59,7 @@ func NewMessageFromHttpResponse(req *nethttp.Response) *Message {
 	return NewMessage(req.Header, req.Body)
 }
 
-func (m *Message) Encoding() binding.Encoding {
+func (m *Message) ReadEncoding() binding.Encoding {
 	if m.version != nil {
 		return binding.EncodingBinary
 	}

--- a/pkg/bindings/http/message_test.go
+++ b/pkg/bindings/http/message_test.go
@@ -39,7 +39,7 @@ func TestNewMessage(t *testing.T) {
 				}
 
 				req := httptest.NewRequest("POST", "http://localhost", nil)
-				require.NoError(t, EncodeHttpRequest(ctx, binding.EventMessage(eventIn), req, binding.TransformerFactories{}))
+				require.NoError(t, WriteHttpRequest(ctx, binding.EventMessage(eventIn), req, binding.TransformerFactories{}))
 
 				got := NewMessageFromHttpRequest(req)
 				require.Equal(t, tt.encoding, got.Encoding())

--- a/pkg/bindings/http/message_test.go
+++ b/pkg/bindings/http/message_test.go
@@ -42,7 +42,7 @@ func TestNewMessage(t *testing.T) {
 				require.NoError(t, WriteHttpRequest(ctx, binding.EventMessage(eventIn), req, binding.TransformerFactories{}))
 
 				got := NewMessageFromHttpRequest(req)
-				require.Equal(t, tt.encoding, got.Encoding())
+				require.Equal(t, tt.encoding, got.ReadEncoding())
 			})
 		})
 	}
@@ -54,6 +54,6 @@ func TestNewMessageUnknown(t *testing.T) {
 		req.Header.Add("content-type", "application/json")
 
 		got := NewMessageFromHttpRequest(req)
-		require.Equal(t, binding.EncodingUnknown, got.Encoding())
+		require.Equal(t, binding.EncodingUnknown, got.ReadEncoding())
 	})
 }

--- a/pkg/bindings/http/receiver.go
+++ b/pkg/bindings/http/receiver.go
@@ -28,7 +28,7 @@ type Receiver struct {
 func (r *Receiver) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	var err error
 	m := NewMessageFromHttpRequest(req)
-	if m.Encoding() == binding.EncodingUnknown {
+	if m.ReadEncoding() == binding.EncodingUnknown {
 		r.incoming <- msgErr{nil, binding.ErrUnknownEncoding}
 	}
 	done := make(chan error)

--- a/pkg/bindings/http/request_encoder.go
+++ b/pkg/bindings/http/request_encoder.go
@@ -13,43 +13,43 @@ import (
 )
 
 // Fill the provided httpRequest with the message m.
-// Using context you can tweak the encoding processing (more details on binding.Encode documentation).
-func EncodeHttpRequest(ctx context.Context, m binding.Message, httpRequest *http.Request, transformers binding.TransformerFactories) error {
-	structuredEncoder := (*httpRequestEncoder)(httpRequest)
-	binaryEncoder := (*httpRequestEncoder)(httpRequest)
+// Using context you can tweak the encoding processing (more details on binding.Write documentation).
+func WriteHttpRequest(ctx context.Context, m binding.Message, httpRequest *http.Request, transformers binding.TransformerFactories) error {
+	structuredWriter := (*httpRequestWriter)(httpRequest)
+	binaryWriter := (*httpRequestWriter)(httpRequest)
 
-	_, err := binding.Encode(
+	_, err := binding.Write(
 		ctx,
 		m,
-		structuredEncoder,
-		binaryEncoder,
+		structuredWriter,
+		binaryWriter,
 		transformers,
 	)
 	return err
 }
 
-type httpRequestEncoder http.Request
+type httpRequestWriter http.Request
 
-func (b *httpRequestEncoder) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
+func (b *httpRequestWriter) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
 	b.Header.Set(ContentType, format.MediaType())
 	b.Body = ioutil.NopCloser(event)
 	return nil
 }
 
-func (b *httpRequestEncoder) Start(ctx context.Context) error {
+func (b *httpRequestWriter) Start(ctx context.Context) error {
 	return nil
 }
 
-func (b *httpRequestEncoder) End() error {
+func (b *httpRequestWriter) End() error {
 	return nil
 }
 
-func (b *httpRequestEncoder) SetData(reader io.Reader) error {
+func (b *httpRequestWriter) SetData(reader io.Reader) error {
 	b.Body = ioutil.NopCloser(reader)
 	return nil
 }
 
-func (b *httpRequestEncoder) SetAttribute(attribute spec.Attribute, value interface{}) error {
+func (b *httpRequestWriter) SetAttribute(attribute spec.Attribute, value interface{}) error {
 	// Http headers, everything is a string!
 	s, err := types.Format(value)
 	if err != nil {
@@ -64,7 +64,7 @@ func (b *httpRequestEncoder) SetAttribute(attribute spec.Attribute, value interf
 	return nil
 }
 
-func (b *httpRequestEncoder) SetExtension(name string, value interface{}) error {
+func (b *httpRequestWriter) SetExtension(name string, value interface{}) error {
 	// Http headers, everything is a string!
 	s, err := types.Format(value)
 	if err != nil {
@@ -74,5 +74,5 @@ func (b *httpRequestEncoder) SetExtension(name string, value interface{}) error 
 	return nil
 }
 
-var _ binding.StructuredEncoder = (*httpRequestEncoder)(nil) // Test it conforms to the interface
-var _ binding.BinaryEncoder = (*httpRequestEncoder)(nil)     // Test it conforms to the interface
+var _ binding.StructuredWriter = (*httpRequestWriter)(nil) // Test it conforms to the interface
+var _ binding.BinaryWriter = (*httpRequestWriter)(nil)     // Test it conforms to the interface

--- a/pkg/bindings/http/response_encoder.go
+++ b/pkg/bindings/http/response_encoder.go
@@ -13,16 +13,16 @@ import (
 )
 
 // Fill the provided httpResponse with the message m.
-// Using context you can tweak the encoding processing (more details on binding.Encode documentation).
+// Using context you can tweak the encoding processing (more details on binding.Write documentation).
 func EncodeHttpResponse(ctx context.Context, m binding.Message, httpResponse *http.Response, transformers binding.TransformerFactories) error {
-	structuredEncoder := (*httpResponseEncoder)(httpResponse)
-	binaryEncoder := (*httpResponseEncoder)(httpResponse)
+	structuredWriter := (*httpResponseEncoder)(httpResponse)
+	binaryWriter := (*httpResponseEncoder)(httpResponse)
 
-	_, err := binding.Encode(
+	_, err := binding.Write(
 		ctx,
 		m,
-		structuredEncoder,
-		binaryEncoder,
+		structuredWriter,
+		binaryWriter,
 		transformers,
 	)
 	return err
@@ -74,5 +74,5 @@ func (b *httpResponseEncoder) SetExtension(name string, value interface{}) error
 	return nil
 }
 
-var _ binding.StructuredEncoder = (*httpResponseEncoder)(nil) // Test it conforms to the interface
-var _ binding.BinaryEncoder = (*httpResponseEncoder)(nil)     // Test it conforms to the interface
+var _ binding.StructuredWriter = (*httpResponseEncoder)(nil) // Test it conforms to the interface
+var _ binding.BinaryWriter = (*httpResponseEncoder)(nil)     // Test it conforms to the interface

--- a/pkg/bindings/http/response_encoder_test.go
+++ b/pkg/bindings/http/response_encoder_test.go
@@ -59,7 +59,7 @@ func TestEncodeHttpResponse(t *testing.T) {
 
 				//Little hack to go back to Message
 				messageOut := NewMessageFromHttpResponse(res)
-				require.Equal(t, tt.expectedEncoding, messageOut.Encoding())
+				require.Equal(t, tt.expectedEncoding, messageOut.ReadEncoding())
 
 				eventOut, err := binding.ToEvent(context.TODO(), messageOut, nil)
 				test.AssertEventEquals(t, eventIn, eventOut)

--- a/pkg/bindings/http/responsewriter_encoder.go
+++ b/pkg/bindings/http/responsewriter_encoder.go
@@ -14,16 +14,16 @@ import (
 )
 
 // Write out to the the provided httpResponseWriter with the message m.
-// Using context you can tweak the encoding processing (more details on binding.Encode documentation).
+// Using context you can tweak the encoding processing (more details on binding.Write documentation).
 func EncodeHttpResponseWriter(ctx context.Context, m binding.Message, rw http.ResponseWriter, transformers binding.TransformerFactories) error {
-	structuredEncoder := &httpResponseWriterEncoder{rw: rw}
-	binaryEncoder := &httpResponseWriterEncoder{rw: rw}
+	structuredWriter := &httpResponseWriterEncoder{rw: rw}
+	binaryWriter := &httpResponseWriterEncoder{rw: rw}
 
-	_, err := binding.Encode(
+	_, err := binding.Write(
 		ctx,
 		m,
-		structuredEncoder,
-		binaryEncoder,
+		structuredWriter,
+		binaryWriter,
 		transformers,
 	)
 	return err
@@ -82,5 +82,5 @@ func (b *httpResponseWriterEncoder) SetExtension(name string, value interface{})
 	return nil
 }
 
-var _ binding.StructuredEncoder = (*httpResponseEncoder)(nil) // Test it conforms to the interface
-var _ binding.BinaryEncoder = (*httpResponseEncoder)(nil)     // Test it conforms to the interface
+var _ binding.StructuredWriter = (*httpResponseEncoder)(nil) // Test it conforms to the interface
+var _ binding.BinaryWriter = (*httpResponseEncoder)(nil)     // Test it conforms to the interface

--- a/pkg/bindings/http/sender.go
+++ b/pkg/bindings/http/sender.go
@@ -61,7 +61,7 @@ func (s *Sender) Request(ctx context.Context, m binding.Message) (binding.Messag
 		return nil, fmt.Errorf("not initialized: %#v", s)
 	}
 
-	if err = EncodeHttpRequest(ctx, m, req, s.transformers); err != nil {
+	if err = WriteHttpRequest(ctx, m, req, s.transformers); err != nil {
 		return nil, err
 	}
 	resp, err := s.Client.Do(req)

--- a/pkg/bindings/kafka_sarama/message.go
+++ b/pkg/bindings/kafka_sarama/message.go
@@ -94,7 +94,7 @@ func NewMessage(key []byte, value []byte, contentType string, headers map[string
 	}, nil
 }
 
-func (m *Message) Encoding() binding.Encoding {
+func (m *Message) ReadEncoding() binding.Encoding {
 	if m.version != nil {
 		return binding.EncodingBinary
 	}

--- a/pkg/bindings/kafka_sarama/message.go
+++ b/pkg/bindings/kafka_sarama/message.go
@@ -104,14 +104,14 @@ func (m *Message) Encoding() binding.Encoding {
 	return binding.EncodingUnknown
 }
 
-func (m *Message) Structured(ctx context.Context, encoder binding.StructuredEncoder) error {
+func (m *Message) ReadStructured(ctx context.Context, encoder binding.StructuredWriter) error {
 	if m.format != nil {
 		return encoder.SetStructuredEvent(ctx, m.format, bytes.NewReader(m.Value))
 	}
 	return binding.ErrNotStructured
 }
 
-func (m *Message) Binary(ctx context.Context, encoder binding.BinaryEncoder) error {
+func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) error {
 	if m.version == nil {
 		return binding.ErrNotBinary
 	}

--- a/pkg/bindings/kafka_sarama/producer_message_encoder.go
+++ b/pkg/bindings/kafka_sarama/producer_message_encoder.go
@@ -24,19 +24,19 @@ func WithSkipKeyExtension(ctx context.Context) context.Context {
 }
 
 // Fill the provided producerMessage with the message m.
-// Using context you can tweak the encoding processing (more details on binding.Encode documentation).
+// Using context you can tweak the encoding processing (more details on binding.Write documentation).
 // You can skip the key extension handling decorating the context using WithSkipKeyExtension:
 // https://github.com/cloudevents/spec/blob/master/kafka-protocol-binding.md#31-key-attribute
-func EncodeKafkaProducerMessage(ctx context.Context, m binding.Message, producerMessage *sarama.ProducerMessage, transformerFactories binding.TransformerFactories) error {
+func WriteKafkaProducerMessage(ctx context.Context, m binding.Message, producerMessage *sarama.ProducerMessage, transformerFactories binding.TransformerFactories) error {
 	skipKey := binding.GetOrDefaultFromCtx(ctx, SKIP_KEY_EXTENSION, false).(bool)
 
 	if skipKey {
-		enc := &kafkaProducerMessageEncoder{
+		enc := &kafkaProducerMessageWriter{
 			producerMessage,
 			skipKey,
 		}
 
-		_, err := binding.Encode(
+		_, err := binding.Write(
 			ctx,
 			m,
 			enc,
@@ -50,11 +50,11 @@ func EncodeKafkaProducerMessage(ctx context.Context, m binding.Message, producer
 	var err error
 	// Skip direct encoding if the event is an event message
 	if enc == binding.EncodingBinary {
-		encoder := &kafkaProducerMessageEncoder{
+		encoder := &kafkaProducerMessageWriter{
 			producerMessage,
 			skipKey,
 		}
-		enc, err = binding.RunDirectEncoding(ctx, m, nil, encoder, transformerFactories)
+		enc, err = binding.DirectWrite(ctx, m, nil, encoder, transformerFactories)
 		if enc != binding.EncodingUnknown {
 			// Message directly encoded binary -> binary, nothing else to do here
 			return err
@@ -78,24 +78,24 @@ func EncodeKafkaProducerMessage(ctx context.Context, m binding.Message, producer
 
 	eventMessage := binding.EventMessage(e)
 
-	encoder := &kafkaProducerMessageEncoder{
+	encoder := &kafkaProducerMessageWriter{
 		producerMessage,
 		skipKey,
 	}
 
 	if binding.GetOrDefaultFromCtx(ctx, binding.PREFERRED_EVENT_ENCODING, binding.EncodingBinary).(binding.Encoding) == binding.EncodingStructured {
-		return eventMessage.Structured(ctx, encoder)
+		return eventMessage.ReadStructured(ctx, encoder)
 	} else {
-		return eventMessage.Binary(ctx, encoder)
+		return eventMessage.ReadBinary(ctx, encoder)
 	}
 }
 
-type kafkaProducerMessageEncoder struct {
+type kafkaProducerMessageWriter struct {
 	*sarama.ProducerMessage
 	skipKey bool
 }
 
-func (b *kafkaProducerMessageEncoder) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
+func (b *kafkaProducerMessageWriter) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
 	b.Headers = []sarama.RecordHeader{{
 		Key:   []byte(contentTypeHeader),
 		Value: []byte(format.MediaType()),
@@ -111,16 +111,16 @@ func (b *kafkaProducerMessageEncoder) SetStructuredEvent(ctx context.Context, fo
 	return nil
 }
 
-func (b *kafkaProducerMessageEncoder) Start(ctx context.Context) error {
+func (b *kafkaProducerMessageWriter) Start(ctx context.Context) error {
 	b.Headers = []sarama.RecordHeader{}
 	return nil
 }
 
-func (b *kafkaProducerMessageEncoder) End() error {
+func (b *kafkaProducerMessageWriter) End() error {
 	return nil
 }
 
-func (b *kafkaProducerMessageEncoder) SetData(reader io.Reader) error {
+func (b *kafkaProducerMessageWriter) SetData(reader io.Reader) error {
 	var buf bytes.Buffer
 	_, err := io.Copy(&buf, reader)
 	if err != nil {
@@ -131,7 +131,7 @@ func (b *kafkaProducerMessageEncoder) SetData(reader io.Reader) error {
 	return nil
 }
 
-func (b *kafkaProducerMessageEncoder) SetAttribute(attribute spec.Attribute, value interface{}) error {
+func (b *kafkaProducerMessageWriter) SetAttribute(attribute spec.Attribute, value interface{}) error {
 	// Everything is a string here
 	s, err := types.Format(value)
 	if err != nil {
@@ -146,7 +146,7 @@ func (b *kafkaProducerMessageEncoder) SetAttribute(attribute spec.Attribute, val
 	return nil
 }
 
-func (b *kafkaProducerMessageEncoder) SetExtension(name string, value interface{}) error {
+func (b *kafkaProducerMessageWriter) SetExtension(name string, value interface{}) error {
 	if !b.skipKey && name == "key" {
 		if v, ok := value.([]byte); ok {
 			b.Key = sarama.ByteEncoder(v)
@@ -169,5 +169,5 @@ func (b *kafkaProducerMessageEncoder) SetExtension(name string, value interface{
 	return nil
 }
 
-var _ binding.StructuredEncoder = (*kafkaProducerMessageEncoder)(nil) // Test it conforms to the interface
-var _ binding.BinaryEncoder = (*kafkaProducerMessageEncoder)(nil)     // Test it conforms to the interface
+var _ binding.StructuredWriter = (*kafkaProducerMessageWriter)(nil) // Test it conforms to the interface
+var _ binding.BinaryWriter = (*kafkaProducerMessageWriter)(nil)     // Test it conforms to the interface

--- a/pkg/bindings/kafka_sarama/producer_message_encoder.go
+++ b/pkg/bindings/kafka_sarama/producer_message_encoder.go
@@ -46,7 +46,7 @@ func WriteKafkaProducerMessage(ctx context.Context, m binding.Message, producerM
 		return err
 	}
 
-	enc := m.Encoding()
+	enc := m.ReadEncoding()
 	var err error
 	// Skip direct encoding if the event is an event message
 	if enc == binding.EncodingBinary {

--- a/pkg/bindings/kafka_sarama/producer_message_encoder_benchmark_test.go
+++ b/pkg/bindings/kafka_sarama/producer_message_encoder_benchmark_test.go
@@ -43,27 +43,27 @@ func init() {
 func BenchmarkEncodeStructuredMessageSkipKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ProducerMessage = &sarama.ProducerMessage{}
-		Err = kafka_sarama.EncodeKafkaProducerMessage(ctxSkipKey, structuredMessageWithoutKey, ProducerMessage, nil)
+		Err = kafka_sarama.WriteKafkaProducerMessage(ctxSkipKey, structuredMessageWithoutKey, ProducerMessage, nil)
 	}
 }
 
 func BenchmarkEncodeStructuredMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ProducerMessage = &sarama.ProducerMessage{}
-		Err = kafka_sarama.EncodeKafkaProducerMessage(ctx, structuredMessageWithKey, ProducerMessage, nil)
+		Err = kafka_sarama.WriteKafkaProducerMessage(ctx, structuredMessageWithKey, ProducerMessage, nil)
 	}
 }
 
 func BenchmarkEncodeBinaryMessageSkipKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ProducerMessage = &sarama.ProducerMessage{}
-		Err = kafka_sarama.EncodeKafkaProducerMessage(ctxSkipKey, binaryMessageWithoutKey, ProducerMessage, nil)
+		Err = kafka_sarama.WriteKafkaProducerMessage(ctxSkipKey, binaryMessageWithoutKey, ProducerMessage, nil)
 	}
 }
 
 func BenchmarkEncodeBinaryMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ProducerMessage = &sarama.ProducerMessage{}
-		Err = kafka_sarama.EncodeKafkaProducerMessage(ctx, binaryMessageWithKey, ProducerMessage, nil)
+		Err = kafka_sarama.WriteKafkaProducerMessage(ctx, binaryMessageWithKey, ProducerMessage, nil)
 	}
 }

--- a/pkg/bindings/kafka_sarama/producer_message_encoder_test.go
+++ b/pkg/bindings/kafka_sarama/producer_message_encoder_test.go
@@ -122,7 +122,7 @@ func TestEncodeKafkaProducerMessage(t *testing.T) {
 				}
 
 				messageOut, err := NewMessage(key, value, string(headers[contentTypeHeader]), headers)
-				require.Equal(t, tt.expectedEncoding, messageOut.Encoding())
+				require.Equal(t, tt.expectedEncoding, messageOut.ReadEncoding())
 				require.NoError(t, err)
 
 				eventOut, err := binding.ToEvent(context.TODO(), messageOut, nil)

--- a/pkg/bindings/kafka_sarama/producer_message_encoder_test.go
+++ b/pkg/bindings/kafka_sarama/producer_message_encoder_test.go
@@ -96,7 +96,7 @@ func TestEncodeKafkaProducerMessage(t *testing.T) {
 				eventIn = test.ExToStr(t, eventIn)
 				messageIn := tt.messageFactory(eventIn)
 
-				err := EncodeKafkaProducerMessage(ctx, messageIn, kafkaMessage, nil)
+				err := WriteKafkaProducerMessage(ctx, messageIn, kafkaMessage, nil)
 				require.NoError(t, err)
 
 				//Little hack to go back to Message

--- a/pkg/bindings/kafka_sarama/sender.go
+++ b/pkg/bindings/kafka_sarama/sender.go
@@ -37,7 +37,7 @@ func NewSender(client sarama.Client, topic string, options ...SenderOptionFunc) 
 func (s *Sender) Send(ctx context.Context, m binding.Message) error {
 	kafkaMessage := sarama.ProducerMessage{Topic: s.topic}
 
-	if err := EncodeKafkaProducerMessage(ctx, m, &kafkaMessage, s.transformers); err != nil {
+	if err := WriteKafkaProducerMessage(ctx, m, &kafkaMessage, s.transformers); err != nil {
 		return err
 	}
 

--- a/test/benchmark/http_request_to_kafka_sarama_encode/benchmark_test.go
+++ b/test/benchmark/http_request_to_kafka_sarama_encode/benchmark_test.go
@@ -32,25 +32,25 @@ func init() {
 	eventWithKey.SetExtension("key", "aaa")
 
 	structuredHttpRequestWithoutKey, _ = nethttp.NewRequest("POST", "http://localhost", nil)
-	Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), structuredHttpRequestWithoutKey, binding.TransformerFactories{})
+	Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), structuredHttpRequestWithoutKey, binding.TransformerFactories{})
 	if Err != nil {
 		panic(Err)
 	}
 
 	structuredHttpRequestWithKey, _ = nethttp.NewRequest("POST", "http://localhost", nil)
-	Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), structuredHttpRequestWithKey, binding.TransformerFactories{})
+	Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), structuredHttpRequestWithKey, binding.TransformerFactories{})
 	if Err != nil {
 		panic(Err)
 	}
 
 	binaryHttpRequestWithoutKey, _ = nethttp.NewRequest("POST", "http://localhost", nil)
-	Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), binaryHttpRequestWithoutKey, binding.TransformerFactories{})
+	Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), binaryHttpRequestWithoutKey, binding.TransformerFactories{})
 	if Err != nil {
 		panic(Err)
 	}
 
 	binaryHttpRequestWithKey, _ = nethttp.NewRequest("POST", "http://localhost", nil)
-	Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), binaryHttpRequestWithKey, binding.TransformerFactories{})
+	Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), binaryHttpRequestWithKey, binding.TransformerFactories{})
 	if Err != nil {
 		panic(Err)
 	}
@@ -65,75 +65,75 @@ var Err error
 func BenchmarkBaselineStructured(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Req, _ = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), Req, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), Req, binding.TransformerFactories{})
 	}
 }
 
 func BenchmarkStructured(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tempReq, _ := nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), tempReq, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), tempReq, binding.TransformerFactories{})
 
 		M = http.NewMessageFromHttpRequest(tempReq)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
 		producerMessage := &sarama.ProducerMessage{}
-		Err = kafka_sarama.EncodeKafkaProducerMessage(ctx, M, producerMessage, binding.TransformerFactories{})
+		Err = kafka_sarama.WriteKafkaProducerMessage(ctx, M, producerMessage, binding.TransformerFactories{})
 	}
 }
 
 func BenchmarkBaselineStructuredSkipKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Req, _ = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), Req, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), Req, binding.TransformerFactories{})
 	}
 }
 
 func BenchmarkStructuredSkipKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tempReq, _ := nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), tempReq, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), tempReq, binding.TransformerFactories{})
 
 		M = http.NewMessageFromHttpRequest(tempReq)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
 		producerMessage := &sarama.ProducerMessage{}
-		Err = kafka_sarama.EncodeKafkaProducerMessage(ctxSkipKey, M, producerMessage, binding.TransformerFactories{})
+		Err = kafka_sarama.WriteKafkaProducerMessage(ctxSkipKey, M, producerMessage, binding.TransformerFactories{})
 	}
 }
 
 func BenchmarkBaselineBinary(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Req, _ = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), Req, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), Req, binding.TransformerFactories{})
 	}
 }
 
 func BenchmarkBinary(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tempReq, _ := nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), tempReq, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithKey), tempReq, binding.TransformerFactories{})
 
 		M = http.NewMessageFromHttpRequest(tempReq)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
 		producerMessage := &sarama.ProducerMessage{}
-		Err = kafka_sarama.EncodeKafkaProducerMessage(ctx, M, producerMessage, binding.TransformerFactories{})
+		Err = kafka_sarama.WriteKafkaProducerMessage(ctx, M, producerMessage, binding.TransformerFactories{})
 	}
 }
 
 func BenchmarkBaselineBinarySkipKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Req, _ = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), Req, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), Req, binding.TransformerFactories{})
 	}
 }
 
 func BenchmarkBinarySkipKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tempReq, _ := nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), tempReq, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), binding.EventMessage(eventWithoutKey), tempReq, binding.TransformerFactories{})
 
 		M = http.NewMessageFromHttpRequest(tempReq)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
 		producerMessage := &sarama.ProducerMessage{}
-		Err = kafka_sarama.EncodeKafkaProducerMessage(ctxSkipKey, M, producerMessage, binding.TransformerFactories{})
+		Err = kafka_sarama.WriteKafkaProducerMessage(ctxSkipKey, M, producerMessage, binding.TransformerFactories{})
 	}
 }

--- a/test/benchmark/kafka_sarama_to_http_request_encode/benchmark_test.go
+++ b/test/benchmark/kafka_sarama_to_http_request_encode/benchmark_test.go
@@ -81,7 +81,7 @@ func BenchmarkStructuredWithKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		M, Err = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessageWithKey)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), M, Req, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), M, Req, binding.TransformerFactories{})
 	}
 }
 
@@ -89,7 +89,7 @@ func BenchmarkStructuredWithoutKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		M, Err = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessageWithoutKey)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), M, Req, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), M, Req, binding.TransformerFactories{})
 	}
 }
 
@@ -97,7 +97,7 @@ func BenchmarkBinaryWithKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		M, Err = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessageWithKey)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), M, Req, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), M, Req, binding.TransformerFactories{})
 	}
 }
 
@@ -105,6 +105,6 @@ func BenchmarkBinaryWithoutKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		M, Err = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessageWithoutKey)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.EncodeHttpRequest(context.TODO(), M, Req, binding.TransformerFactories{})
+		Err = http.WriteHttpRequest(context.TODO(), M, Req, binding.TransformerFactories{})
 	}
 }

--- a/test/integration/amqp_binding/amqp_test.go
+++ b/test/integration/amqp_binding/amqp_test.go
@@ -25,7 +25,7 @@ func TestSendSkipBinary(t *testing.T) {
 		in := test.MustCreateMockBinaryMessage(eventIn)
 		test.SendReceive(t, binding.WithSkipDirectBinaryEncoding(binding.WithPreferredEventEncoding(context.Background(), binding.EncodingStructured), true), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.TODO(), out)
-			assert.Equal(t, out.Encoding(), binding.EncodingStructured)
+			assert.Equal(t, out.ReadEncoding(), binding.EncodingStructured)
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -39,7 +39,7 @@ func TestSendSkipStructured(t *testing.T) {
 		in := test.MustCreateMockStructuredMessage(eventIn)
 		test.SendReceive(t, binding.WithSkipDirectStructuredEncoding(context.Background(), true), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, out.Encoding(), binding.EncodingBinary)
+			assert.Equal(t, out.ReadEncoding(), binding.EncodingBinary)
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -53,7 +53,7 @@ func TestSendEventReceiveStruct(t *testing.T) {
 		in := binding.EventMessage(eventIn)
 		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, out.Encoding(), binding.EncodingStructured)
+			assert.Equal(t, out.ReadEncoding(), binding.EncodingStructured)
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -67,7 +67,7 @@ func TestSendEventReceiveBinary(t *testing.T) {
 		in := binding.EventMessage(eventIn)
 		test.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, out.Encoding(), binding.EncodingBinary)
+			assert.Equal(t, out.ReadEncoding(), binding.EncodingBinary)
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})

--- a/test/integration/http_binding/http_test.go
+++ b/test/integration/http_binding/http_test.go
@@ -25,7 +25,7 @@ func TestSendSkipBinary(t *testing.T) {
 		in := test.MustCreateMockBinaryMessage(eventIn)
 		test.SendReceive(t, binding.WithSkipDirectBinaryEncoding(binding.WithPreferredEventEncoding(context.Background(), binding.EncodingStructured), true), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingStructured, out.Encoding())
+			assert.Equal(t, binding.EncodingStructured, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -39,7 +39,7 @@ func TestSendSkipStructured(t *testing.T) {
 		in := test.MustCreateMockStructuredMessage(eventIn)
 		test.SendReceive(t, binding.WithSkipDirectStructuredEncoding(context.Background(), true), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingBinary, out.Encoding())
+			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -53,7 +53,7 @@ func TestSendBinaryReceiveBinary(t *testing.T) {
 		in := test.MustCreateMockBinaryMessage(eventIn)
 		test.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingBinary, out.Encoding())
+			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -67,7 +67,7 @@ func TestSendStructReceiveStruct(t *testing.T) {
 		in := test.MustCreateMockStructuredMessage(eventIn)
 		test.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			require.Equal(t, binding.EncodingStructured, out.Encoding())
+			require.Equal(t, binding.EncodingStructured, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -81,7 +81,7 @@ func TestSendEventReceiveBinary(t *testing.T) {
 		in := binding.EventMessage(eventIn)
 		test.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			require.Equal(t, binding.EncodingBinary, out.Encoding())
+			require.Equal(t, binding.EncodingBinary, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})

--- a/test/integration/kafka_sarama_binding/kafka_test.go
+++ b/test/integration/kafka_sarama_binding/kafka_test.go
@@ -31,7 +31,7 @@ func TestSendStructuredMessageToStructuredWithKey(t *testing.T) {
 		in := test.MustCreateMockStructuredMessage(eventIn)
 		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingEvent, out.Encoding())
+			assert.Equal(t, binding.EncodingEvent, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -46,7 +46,7 @@ func TestSendStructuredMessageToStructuredWithoutKey(t *testing.T) {
 		in := test.MustCreateMockStructuredMessage(eventIn)
 		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingStructured, out.Encoding())
+			assert.Equal(t, binding.EncodingStructured, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -62,7 +62,7 @@ func TestSendBinaryMessageToBinaryWithKey(t *testing.T) {
 		in := test.MustCreateMockBinaryMessage(eventIn)
 		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingBinary, out.Encoding())
+			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})
@@ -77,7 +77,7 @@ func TestSendBinaryMessageToBinaryWithoutKey(t *testing.T) {
 		in := test.MustCreateMockBinaryMessage(eventIn)
 		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingBinary, out.Encoding())
+			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
 		})
 	})


### PR DESCRIPTION
* Renamed `Structured` and `Binary` methods to `ReadStructured` and `ReadBinary`
* Splitted `Message` into `MessageReader` and `Message`