### PR TITLE
ToEvent returns a pointer. Move Sender/Receiver out of Binding.

### DIFF
--- a/docs/SDK_v2.md
+++ b/docs/SDK_v2.md
@@ -77,3 +77,21 @@ Mutator, when a Producer or Intermediary blocks on a response from a Consumer, r
 
 
 
+---
+
+# For Integrators
+
+To leverage the SDK, the following interfaces need to be considered:
+
+Event -> Message -> bits
+
+bits -> Message -> Event
+
+bit -> Message -> bits
+
+
+
+
+
+
+

--- a/pkg/binding/buffering/copy_message.go
+++ b/pkg/binding/buffering/copy_message.go
@@ -32,7 +32,7 @@ func CopyMessage(ctx context.Context, m binding.Message, transformers binding.Tr
 		if err != nil {
 			return nil, err
 		}
-		return binding.EventMessage(e), nil
+		return binding.EventMessage(*e), nil
 	}
 
 	sm := structBufferedMessage{}
@@ -48,6 +48,6 @@ func CopyMessage(ctx context.Context, m binding.Message, transformers binding.Tr
 		if err != nil {
 			return nil, err
 		}
-		return binding.EventMessage(e), nil
+		return binding.EventMessage(*e), nil
 	}
 }

--- a/pkg/binding/buffering/copy_message_test.go
+++ b/pkg/binding/buffering/copy_message_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
-	"github.com/cloudevents/sdk-go/pkg/binding/test"
+	. "github.com/cloudevents/sdk-go/pkg/binding/test"
 	"github.com/cloudevents/sdk-go/pkg/event"
 )
 
@@ -23,40 +23,40 @@ type copyMessageTestCase struct {
 func TestCopyMessage(t *testing.T) {
 	tests := []copyMessageTestCase{}
 
-	for _, v := range test.Events() {
+	for _, v := range Events() {
 		tests = append(tests, []copyMessageTestCase{
 			{
-				name:     "From structured with payload/" + test.NameOf(v),
+				name:     "From structured with payload/" + NameOf(v),
 				encoding: binding.EncodingStructured,
-				message:  test.MustCreateMockStructuredMessage(v),
+				message:  MustCreateMockStructuredMessage(v),
 				want:     v,
 			},
 			{
-				name:     "From structured without payload/" + test.NameOf(v),
+				name:     "From structured without payload/" + NameOf(v),
 				encoding: binding.EncodingStructured,
-				message:  test.MustCreateMockStructuredMessage(v),
+				message:  MustCreateMockStructuredMessage(v),
 				want:     v,
 			},
 			{
-				name:     "From binary with payload/" + test.NameOf(v),
+				name:     "From binary with payload/" + NameOf(v),
 				encoding: binding.EncodingBinary,
-				message:  test.MustCreateMockBinaryMessage(v),
+				message:  MustCreateMockBinaryMessage(v),
 				want:     v,
 			},
 			{
-				name:     "From binary without payload/" + test.NameOf(v),
+				name:     "From binary without payload/" + NameOf(v),
 				encoding: binding.EncodingBinary,
-				message:  test.MustCreateMockBinaryMessage(v),
+				message:  MustCreateMockBinaryMessage(v),
 				want:     v,
 			},
 			{
-				name:     "From event with payload/" + test.NameOf(v),
+				name:     "From event with payload/" + NameOf(v),
 				encoding: binding.EncodingEvent,
 				message:  binding.EventMessage(v),
 				want:     v,
 			},
 			{
-				name:     "From event without payload/" + test.NameOf(v),
+				name:     "From event without payload/" + NameOf(v),
 				encoding: binding.EncodingEvent,
 				message:  binding.EventMessage(v),
 				want:     v,
@@ -77,7 +77,7 @@ func TestCopyMessage(t *testing.T) {
 				got, err := binding.ToEvent(context.Background(), cpy, nil)
 				assert.NoError(t, err)
 				require.Equal(t, tt.encoding, cpy.ReadEncoding())
-				test.AssertEventEquals(t, test.ExToStr(t, tt.want), test.ExToStr(t, got))
+				AssertEventEquals(t, ExToStr(t, tt.want), ExToStr(t, *got))
 			}
 			require.NoError(t, cpy.Finish(nil))
 			require.Equal(t, false, finished)
@@ -94,7 +94,7 @@ func TestCopyMessage(t *testing.T) {
 				got, err := binding.ToEvent(context.Background(), cpy, nil)
 				assert.NoError(t, err)
 				require.Equal(t, tt.encoding, cpy.ReadEncoding())
-				test.AssertEventEquals(t, test.ExToStr(t, tt.want), test.ExToStr(t, got))
+				AssertEventEquals(t, ExToStr(t, tt.want), ExToStr(t, *got))
 			}
 			require.NoError(t, cpy.Finish(nil))
 			require.Equal(t, true, finished)

--- a/pkg/binding/example_implementing_test.go
+++ b/pkg/binding/example_implementing_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"io"
 	"io/ioutil"
 
@@ -43,7 +44,7 @@ type ExSender struct {
 	transformers binding.TransformerFactories
 }
 
-func NewExSender(w io.Writer, factories ...binding.TransformerFactory) binding.Sender {
+func NewExSender(w io.Writer, factories ...binding.TransformerFactory) bindings.Sender {
 	return &ExSender{encoder: json.NewEncoder(w), transformers: factories}
 }
 
@@ -73,13 +74,13 @@ func (s *ExSender) SetStructuredEvent(ctx context.Context, f format.Format, even
 	}
 }
 
-var _ binding.Sender = (*ExSender)(nil)
+var _ bindings.Sender = (*ExSender)(nil)
 var _ binding.StructuredWriter = (*ExSender)(nil)
 
 // ExReceiver receives by reading JSON encoded events from an io.Reader
 type ExReceiver struct{ decoder *json.Decoder }
 
-func NewExReceiver(r io.Reader) binding.Receiver { return &ExReceiver{json.NewDecoder(r)} }
+func NewExReceiver(r io.Reader) bindings.Receiver { return &ExReceiver{json.NewDecoder(r)} }
 
 func (r *ExReceiver) Receive(context.Context) (binding.Message, error) {
 	var rm json.RawMessage
@@ -91,5 +92,5 @@ func (r *ExReceiver) Close(context.Context) error { return nil }
 // NewExTransport returns a transport.Transport which is implemented by
 // an ExSender and an ExReceiver
 func NewExTransport(r io.Reader, w io.Writer) transport.Transport {
-	return binding.NewSendingTransport(NewExSender(w), NewExReceiver(r), []func(ctx context.Context) context.Context{})
+	return bindings.NewSendingTransport(NewExSender(w), NewExReceiver(r), []func(ctx context.Context) context.Context{})
 }

--- a/pkg/binding/to_event_test.go
+++ b/pkg/binding/to_event_test.go
@@ -2,6 +2,7 @@ package binding_test
 
 import (
 	"context"
+	test2 "github.com/cloudevents/sdk-go/pkg/binding/test"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,32 +24,32 @@ func TestToEvent(t *testing.T) {
 	for _, v := range test.Events() {
 		tests = append(tests, []toEventTestCase{
 			{
-				name:    "From mock structured with payload/" + test.NameOf(v),
+				name:    "From mock structured with payload/" + test2.NameOf(v),
 				message: test.MustCreateMockStructuredMessage(v),
 				want:    v,
 			},
 			{
-				name:    "From mock structured without payload/" + test.NameOf(v),
+				name:    "From mock structured without payload/" + test2.NameOf(v),
 				message: test.MustCreateMockStructuredMessage(v),
 				want:    v,
 			},
 			{
-				name:    "From mock binary with payload/" + test.NameOf(v),
+				name:    "From mock binary with payload/" + test2.NameOf(v),
 				message: test.MustCreateMockBinaryMessage(v),
 				want:    v,
 			},
 			{
-				name:    "From mock binary without payload/" + test.NameOf(v),
+				name:    "From mock binary without payload/" + test2.NameOf(v),
 				message: test.MustCreateMockBinaryMessage(v),
 				want:    v,
 			},
 			{
-				name:    "From event with payload/" + test.NameOf(v),
+				name:    "From event with payload/" + test2.NameOf(v),
 				message: binding.EventMessage(v),
 				want:    v,
 			},
 			{
-				name:    "From event without payload/" + test.NameOf(v),
+				name:    "From event without payload/" + test2.NameOf(v),
 				message: binding.EventMessage(v),
 				want:    v,
 			},
@@ -59,7 +60,7 @@ func TestToEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := binding.ToEvent(context.Background(), tt.message, nil)
 			require.NoError(t, err)
-			test.AssertEventEquals(t, test.ExToStr(t, tt.want), test.ExToStr(t, got))
+			test2.AssertEventEquals(t, test2.ExToStr(t, tt.want), test2.ExToStr(t, *got))
 		})
 	}
 }

--- a/pkg/binding/transformer/add_metadata_test.go
+++ b/pkg/binding/transformer/add_metadata_test.go
@@ -9,75 +9,77 @@ import (
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
-	"github.com/cloudevents/sdk-go/pkg/binding/test"
 	"github.com/cloudevents/sdk-go/pkg/types"
+
+	. "github.com/cloudevents/sdk-go/pkg/binding/test"
+	. "github.com/cloudevents/sdk-go/pkg/bindings/test"
 )
 
 func TestAddAttribute(t *testing.T) {
-	e := test.MinEvent()
+	e := MinEvent()
 	e.Context = e.Context.AsV1()
 
 	subject := "aaa"
-	expectedEventWithSubject := test.CopyEventContext(e)
+	expectedEventWithSubject := CopyEventContext(e)
 	require.NoError(t, expectedEventWithSubject.Context.SetSubject(subject))
 
 	timestamp, err := types.ToTime(time.Now())
 	require.NoError(t, err)
-	expectedEventWithTime := test.CopyEventContext(e)
+	expectedEventWithTime := CopyEventContext(e)
 	require.NoError(t, expectedEventWithTime.Context.SetTime(timestamp))
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "No change to id to Mock Structured message",
-			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(e)),
-			WantEvent:    test.CopyEventContext(e),
+			InputMessage: MustCreateMockStructuredMessage(CopyEventContext(e)),
+			WantEvent:    CopyEventContext(e),
 			Transformers: binding.TransformerFactories{AddAttribute(spec.ID, "new-id")},
 		},
 		{
 			Name:         "No change to id to Mock Binary message",
-			InputMessage: test.MustCreateMockBinaryMessage(test.CopyEventContext(e)),
-			WantEvent:    test.CopyEventContext(e),
+			InputMessage: MustCreateMockBinaryMessage(CopyEventContext(e)),
+			WantEvent:    CopyEventContext(e),
 			Transformers: binding.TransformerFactories{AddAttribute(spec.ID, "new-id")},
 		},
 		{
 			Name:         "No change to id to Event message",
-			InputMessage: binding.EventMessage(test.CopyEventContext(e)),
-			WantEvent:    test.CopyEventContext(e),
+			InputMessage: binding.EventMessage(CopyEventContext(e)),
+			WantEvent:    CopyEventContext(e),
 			Transformers: binding.TransformerFactories{AddAttribute(spec.ID, "new-id")},
 		},
 		{
 			Name:         "Add subject to Mock Structured message",
-			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(e)),
+			InputMessage: MustCreateMockStructuredMessage(CopyEventContext(e)),
 			WantEvent:    expectedEventWithSubject,
 			Transformers: binding.TransformerFactories{AddAttribute(spec.Subject, subject)},
 		},
 		{
 			Name:         "Add subject to Mock Binary message",
-			InputMessage: test.MustCreateMockBinaryMessage(test.CopyEventContext(e)),
+			InputMessage: MustCreateMockBinaryMessage(CopyEventContext(e)),
 			WantEvent:    expectedEventWithSubject,
 			Transformers: binding.TransformerFactories{AddAttribute(spec.Subject, subject)},
 		},
 		{
 			Name:         "Add subject to Event message",
-			InputMessage: binding.EventMessage(test.CopyEventContext(e)),
+			InputMessage: binding.EventMessage(CopyEventContext(e)),
 			WantEvent:    expectedEventWithSubject,
 			Transformers: binding.TransformerFactories{AddAttribute(spec.Subject, subject)},
 		},
 		{
 			Name:         "Add time to Mock Structured message",
-			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(e)),
+			InputMessage: MustCreateMockStructuredMessage(CopyEventContext(e)),
 			WantEvent:    expectedEventWithTime,
 			Transformers: binding.TransformerFactories{AddAttribute(spec.Time, timestamp)},
 		},
 		{
 			Name:         "Add time to Mock Binary message",
-			InputMessage: test.MustCreateMockBinaryMessage(test.CopyEventContext(e)),
+			InputMessage: MustCreateMockBinaryMessage(CopyEventContext(e)),
 			WantEvent:    expectedEventWithTime,
 			Transformers: binding.TransformerFactories{AddAttribute(spec.Time, timestamp)},
 		},
 		{
 			Name:         "Add time to Event message",
-			InputMessage: binding.EventMessage(test.CopyEventContext(e)),
+			InputMessage: binding.EventMessage(CopyEventContext(e)),
 			WantEvent:    expectedEventWithTime,
 			Transformers: binding.TransformerFactories{AddAttribute(spec.Time, timestamp)},
 		},
@@ -85,49 +87,49 @@ func TestAddAttribute(t *testing.T) {
 }
 
 func TestAddExtension(t *testing.T) {
-	e := test.MinEvent()
+	e := MinEvent()
 	e.Context = e.Context.AsV1()
 
 	extName := "aaa"
 	extValue := "bbb"
-	expectedEventWithExtension := test.CopyEventContext(e)
+	expectedEventWithExtension := CopyEventContext(e)
 	require.NoError(t, expectedEventWithExtension.Context.SetExtension(extName, extValue))
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "No change to extension 'aaa' to Mock Structured message",
-			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(expectedEventWithExtension)),
-			WantEvent:    test.CopyEventContext(expectedEventWithExtension),
+			InputMessage: MustCreateMockStructuredMessage(CopyEventContext(expectedEventWithExtension)),
+			WantEvent:    CopyEventContext(expectedEventWithExtension),
 			Transformers: binding.TransformerFactories{AddExtension(extName, extValue)},
 		},
 		{
 			Name:         "No change to extension 'aaa' to Mock Binary message",
-			InputMessage: test.MustCreateMockBinaryMessage(test.CopyEventContext(expectedEventWithExtension)),
-			WantEvent:    test.CopyEventContext(expectedEventWithExtension),
+			InputMessage: MustCreateMockBinaryMessage(CopyEventContext(expectedEventWithExtension)),
+			WantEvent:    CopyEventContext(expectedEventWithExtension),
 			Transformers: binding.TransformerFactories{AddExtension(extName, extValue)},
 		},
 		{
 			Name:         "No change to extension 'aaa' to Event message",
-			InputMessage: binding.EventMessage(test.CopyEventContext(expectedEventWithExtension)),
-			WantEvent:    test.CopyEventContext(expectedEventWithExtension),
+			InputMessage: binding.EventMessage(CopyEventContext(expectedEventWithExtension)),
+			WantEvent:    CopyEventContext(expectedEventWithExtension),
 			Transformers: binding.TransformerFactories{AddExtension(extName, extValue)},
 		},
 		{
 			Name:         "Add extension 'aaa' to Mock Structured message",
-			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(e)),
-			WantEvent:    test.CopyEventContext(expectedEventWithExtension),
+			InputMessage: MustCreateMockStructuredMessage(CopyEventContext(e)),
+			WantEvent:    CopyEventContext(expectedEventWithExtension),
 			Transformers: binding.TransformerFactories{AddExtension(extName, extValue)},
 		},
 		{
 			Name:         "Add extension 'aaa' to Mock Binary message",
-			InputMessage: test.MustCreateMockBinaryMessage(test.CopyEventContext(e)),
-			WantEvent:    test.CopyEventContext(expectedEventWithExtension),
+			InputMessage: MustCreateMockBinaryMessage(CopyEventContext(e)),
+			WantEvent:    CopyEventContext(expectedEventWithExtension),
 			Transformers: binding.TransformerFactories{AddExtension(extName, extValue)},
 		},
 		{
 			Name:         "Add extension 'aaa' to Event message",
-			InputMessage: binding.EventMessage(test.CopyEventContext(e)),
-			WantEvent:    test.CopyEventContext(expectedEventWithExtension),
+			InputMessage: binding.EventMessage(CopyEventContext(e)),
+			WantEvent:    CopyEventContext(expectedEventWithExtension),
 			Transformers: binding.TransformerFactories{AddExtension(extName, extValue)},
 		},
 	})

--- a/pkg/binding/transformer/add_or_update_metadata_test.go
+++ b/pkg/binding/transformer/add_or_update_metadata_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
 	"github.com/cloudevents/sdk-go/pkg/binding/test"
 	"github.com/cloudevents/sdk-go/pkg/types"
+
+	. "github.com/cloudevents/sdk-go/pkg/bindings/test"
 )
 
 func TestSetAttribute(t *testing.T) {
@@ -38,7 +40,7 @@ func TestSetAttribute(t *testing.T) {
 		return t.Add(1 * time.Hour), nil
 	})
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "Add time to Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(e),
@@ -108,7 +110,7 @@ func TestSetExtension(t *testing.T) {
 		return strconv.Itoa(n), nil
 	})
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "Add exnum to Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(e),

--- a/pkg/binding/transformer/default_metadata_test.go
+++ b/pkg/binding/transformer/default_metadata_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/test"
 	"github.com/cloudevents/sdk-go/pkg/event"
+
+	. "github.com/cloudevents/sdk-go/pkg/bindings/test"
 )
 
 func TestAddUUID(t *testing.T) {
@@ -27,7 +29,7 @@ func TestAddUUID(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "No change to id to Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(eventWithId)),
@@ -74,7 +76,7 @@ func TestAddTimeNow(t *testing.T) {
 		require.False(t, ev.Context.GetTime().IsZero())
 	}
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "No change to time to Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(eventWithTime)),

--- a/pkg/binding/transformer/delete_metadata_test.go
+++ b/pkg/binding/transformer/delete_metadata_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
 	"github.com/cloudevents/sdk-go/pkg/binding/test"
+
+	. "github.com/cloudevents/sdk-go/pkg/bindings/test"
 )
 
 func TestDeleteAttribute(t *testing.T) {
@@ -23,7 +25,7 @@ func TestDeleteAttribute(t *testing.T) {
 	noSubjectEvent := test.CopyEventContext(withSubjectEvent)
 	require.NoError(t, noSubjectEvent.Context.SetSubject(""))
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "Remove subject from Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(withSubjectEvent)),
@@ -90,7 +92,7 @@ func TestDeleteExtension(t *testing.T) {
 	expectedEventWithExtension := test.CopyEventContext(e)
 	require.NoError(t, expectedEventWithExtension.Context.SetExtension(extName, extValue))
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "No change to Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(expectedEventWithExtension)),

--- a/pkg/binding/transformer/update_metadata_test.go
+++ b/pkg/binding/transformer/update_metadata_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
-	"github.com/cloudevents/sdk-go/pkg/binding/test"
+	test "github.com/cloudevents/sdk-go/pkg/binding/test"
+
+	. "github.com/cloudevents/sdk-go/pkg/bindings/test"
 )
 
 func TestUpdateAttribute(t *testing.T) {
@@ -36,7 +38,7 @@ func TestUpdateAttribute(t *testing.T) {
 	updatedTimeEvent := test.CopyEventContext(withTimeEvent)
 	require.NoError(t, updatedTimeEvent.Context.SetTime(timestamp.Add(3*time.Hour)))
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "Update subject in Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(withSubjectEvent)),
@@ -111,7 +113,7 @@ func TestUpdateExtension(t *testing.T) {
 	updatedExtensionEvent := test.CopyEventContext(e)
 	require.NoError(t, updatedExtensionEvent.Context.SetExtension("aaa", strings.ToUpper("bbb")))
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "No change in Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(e)),

--- a/pkg/binding/transformer/version_test.go
+++ b/pkg/binding/transformer/version_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
-	"github.com/cloudevents/sdk-go/pkg/binding/test"
+	test "github.com/cloudevents/sdk-go/pkg/binding/test"
 	"github.com/cloudevents/sdk-go/pkg/event"
 	"github.com/cloudevents/sdk-go/pkg/types"
+
+	. "github.com/cloudevents/sdk-go/pkg/bindings/test"
 )
 
 func TestVersionTranscoder(t *testing.T) {
@@ -33,7 +35,7 @@ func TestVersionTranscoder(t *testing.T) {
 	err = testEventV1.SetData(data)
 	require.NoError(t, err)
 
-	test.RunTransformerTests(t, context.Background(), []test.TransformerTestArgs{
+	RunTransformerTests(t, context.Background(), []TransformerTestArgs{
 		{
 			Name:         "V03 -> V1 with Mock Structured message",
 			InputMessage: test.MustCreateMockStructuredMessage(test.CopyEventContext(testEventV03)),

--- a/pkg/binding/write.go
+++ b/pkg/binding/write.go
@@ -86,13 +86,13 @@ func Write(
 		}
 	}
 
-	var e event.Event
+	var e *event.Event
 	e, err = ToEvent(ctx, message, transformers)
 	if err != nil {
 		return enc, err
 	}
 
-	message = EventMessage(e)
+	message = EventMessage(*e)
 
 	if GetOrDefaultFromCtx(ctx, PREFERRED_EVENT_ENCODING, EncodingBinary).(Encoding) == EncodingStructured {
 		if structuredWriter != nil {

--- a/pkg/bindings/amqp/receiver.go
+++ b/pkg/bindings/amqp/receiver.go
@@ -2,8 +2,8 @@ package amqp
 
 import (
 	"context"
-
 	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"pack.ag/amqp"
 )
 
@@ -22,6 +22,6 @@ func (r *receiver) Receive(ctx context.Context) (binding.Message, error) {
 func (r *receiver) Close(ctx context.Context) error { return r.amqp.Close(ctx) }
 
 // Create a new Receiver which wraps an amqp.Receiver in a binding.Receiver
-func NewReceiver(amqp *amqp.Receiver) binding.Receiver {
+func NewReceiver(amqp *amqp.Receiver) bindings.Receiver {
 	return &receiver{amqp: amqp}
 }

--- a/pkg/bindings/amqp/sender.go
+++ b/pkg/bindings/amqp/sender.go
@@ -2,7 +2,7 @@ package amqp
 
 import (
 	"context"
-
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"pack.ag/amqp"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
@@ -33,7 +33,7 @@ func (s *sender) Send(ctx context.Context, in binding.Message) error {
 func (s *sender) Close(ctx context.Context) error { return s.amqp.Close(ctx) }
 
 // Create a new Sender which wraps an amqp.Sender in a binding.Sender
-func NewSender(amqpSender *amqp.Sender, options ...SenderOptionFunc) binding.Sender {
+func NewSender(amqpSender *amqp.Sender, options ...SenderOptionFunc) bindings.Sender {
 	s := &sender{amqp: amqpSender, transformers: make(binding.TransformerFactories, 0)}
 	for _, o := range options {
 		o(s)

--- a/pkg/bindings/closer.go
+++ b/pkg/bindings/closer.go
@@ -1,4 +1,4 @@
-package binding
+package bindings
 
 import (
 	"context"

--- a/pkg/bindings/http/response_encoder_test.go
+++ b/pkg/bindings/http/response_encoder_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	test2 "github.com/cloudevents/sdk-go/pkg/binding/test"
 	"net/http"
 	"testing"
 
@@ -45,13 +46,13 @@ func TestEncodeHttpResponse(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+		test2.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 			t.Run(tt.name, func(t *testing.T) {
 				res := &http.Response{
 					Header: make(http.Header),
 				}
 
-				eventIn = test.ExToStr(t, eventIn)
+				eventIn = test2.ExToStr(t, eventIn)
 				messageIn := tt.messageFactory(eventIn)
 
 				err := EncodeHttpResponse(tt.context, messageIn, res, nil)
@@ -62,7 +63,7 @@ func TestEncodeHttpResponse(t *testing.T) {
 				require.Equal(t, tt.expectedEncoding, messageOut.ReadEncoding())
 
 				eventOut, err := binding.ToEvent(context.TODO(), messageOut, nil)
-				test.AssertEventEquals(t, eventIn, eventOut)
+				test2.AssertEventEquals(t, eventIn, *eventOut)
 			})
 		})
 	}

--- a/pkg/bindings/http/sender.go
+++ b/pkg/bindings/http/sender.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	cecontext "github.com/cloudevents/sdk-go/pkg/cloudevents/context"
 	"net/http"
 	nethttp "net/http"
@@ -25,7 +26,7 @@ type Sender struct {
 	transformers binding.TransformerFactories
 }
 
-func NewRequester(client *http.Client, target *url.URL, options ...SenderOptionFunc) binding.Requester {
+func NewRequester(client *http.Client, target *url.URL, options ...SenderOptionFunc) bindings.Requester {
 	s := &Sender{
 		Client:          client,
 		RequestTemplate: &http.Request{Method: http.MethodPost, URL: target},
@@ -37,12 +38,12 @@ func NewRequester(client *http.Client, target *url.URL, options ...SenderOptionF
 	return s
 }
 
-func NewSender(client *http.Client, target *url.URL, options ...SenderOptionFunc) binding.Sender {
+func NewSender(client *http.Client, target *url.URL, options ...SenderOptionFunc) bindings.Sender {
 	return NewRequester(client, target, options...)
 }
 
 // Confirm Sender implements binding.Requester
-var _ binding.Requester = (*Sender)(nil)
+var _ bindings.Requester = (*Sender)(nil)
 
 // Send implements binding.Sender
 func (s *Sender) Send(ctx context.Context, m binding.Message) error {

--- a/pkg/bindings/kafka_sarama/message_benchmark_test.go
+++ b/pkg/bindings/kafka_sarama/message_benchmark_test.go
@@ -15,7 +15,7 @@ import (
 
 // Avoid DCE
 var M binding.Message
-var Event event.Event
+var Event *event.Event
 var Err error
 
 var (

--- a/pkg/bindings/kafka_sarama/producer_message_encoder.go
+++ b/pkg/bindings/kafka_sarama/producer_message_encoder.go
@@ -61,7 +61,7 @@ func WriteKafkaProducerMessage(ctx context.Context, m binding.Message, producerM
 		}
 	}
 
-	var e ce.Event
+	var e *ce.Event
 	e, err = binding.ToEvent(ctx, m, transformerFactories)
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func WriteKafkaProducerMessage(ctx context.Context, m binding.Message, producerM
 		producerMessage.Key = sarama.StringEncoder(s)
 	}
 
-	eventMessage := binding.EventMessage(e)
+	eventMessage := binding.EventMessage(*e)
 
 	encoder := &kafkaProducerMessageWriter{
 		producerMessage,

--- a/pkg/bindings/kafka_sarama/producer_message_encoder_test.go
+++ b/pkg/bindings/kafka_sarama/producer_message_encoder_test.go
@@ -127,7 +127,7 @@ func TestEncodeKafkaProducerMessage(t *testing.T) {
 
 				eventOut, err := binding.ToEvent(context.TODO(), messageOut, nil)
 				require.NoError(t, err)
-				test.AssertEventEquals(t, eventIn, eventOut)
+				test.AssertEventEquals(t, eventIn, *eventOut)
 			})
 		})
 	}

--- a/pkg/bindings/receiver.go
+++ b/pkg/bindings/receiver.go
@@ -1,6 +1,9 @@
-package binding
+package bindings
 
-import "context"
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
 
 // Receiver receives messages.
 type Receiver interface {
@@ -8,7 +11,7 @@ type Receiver interface {
 	//
 	// A non-nil error means the receiver is closed.
 	// io.EOF means it closed cleanly, any other value indicates an error.
-	Receive(ctx context.Context) (Message, error)
+	Receive(ctx context.Context) (binding.Message, error)
 }
 
 // ReceiveCloser is a Receiver that can be closed.

--- a/pkg/bindings/sender.go
+++ b/pkg/bindings/sender.go
@@ -1,6 +1,9 @@
-package binding
+package bindings
 
-import "context"
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
 
 // Sender sends messages.
 type Sender interface {
@@ -12,7 +15,7 @@ type Sender interface {
 	// m.Finish() is called when sending is finished: expected acknowledgments (or
 	// errors) have been received, the Sender is no longer holding any state for
 	// the message. m.Finish() may be called during or after Send().
-	Send(ctx context.Context, m Message) error
+	Send(ctx context.Context, m binding.Message) error
 }
 
 // Requester sends a message and receives a response
@@ -23,7 +26,7 @@ type Requester interface {
 	Sender
 
 	// Request sends m like Sender.Send() but also arranges to receive a response.
-	Request(ctx context.Context, m Message) (Message, error)
+	Request(ctx context.Context, m binding.Message) (binding.Message, error)
 }
 
 // SendCloser is a Sender that can be closed.

--- a/pkg/bindings/test/benchmark.go
+++ b/pkg/bindings/test/benchmark.go
@@ -2,17 +2,19 @@ package test
 
 import (
 	"context"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
+	. "github.com/cloudevents/sdk-go/pkg/binding/test"
 )
 
 // Simple send/receive benchmark.
 // Requires a sender and receiver that are connected to each other.
-func BenchmarkSendReceive(b *testing.B, s binding.Sender, r binding.Receiver) {
+func BenchmarkSendReceive(b *testing.B, s bindings.Sender, r bindings.Receiver) {
 	m := binding.EventMessage(FullEvent())
 	ctx := context.Background()
 	b.ResetTimer() // Don't count setup.

--- a/pkg/bindings/test/doc.go
+++ b/pkg/bindings/test/doc.go
@@ -1,0 +1,6 @@
+package test
+
+/*
+Package test provides utilities to test binding implementations and transformers.
+
+*/

--- a/pkg/bindings/test/test.go
+++ b/pkg/bindings/test/test.go
@@ -1,0 +1,38 @@
+// Package test provides re-usable functions for binding tests.
+package test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
+)
+
+// SendReceive does s.Send(in), then it receives the message in r.Receive() and executes outAssert
+// Halt test on error.
+func SendReceive(t *testing.T, ctx context.Context, in binding.Message, s bindings.Sender, r bindings.Receiver, outAssert func(binding.Message)) {
+	t.Helper()
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		out, recvErr := r.Receive(ctx)
+		require.NoError(t, recvErr)
+		outAssert(out)
+		finishErr := out.Finish(nil)
+		require.NoError(t, finishErr)
+	}()
+
+	go func() {
+		defer wg.Done()
+		err := s.Send(ctx, in)
+		require.NoError(t, err)
+	}()
+
+	wg.Wait()
+}

--- a/pkg/bindings/test/test_test.go
+++ b/pkg/bindings/test/test_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
-	"github.com/cloudevents/sdk-go/pkg/binding/test"
+	. "github.com/cloudevents/sdk-go/pkg/binding/test"
+	. "github.com/cloudevents/sdk-go/pkg/bindings/test"
 )
 
 func TestEvent(t *testing.T) {
 	assert := assert.New(t)
 
-	e := test.FullEvent()
+	e := FullEvent()
 	assert.Equal("1.0", e.SpecVersion())
 	assert.Equal("com.example.FullEvent", e.Type())
 	assert.Equal(true, e.DataEncoded)
@@ -22,7 +23,7 @@ func TestEvent(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("hello", s)
 
-	e = test.MinEvent()
+	e = MinEvent()
 	assert.Equal("1.0", e.SpecVersion())
 	assert.Equal("com.example.MinEvent", e.Type())
 	assert.Nil(e.Data)
@@ -37,13 +38,13 @@ func (d dummySR) Receive(ctx context.Context) (binding.Message, error)    { retu
 func TestSendReceive(t *testing.T) {
 	sr := make(dummySR)
 	allIn := []binding.Message{}
-	for _, e := range test.Events() {
+	for _, e := range Events() {
 		allIn = append(allIn, binding.EventMessage(e))
 	}
 
 	var allOut []binding.Message
-	test.EachMessage(t, allIn, func(t *testing.T, in binding.Message) {
-		test.SendReceive(t, context.Background(), in, sr, sr, func(out binding.Message) {
+	EachMessage(t, allIn, func(t *testing.T, in binding.Message) {
+		SendReceive(t, context.Background(), in, sr, sr, func(out binding.Message) {
 			assert.Equal(t, in, out)
 			allOut = append(allOut, out)
 		})

--- a/pkg/bindings/test/transformer.go
+++ b/pkg/bindings/test/transformer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
+	. "github.com/cloudevents/sdk-go/pkg/binding/test"
 	"github.com/cloudevents/sdk-go/pkg/event"
 )
 
@@ -29,7 +30,7 @@ func RunTransformerTests(t *testing.T, ctx context.Context, tests []TransformerT
 			enc, err := binding.Write(ctx, tt.InputMessage, &mockStructured, &mockBinary, tt.Transformers)
 			require.NoError(t, err)
 
-			var e event.Event
+			var e *event.Event
 			if enc == binding.EncodingStructured {
 				e, err = binding.ToEvent(ctx, &mockStructured, nil)
 				require.NoError(t, err)
@@ -41,9 +42,9 @@ func RunTransformerTests(t *testing.T, ctx context.Context, tests []TransformerT
 			}
 			require.NoError(t, err)
 			if tt.AssertFunc != nil {
-				tt.AssertFunc(t, e)
+				tt.AssertFunc(t, *e)
 			} else {
-				AssertEventEquals(t, tt.WantEvent, e)
+				AssertEventEquals(t, tt.WantEvent, *e)
 			}
 		})
 	}

--- a/pkg/bindings/transport_test.go
+++ b/pkg/bindings/transport_test.go
@@ -1,4 +1,4 @@
-package binding_test
+package bindings_test
 
 import (
 	"context"
@@ -8,13 +8,14 @@ import (
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/test"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	client "github.com/cloudevents/sdk-go/pkg/client"
 	"github.com/cloudevents/sdk-go/pkg/event"
 )
 
 func TestTransportSend(t *testing.T) {
 	messageChannel := make(chan binding.Message, 1)
-	transport := binding.NewSendingTransport(binding.ChanSender(messageChannel), binding.ChanReceiver(messageChannel), nil)
+	transport := bindings.NewSendingTransport(binding.ChanSender(messageChannel), binding.ChanReceiver(messageChannel), nil)
 	ev := test.MinEvent()
 
 	c, err := client.New(transport, client.WithoutTracePropagation())
@@ -31,7 +32,7 @@ func TestTransportSend(t *testing.T) {
 func TestTransportReceive(t *testing.T) {
 	messageChannel := make(chan binding.Message, 1)
 	eventReceivedChannel := make(chan event.Event, 1)
-	transport := binding.NewSendingTransport(binding.ChanSender(messageChannel), binding.ChanReceiver(messageChannel), nil)
+	transport := bindings.NewSendingTransport(binding.ChanSender(messageChannel), binding.ChanReceiver(messageChannel), nil)
 	ev := test.MinEvent()
 
 	c, err := client.New(transport)

--- a/pkg/cloudevents/transport/amqp/transport.go
+++ b/pkg/cloudevents/transport/amqp/transport.go
@@ -2,7 +2,7 @@ package amqp
 
 import (
 	"context"
-
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"pack.ag/amqp"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
@@ -22,7 +22,7 @@ const (
 )
 
 type Transport struct {
-	binding.BindingTransport
+	bindings.BindingTransport
 	connOpts         []amqp.ConnOption
 	sessionOpts      []amqp.SessionOption
 	senderLinkOpts   []amqp.LinkOption
@@ -85,7 +85,7 @@ func New(server, queue string, opts ...Option) (*Transport, error) {
 	return t, nil
 }
 
-func (t *Transport) applyEncoding(amqpSender *amqp.Sender) (binding.Sender, []func(context.Context) context.Context) {
+func (t *Transport) applyEncoding(amqpSender *amqp.Sender) (bindings.Sender, []func(context.Context) context.Context) {
 	switch t.Encoding {
 	case BinaryV03:
 		return bindings_amqp.NewSender(

--- a/pkg/cloudevents/transport/amqp/transport_test.go
+++ b/pkg/cloudevents/transport/amqp/transport_test.go
@@ -4,6 +4,7 @@ package amqp_test
 
 import (
 	"context"
+	test2 "github.com/cloudevents/sdk-go/pkg/binding/test"
 	"net/url"
 	"os"
 	"testing"
@@ -11,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudevents/sdk-go/pkg/binding/spec"
-	"github.com/cloudevents/sdk-go/pkg/binding/test"
+	"github.com/cloudevents/sdk-go/pkg/bindings/test"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/amqp"
 	"github.com/cloudevents/sdk-go/pkg/event"
@@ -85,11 +86,11 @@ func TestSendReceive(t *testing.T) {
 	ctx := context.Background()
 	tester := newTester(t, nil, nil)
 	defer tester.Close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, e event.Event) {
+	test2.EachEvent(t, test.Events(), func(t *testing.T, e event.Event) {
 		_, _, err := tester.s.Send(ctx, e)
 		require.NoError(t, err)
 		got := <-tester.got
-		test.AssertEventEquals(t, exurl(e), got.(event.Event))
+		test2.AssertEventEquals(t, exurl(e), got.(event.Event))
 	})
 }
 
@@ -99,11 +100,11 @@ func TestWithEncoding(t *testing.T) {
 	defer tester.Close()
 	// FIXME(alanconway) problem with JSON round-tripping extensions
 	events := test.NoExtensions(test.Events())
-	test.EachEvent(t, events, func(t *testing.T, e event.Event) {
+	test2.EachEvent(t, events, func(t *testing.T, e event.Event) {
 		_, _, err := tester.s.Send(ctx, e)
 		require.NoError(t, err)
 		got := <-tester.got
 		e.Context = spec.V03.Convert(e.Context)
-		test.AssertEventEquals(t, exurl(e), got.(event.Event))
+		test2.AssertEventEquals(t, exurl(e), got.(event.Event))
 	})
 }

--- a/pkg/cloudevents/transport/httpb/transport.go
+++ b/pkg/cloudevents/transport/httpb/transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"github.com/cloudevents/sdk-go/pkg/bindings/http"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
@@ -28,7 +29,7 @@ const (
 
 // Transport acts as both a http client and a http handler.
 type Transport struct {
-	binding.BindingTransport
+	bindings.BindingTransport
 
 	// The encoding used to select the codec for outbound events.
 	Encoding Encoding

--- a/test/benchmark/e2e/http/http_mock.go
+++ b/test/benchmark/e2e/http/http_mock.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"io"
 	"io/ioutil"
 	nethttp "net/http"
@@ -9,7 +10,6 @@ import (
 	"net/url"
 
 	cloudevents "github.com/cloudevents/sdk-go"
-	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/bindings/http"
 	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 )
@@ -26,7 +26,7 @@ func NewTestClient(fn RoundTripFunc) *nethttp.Client {
 	}
 }
 
-func MockedSender(options ...http.SenderOptionFunc) binding.Sender {
+func MockedSender(options ...http.SenderOptionFunc) bindings.Sender {
 	u, _ := url.Parse("http://localhost")
 	return http.NewSender(NewTestClient(func(req *nethttp.Request) *nethttp.Response {
 		return &nethttp.Response{

--- a/test/benchmark/kafka_sarama_to_http_request_encode/benchmark_test.go
+++ b/test/benchmark/kafka_sarama_to_http_request_encode/benchmark_test.go
@@ -2,6 +2,7 @@ package kafka_sarama_to_http_request_encode
 
 import (
 	"context"
+	test2 "github.com/cloudevents/sdk-go/pkg/binding/test"
 	nethttp "net/http"
 	"testing"
 
@@ -17,7 +18,7 @@ import (
 var (
 	e                                   = test.FullEvent()
 	structuredConsumerMessageWithoutKey = &sarama.ConsumerMessage{
-		Value: test.MustJSON(e),
+		Value: test2.MustJSON(e),
 		Headers: []*sarama.RecordHeader{{
 			Key:   []byte("Content-Type"),
 			Value: []byte(cloudevents.ApplicationCloudEventsJSON),
@@ -25,7 +26,7 @@ var (
 	}
 	structuredConsumerMessageWithKey = &sarama.ConsumerMessage{
 		Key:   []byte("aaa"),
-		Value: test.MustJSON(e),
+		Value: test2.MustJSON(e),
 		Headers: []*sarama.RecordHeader{{
 			Key:   []byte("Content-Type"),
 			Value: []byte(cloudevents.ApplicationCloudEventsJSON),

--- a/test/integration/amqp_binding/amqp_test.go
+++ b/test/integration/amqp_binding/amqp_test.go
@@ -12,21 +12,23 @@ import (
 	"pack.ag/amqp"
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
-	"github.com/cloudevents/sdk-go/pkg/binding/test"
-	amqp2 "github.com/cloudevents/sdk-go/pkg/bindings/amqp"
+	. "github.com/cloudevents/sdk-go/pkg/binding/test"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
+	amqpb "github.com/cloudevents/sdk-go/pkg/bindings/amqp"
+	"github.com/cloudevents/sdk-go/pkg/bindings/test"
 	"github.com/cloudevents/sdk-go/pkg/event"
 )
 
 func TestSendSkipBinary(t *testing.T) {
 	c, s, r := testSenderReceiver(t)
 	defer c.Close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, e event.Event) {
-		eventIn := test.ExToStr(t, e)
-		in := test.MustCreateMockBinaryMessage(eventIn)
+	EachEvent(t, Events(), func(t *testing.T, e event.Event) {
+		eventIn := ExToStr(t, e)
+		in := MustCreateMockBinaryMessage(eventIn)
 		test.SendReceive(t, binding.WithSkipDirectBinaryEncoding(binding.WithPreferredEventEncoding(context.Background(), binding.EncodingStructured), true), in, s, r, func(out binding.Message) {
-			eventOut := test.MustToEvent(t, context.TODO(), out)
+			eventOut := MustToEvent(t, context.TODO(), out)
 			assert.Equal(t, out.ReadEncoding(), binding.EncodingStructured)
-			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
+			AssertEventEquals(t, eventIn, ExToStr(t, eventOut))
 		})
 	})
 }
@@ -34,13 +36,13 @@ func TestSendSkipBinary(t *testing.T) {
 func TestSendSkipStructured(t *testing.T) {
 	c, s, r := testSenderReceiver(t)
 	defer c.Close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, e event.Event) {
-		eventIn := test.ExToStr(t, e)
-		in := test.MustCreateMockStructuredMessage(eventIn)
+	EachEvent(t, Events(), func(t *testing.T, e event.Event) {
+		eventIn := ExToStr(t, e)
+		in := MustCreateMockStructuredMessage(eventIn)
 		test.SendReceive(t, binding.WithSkipDirectStructuredEncoding(context.Background(), true), in, s, r, func(out binding.Message) {
-			eventOut := test.MustToEvent(t, context.Background(), out)
+			eventOut := MustToEvent(t, context.Background(), out)
 			assert.Equal(t, out.ReadEncoding(), binding.EncodingBinary)
-			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
+			AssertEventEquals(t, eventIn, ExToStr(t, eventOut))
 		})
 	})
 }
@@ -48,13 +50,13 @@ func TestSendSkipStructured(t *testing.T) {
 func TestSendEventReceiveStruct(t *testing.T) {
 	c, s, r := testSenderReceiver(t)
 	defer c.Close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, e event.Event) {
-		eventIn := test.ExToStr(t, e)
+	EachEvent(t, Events(), func(t *testing.T, e event.Event) {
+		eventIn := ExToStr(t, e)
 		in := binding.EventMessage(eventIn)
 		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
-			eventOut := test.MustToEvent(t, context.Background(), out)
+			eventOut := MustToEvent(t, context.Background(), out)
 			assert.Equal(t, out.ReadEncoding(), binding.EncodingStructured)
-			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
+			AssertEventEquals(t, eventIn, ExToStr(t, eventOut))
 		})
 	})
 }
@@ -62,13 +64,13 @@ func TestSendEventReceiveStruct(t *testing.T) {
 func TestSendEventReceiveBinary(t *testing.T) {
 	c, s, r := testSenderReceiver(t)
 	defer c.Close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, e event.Event) {
-		eventIn := test.ExToStr(t, e)
+	EachEvent(t, Events(), func(t *testing.T, e event.Event) {
+		eventIn := ExToStr(t, e)
 		in := binding.EventMessage(eventIn)
 		test.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
-			eventOut := test.MustToEvent(t, context.Background(), out)
+			eventOut := MustToEvent(t, context.Background(), out)
 			assert.Equal(t, out.ReadEncoding(), binding.EncodingBinary)
-			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
+			AssertEventEquals(t, eventIn, ExToStr(t, eventOut))
 		})
 	})
 }
@@ -98,13 +100,13 @@ func testClient(t testing.TB) (client *amqp.Client, session *amqp.Session, addr 
 	return client, session, addr
 }
 
-func testSenderReceiver(t testing.TB, senderOptions ...amqp2.SenderOptionFunc) (io.Closer, binding.Sender, binding.Receiver) {
+func testSenderReceiver(t testing.TB, senderOptions ...amqpb.SenderOptionFunc) (io.Closer, bindings.Sender, bindings.Receiver) {
 	c, ss, a := testClient(t)
 	r, err := ss.NewReceiver(amqp.LinkSourceAddress(a))
 	require.NoError(t, err)
 	s, err := ss.NewSender(amqp.LinkTargetAddress(a))
 	require.NoError(t, err)
-	return c, amqp2.NewSender(s, senderOptions...), amqp2.NewReceiver(r)
+	return c, amqpb.NewSender(s, senderOptions...), amqpb.NewReceiver(r)
 }
 
 func BenchmarkSendReceive(b *testing.B) {

--- a/test/integration/http_binding/http_test.go
+++ b/test/integration/http_binding/http_test.go
@@ -14,7 +14,10 @@ import (
 
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/test"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"github.com/cloudevents/sdk-go/pkg/bindings/http"
+
+	tests "github.com/cloudevents/sdk-go/pkg/bindings/test"
 )
 
 func TestSendSkipBinary(t *testing.T) {
@@ -23,7 +26,7 @@ func TestSendSkipBinary(t *testing.T) {
 	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 		eventIn = test.ExToStr(t, eventIn)
 		in := test.MustCreateMockBinaryMessage(eventIn)
-		test.SendReceive(t, binding.WithSkipDirectBinaryEncoding(binding.WithPreferredEventEncoding(context.Background(), binding.EncodingStructured), true), in, s, r, func(out binding.Message) {
+		tests.SendReceive(t, binding.WithSkipDirectBinaryEncoding(binding.WithPreferredEventEncoding(context.Background(), binding.EncodingStructured), true), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
 			assert.Equal(t, binding.EncodingStructured, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
@@ -37,7 +40,7 @@ func TestSendSkipStructured(t *testing.T) {
 	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 		eventIn = test.ExToStr(t, eventIn)
 		in := test.MustCreateMockStructuredMessage(eventIn)
-		test.SendReceive(t, binding.WithSkipDirectStructuredEncoding(context.Background(), true), in, s, r, func(out binding.Message) {
+		tests.SendReceive(t, binding.WithSkipDirectStructuredEncoding(context.Background(), true), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
 			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
@@ -51,7 +54,7 @@ func TestSendBinaryReceiveBinary(t *testing.T) {
 	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 		eventIn = test.ExToStr(t, eventIn)
 		in := test.MustCreateMockBinaryMessage(eventIn)
-		test.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
+		tests.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
 			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
@@ -65,7 +68,7 @@ func TestSendStructReceiveStruct(t *testing.T) {
 	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 		eventIn = test.ExToStr(t, eventIn)
 		in := test.MustCreateMockStructuredMessage(eventIn)
-		test.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
+		tests.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
 			require.Equal(t, binding.EncodingStructured, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
@@ -79,7 +82,7 @@ func TestSendEventReceiveBinary(t *testing.T) {
 	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 		eventIn = test.ExToStr(t, eventIn)
 		in := binding.EventMessage(eventIn)
-		test.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
+		tests.SendReceive(t, context.Background(), in, s, r, func(out binding.Message) {
 			eventOut := test.MustToEvent(t, context.Background(), out)
 			require.Equal(t, binding.EncodingBinary, out.ReadEncoding())
 			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
@@ -87,7 +90,7 @@ func TestSendEventReceiveBinary(t *testing.T) {
 	})
 }
 
-func testSenderReceiver(t testing.TB, options ...http.SenderOptionFunc) (func(), binding.Sender, binding.Receiver) {
+func testSenderReceiver(t testing.TB, options ...http.SenderOptionFunc) (func(), bindings.Sender, bindings.Receiver) {
 	r := http.NewReceiver() // Parameters? Capacity, sync.
 	srv := httptest.NewServer(r)
 	u, err := url.Parse(srv.URL)
@@ -99,5 +102,5 @@ func testSenderReceiver(t testing.TB, options ...http.SenderOptionFunc) (func(),
 func BenchmarkSendReceive(b *testing.B) {
 	c, s, r := testSenderReceiver(b)
 	defer c() // Cleanup
-	test.BenchmarkSendReceive(b, s, r)
+	tests.BenchmarkSendReceive(b, s, r)
 }

--- a/test/integration/kafka_sarama_binding/kafka_test.go
+++ b/test/integration/kafka_sarama_binding/kafka_test.go
@@ -2,6 +2,8 @@ package kafka_sarama_binding
 
 import (
 	"context"
+	test2 "github.com/cloudevents/sdk-go/pkg/binding/test"
+	"github.com/cloudevents/sdk-go/pkg/bindings"
 	"os"
 	"strings"
 	"testing"
@@ -14,6 +16,7 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/binding"
 	"github.com/cloudevents/sdk-go/pkg/binding/test"
 	"github.com/cloudevents/sdk-go/pkg/bindings/kafka_sarama"
+	tests "github.com/cloudevents/sdk-go/pkg/bindings/test"
 	"github.com/cloudevents/sdk-go/pkg/event"
 )
 
@@ -24,15 +27,15 @@ const (
 func TestSendStructuredMessageToStructuredWithKey(t *testing.T) {
 	close, s, r := testSenderReceiver(t)
 	defer close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
-		eventIn = test.ExToStr(t, eventIn)
+	test2.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+		eventIn = test2.ExToStr(t, eventIn)
 		require.NoError(t, eventIn.Context.SetExtension("key", "aaa"))
 
 		in := test.MustCreateMockStructuredMessage(eventIn)
-		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
-			eventOut := test.MustToEvent(t, context.Background(), out)
+		tests.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
+			eventOut := test2.MustToEvent(t, context.Background(), out)
 			assert.Equal(t, binding.EncodingEvent, out.ReadEncoding())
-			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
+			test2.AssertEventEquals(t, eventIn, test2.ExToStr(t, eventOut))
 		})
 	})
 }
@@ -40,14 +43,14 @@ func TestSendStructuredMessageToStructuredWithKey(t *testing.T) {
 func TestSendStructuredMessageToStructuredWithoutKey(t *testing.T) {
 	close, s, r := testSenderReceiver(t)
 	defer close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
-		eventIn = test.ExToStr(t, eventIn)
+	test2.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+		eventIn = test2.ExToStr(t, eventIn)
 
 		in := test.MustCreateMockStructuredMessage(eventIn)
-		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
-			eventOut := test.MustToEvent(t, context.Background(), out)
+		tests.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
+			eventOut := test2.MustToEvent(t, context.Background(), out)
 			assert.Equal(t, binding.EncodingStructured, out.ReadEncoding())
-			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
+			test2.AssertEventEquals(t, eventIn, test2.ExToStr(t, eventOut))
 		})
 	})
 }
@@ -55,15 +58,15 @@ func TestSendStructuredMessageToStructuredWithoutKey(t *testing.T) {
 func TestSendBinaryMessageToBinaryWithKey(t *testing.T) {
 	close, s, r := testSenderReceiver(t)
 	defer close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
-		eventIn = test.ExToStr(t, eventIn)
+	test2.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+		eventIn = test2.ExToStr(t, eventIn)
 		require.NoError(t, eventIn.Context.SetExtension("key", "aaa"))
 
 		in := test.MustCreateMockBinaryMessage(eventIn)
-		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary), in, s, r, func(out binding.Message) {
-			eventOut := test.MustToEvent(t, context.Background(), out)
+		tests.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary), in, s, r, func(out binding.Message) {
+			eventOut := test2.MustToEvent(t, context.Background(), out)
 			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
-			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
+			test2.AssertEventEquals(t, eventIn, test2.ExToStr(t, eventOut))
 		})
 	})
 }
@@ -71,14 +74,14 @@ func TestSendBinaryMessageToBinaryWithKey(t *testing.T) {
 func TestSendBinaryMessageToBinaryWithoutKey(t *testing.T) {
 	close, s, r := testSenderReceiver(t)
 	defer close()
-	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
-		eventIn = test.ExToStr(t, eventIn)
+	test2.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+		eventIn = test2.ExToStr(t, eventIn)
 
 		in := test.MustCreateMockBinaryMessage(eventIn)
-		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary), in, s, r, func(out binding.Message) {
-			eventOut := test.MustToEvent(t, context.Background(), out)
+		tests.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary), in, s, r, func(out binding.Message) {
+			eventOut := test2.MustToEvent(t, context.Background(), out)
 			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
-			test.AssertEventEquals(t, eventIn, test.ExToStr(t, eventOut))
+			test2.AssertEventEquals(t, eventIn, test2.ExToStr(t, eventOut))
 		})
 	})
 }
@@ -103,7 +106,7 @@ func testClient(t testing.TB) sarama.Client {
 	return client
 }
 
-func testSenderReceiver(t testing.TB, options ...kafka_sarama.SenderOptionFunc) (func(), binding.Sender, binding.Receiver) {
+func testSenderReceiver(t testing.TB, options ...kafka_sarama.SenderOptionFunc) (func(), bindings.Sender, bindings.Receiver) {
 	client := testClient(t)
 
 	topicName := "test-ce-client-" + uuid.New().String()
@@ -124,5 +127,5 @@ func testSenderReceiver(t testing.TB, options ...kafka_sarama.SenderOptionFunc) 
 func BenchmarkSendReceive(b *testing.B) {
 	c, s, r := testSenderReceiver(b)
 	defer c() // Cleanup
-	test.BenchmarkSendReceive(b, s, r)
+	tests.BenchmarkSendReceive(b, s, r)
 }


### PR DESCRIPTION
Signed-off-by: Scott Nichols <snichols@vmware.com>