### PR TITLE
Removed wrong implementation of the skip key extension

### DIFF
--- a/pkg/transport/kafka_sarama/message_benchmark_test.go
+++ b/pkg/transport/kafka_sarama/message_benchmark_test.go
@@ -19,43 +19,20 @@ var Event *event.Event
 var Err error
 
 var (
-	e                                   = test.FullEvent()
-	structuredConsumerMessageWithoutKey = &sarama.ConsumerMessage{
-		Value: test.MustJSON(e),
+	benchEvent                = test.FullEvent()
+	structuredConsumerMessage = &sarama.ConsumerMessage{
+		Value: test.MustJSON(benchEvent),
 		Headers: []*sarama.RecordHeader{{
 			Key:   []byte("content-type"),
 			Value: []byte(cloudevents.ApplicationCloudEventsJSON),
 		}},
 	}
-	structuredConsumerMessageWithKey = &sarama.ConsumerMessage{
-		Key:   []byte("aaa"),
-		Value: test.MustJSON(e),
-		Headers: []*sarama.RecordHeader{{
-			Key:   []byte("content-type"),
-			Value: []byte(cloudevents.ApplicationCloudEventsJSON),
-		}},
-	}
-	binaryConsumerMessageWithoutKey = &sarama.ConsumerMessage{
+	binaryConsumerMessage = &sarama.ConsumerMessage{
 		Value: []byte("hello world!"),
 		Headers: mustToSaramaConsumerHeaders(map[string]string{
-			"ce_type":            e.Type(),
-			"ce_source":          e.Source(),
-			"ce_id":              e.ID(),
-			"ce_time":            test.Timestamp.String(),
-			"ce_specversion":     "1.0",
-			"ce_dataschema":      test.Schema.String(),
-			"ce_datacontenttype": "text/json",
-			"ce_subject":         "topic",
-			"ce_exta":            "someext",
-		}),
-	}
-	binaryConsumerMessageWithKey = &sarama.ConsumerMessage{
-		Key:   []byte("akey"),
-		Value: []byte("hello world!"),
-		Headers: mustToSaramaConsumerHeaders(map[string]string{
-			"ce_type":            e.Type(),
-			"ce_source":          e.Source(),
-			"ce_id":              e.ID(),
+			"ce_type":            benchEvent.Type(),
+			"ce_source":          benchEvent.Source(),
+			"ce_id":              benchEvent.ID(),
 			"ce_time":            test.Timestamp.String(),
 			"ce_specversion":     "1.0",
 			"ce_dataschema":      test.Schema.String(),
@@ -66,54 +43,28 @@ var (
 	}
 )
 
-func BenchmarkNewStructuredMessageWithoutKey(b *testing.B) {
+func BenchmarkNewStructuredMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessageWithoutKey)
+		M = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessage)
 	}
 }
 
-func BenchmarkNewStructuredMessageWithKey(b *testing.B) {
+func BenchmarkNewBinaryMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessageWithKey)
+		M = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessage)
 	}
 }
 
-func BenchmarkNewBinaryMessageWithoutKey(b *testing.B) {
+func BenchmarkNewStructuredMessageToEvent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessageWithoutKey)
-	}
-}
-
-func BenchmarkNewBinaryMessageWithKey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessageWithKey)
-	}
-}
-
-func BenchmarkNewStructuredMessageWithoutKeyToEvent(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessageWithoutKey)
+		M = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessage)
 		Event, Err = binding.ToEvent(context.TODO(), M, nil)
 	}
 }
 
-func BenchmarkNewStructuredMessageWithKeyToEvent(b *testing.B) {
+func BenchmarkNewBinaryMessageToEvent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessageWithKey)
-		Event, Err = binding.ToEvent(context.TODO(), M, nil)
-	}
-}
-
-func BenchmarkNewBinaryMessageWithoutKeyToEvent(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessageWithoutKey)
-		Event, Err = binding.ToEvent(context.TODO(), M, nil)
-	}
-}
-
-func BenchmarkNewBinaryMessageWithKeyToEvent(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessageWithKey)
+		M = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessage)
 		Event, Err = binding.ToEvent(context.TODO(), M, nil)
 	}
 }

--- a/pkg/transport/kafka_sarama/receiver.go
+++ b/pkg/transport/kafka_sarama/receiver.go
@@ -46,16 +46,11 @@ func (r *Receiver) Cleanup(sarama.ConsumerGroupSession) error {
 
 func (r *Receiver) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	for message := range claim.Messages() {
-		m, err := NewMessageFromConsumerMessage(message)
+		m := NewMessageFromConsumerMessage(message)
 
-		if err != nil {
-			r.incoming <- msgErr{err: err}
-		} else {
-			r.incoming <- msgErr{
-				msg: binding.WithFinish(m, func(err error) { session.MarkMessage(message, "") }),
-			}
+		r.incoming <- msgErr{
+			msg: binding.WithFinish(m, func(err error) { session.MarkMessage(message, "") }),
 		}
-
 	}
 	return nil
 }

--- a/pkg/transport/kafka_sarama/write_producer_message_benchmark_test.go
+++ b/pkg/transport/kafka_sarama/write_producer_message_benchmark_test.go
@@ -16,54 +16,31 @@ import (
 var ProducerMessage *sarama.ProducerMessage
 
 var (
-	ctxSkipKey                  context.Context
-	ctx                         context.Context
-	eventWithoutKey             event.Event
-	eventWithKey                event.Event
-	structuredMessageWithoutKey binding.Message
-	structuredMessageWithKey    binding.Message
-	binaryMessageWithoutKey     binding.Message
-	binaryMessageWithKey        binding.Message
+	ctx               context.Context
+	initialEvent      event.Event
+	structuredMessage binding.Message
+	binaryMessage     binding.Message
 )
 
 func init() {
-	ctxSkipKey = kafka_sarama.WithSkipKeyExtension(context.TODO())
 	ctx = context.TODO()
 
-	eventWithoutKey = test.FullEvent()
-	eventWithKey = test.FullEvent()
-	eventWithKey.SetExtension("key", "aaaaaa")
+	initialEvent = test.FullEvent()
 
-	structuredMessageWithoutKey = test.MustCreateMockStructuredMessage(eventWithoutKey)
-	structuredMessageWithKey = test.MustCreateMockStructuredMessage(eventWithKey)
-	binaryMessageWithoutKey = test.MustCreateMockBinaryMessage(eventWithoutKey)
-	binaryMessageWithKey = test.MustCreateMockBinaryMessage(eventWithKey)
-}
-
-func BenchmarkEncodeStructuredMessageSkipKey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		ProducerMessage = &sarama.ProducerMessage{}
-		Err = kafka_sarama.WriteProducerMessage(ctxSkipKey, structuredMessageWithoutKey, ProducerMessage, nil)
-	}
+	structuredMessage = test.MustCreateMockStructuredMessage(initialEvent)
+	binaryMessage = test.MustCreateMockBinaryMessage(initialEvent)
 }
 
 func BenchmarkEncodeStructuredMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ProducerMessage = &sarama.ProducerMessage{}
-		Err = kafka_sarama.WriteProducerMessage(ctx, structuredMessageWithKey, ProducerMessage, nil)
-	}
-}
-
-func BenchmarkEncodeBinaryMessageSkipKey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		ProducerMessage = &sarama.ProducerMessage{}
-		Err = kafka_sarama.WriteProducerMessage(ctxSkipKey, binaryMessageWithoutKey, ProducerMessage, nil)
+		Err = kafka_sarama.WriteProducerMessage(ctx, structuredMessage, ProducerMessage, nil)
 	}
 }
 
 func BenchmarkEncodeBinaryMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ProducerMessage = &sarama.ProducerMessage{}
-		Err = kafka_sarama.WriteProducerMessage(ctx, binaryMessageWithKey, ProducerMessage, nil)
+		Err = kafka_sarama.WriteProducerMessage(ctx, binaryMessage, ProducerMessage, nil)
 	}
 }

--- a/pkg/transport/kafka_sarama/write_producer_message_test.go
+++ b/pkg/transport/kafka_sarama/write_producer_message_test.go
@@ -19,75 +19,36 @@ func TestEncodeKafkaProducerMessage(t *testing.T) {
 		context          context.Context
 		messageFactory   func(e event.Event) binding.Message
 		expectedEncoding binding.Encoding
-		skipKey          bool
 	}{
 		{
-			name:             "Structured to Structured with Skip key",
+			name:             "Structured to Structured",
 			context:          context.TODO(),
 			messageFactory:   test.MustCreateMockStructuredMessage,
 			expectedEncoding: binding.EncodingStructured,
-			skipKey:          true,
-		},
-		{
-			name:             "Binary to Binary with Skip key",
-			context:          context.TODO(),
-			messageFactory:   test.MustCreateMockBinaryMessage,
-			expectedEncoding: binding.EncodingBinary,
-			skipKey:          true,
-		},
-		{
-			name:             "Event to Structured with Skip key",
-			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured),
-			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
-			expectedEncoding: binding.EncodingStructured,
-			skipKey:          true,
-		},
-		{
-			name:             "Event to Binary with Skip key",
-			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary),
-			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
-			expectedEncoding: binding.EncodingBinary,
-			skipKey:          true,
-		},
-		{
-			name:             "Structured to Structured",
-			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured),
-			messageFactory:   func(e event.Event) binding.Message { return test.MustCreateMockStructuredMessage(e) },
-			expectedEncoding: binding.EncodingEvent,
-			skipKey:          false,
 		},
 		{
 			name:             "Binary to Binary",
 			context:          context.TODO(),
-			messageFactory:   func(e event.Event) binding.Message { return test.MustCreateMockBinaryMessage(e) },
+			messageFactory:   test.MustCreateMockBinaryMessage,
 			expectedEncoding: binding.EncodingBinary,
-			skipKey:          false,
 		},
 		{
 			name:             "Event to Structured",
 			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured),
 			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
-			expectedEncoding: binding.EncodingEvent,
-			skipKey:          false,
+			expectedEncoding: binding.EncodingStructured,
 		},
 		{
 			name:             "Event to Binary",
 			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary),
 			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
 			expectedEncoding: binding.EncodingBinary,
-			skipKey:          false,
 		},
 	}
 	for _, tt := range tests {
 		test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 			t.Run(tt.name, func(t *testing.T) {
 				ctx := tt.context
-
-				if tt.skipKey {
-					ctx = WithSkipKeyExtension(ctx)
-				} else {
-					eventIn.SetExtension("key", "bla")
-				}
 
 				kafkaMessage := &sarama.ProducerMessage{
 					Topic: "aaa",
@@ -117,13 +78,8 @@ func TestEncodeKafkaProducerMessage(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				if !tt.skipKey {
-					require.Equal(t, []byte("bla"), key)
-				}
-
-				messageOut, err := NewMessage(key, value, string(headers[contentTypeHeader]), headers)
+				messageOut := NewMessage(key, value, string(headers[contentTypeHeader]), headers)
 				require.Equal(t, tt.expectedEncoding, messageOut.ReadEncoding())
-				require.NoError(t, err)
 
 				eventOut, err := binding.ToEvent(context.TODO(), messageOut, nil)
 				require.NoError(t, err)

--- a/test/benchmark/kafka_sarama_to_http_request_encode/benchmark_test.go
+++ b/test/benchmark/kafka_sarama_to_http_request_encode/benchmark_test.go
@@ -17,43 +17,20 @@ import (
 )
 
 var (
-	e                                   = test.FullEvent()
-	structuredConsumerMessageWithoutKey = &sarama.ConsumerMessage{
-		Value: test2.MustJSON(e),
+	event                     = test.FullEvent()
+	structuredConsumerMessage = &sarama.ConsumerMessage{
+		Value: test2.MustJSON(event),
 		Headers: []*sarama.RecordHeader{{
 			Key:   []byte("Content-Type"),
 			Value: []byte(cloudevents.ApplicationCloudEventsJSON),
 		}},
 	}
-	structuredConsumerMessageWithKey = &sarama.ConsumerMessage{
-		Key:   []byte("aaa"),
-		Value: test2.MustJSON(e),
-		Headers: []*sarama.RecordHeader{{
-			Key:   []byte("Content-Type"),
-			Value: []byte(cloudevents.ApplicationCloudEventsJSON),
-		}},
-	}
-	binaryConsumerMessageWithoutKey = &sarama.ConsumerMessage{
+	binaryConsumerMessage = &sarama.ConsumerMessage{
 		Value: []byte("hello world!"),
 		Headers: mustToSaramaConsumerHeaders(map[string]string{
-			"ce_type":            e.Type(),
-			"ce_source":          e.Source(),
-			"ce_id":              e.ID(),
-			"ce_time":            test.Timestamp.String(),
-			"ce_specversion":     "1.0",
-			"ce_dataschema":      test.Schema.String(),
-			"ce_datacontenttype": "text/json",
-			"ce_subject":         "topic",
-			"ce_exta":            "someext",
-		}),
-	}
-	binaryConsumerMessageWithKey = &sarama.ConsumerMessage{
-		Key:   []byte("akey"),
-		Value: []byte("hello world!"),
-		Headers: mustToSaramaConsumerHeaders(map[string]string{
-			"ce_type":            e.Type(),
-			"ce_source":          e.Source(),
-			"ce_id":              e.ID(),
+			"ce_type":            event.Type(),
+			"ce_source":          event.Source(),
+			"ce_id":              event.ID(),
 			"ce_time":            test.Timestamp.String(),
 			"ce_specversion":     "1.0",
 			"ce_dataschema":      test.Schema.String(),
@@ -79,33 +56,17 @@ var M binding.Message
 var Req *nethttp.Request
 var Err error
 
-func BenchmarkStructuredWithKey(b *testing.B) {
+func BenchmarkStructured(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessageWithKey)
+		M = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessage)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
 		Err = http.WriteRequest(context.TODO(), M, Req, binding.TransformerFactories{})
 	}
 }
 
-func BenchmarkStructuredWithoutKey(b *testing.B) {
+func BenchmarkBinary(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessageWithoutKey)
-		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.WriteRequest(context.TODO(), M, Req, binding.TransformerFactories{})
-	}
-}
-
-func BenchmarkBinaryWithKey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessageWithKey)
-		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
-		Err = http.WriteRequest(context.TODO(), M, Req, binding.TransformerFactories{})
-	}
-}
-
-func BenchmarkBinaryWithoutKey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		M, Err = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessageWithoutKey)
+		M = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessage)
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
 		Err = http.WriteRequest(context.TODO(), M, Req, binding.TransformerFactories{})
 	}

--- a/test/integration/kafka_sarama_binding/kafka_test.go
+++ b/test/integration/kafka_sarama_binding/kafka_test.go
@@ -23,23 +23,7 @@ const (
 	TEST_GROUP_ID = "test_group_id"
 )
 
-func TestSendStructuredMessageToStructuredWithKey(t *testing.T) {
-	close, s, r := testSenderReceiver(t)
-	defer close()
-	EachEvent(t, Events(), func(t *testing.T, eventIn event.Event) {
-		eventIn = ExToStr(t, eventIn)
-		require.NoError(t, eventIn.Context.SetExtension("key", "aaa"))
-
-		in := MustCreateMockStructuredMessage(eventIn)
-		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
-			eventOut := MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingEvent, out.ReadEncoding())
-			AssertEventEquals(t, eventIn, ExToStr(t, eventOut))
-		})
-	})
-}
-
-func TestSendStructuredMessageToStructuredWithoutKey(t *testing.T) {
+func TestSendStructuredMessageToStructured(t *testing.T) {
 	close, s, r := testSenderReceiver(t)
 	defer close()
 	EachEvent(t, Events(), func(t *testing.T, eventIn event.Event) {
@@ -54,23 +38,7 @@ func TestSendStructuredMessageToStructuredWithoutKey(t *testing.T) {
 	})
 }
 
-func TestSendBinaryMessageToBinaryWithKey(t *testing.T) {
-	close, s, r := testSenderReceiver(t)
-	defer close()
-	EachEvent(t, Events(), func(t *testing.T, eventIn event.Event) {
-		eventIn = ExToStr(t, eventIn)
-		require.NoError(t, eventIn.Context.SetExtension("key", "aaa"))
-
-		in := MustCreateMockBinaryMessage(eventIn)
-		test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary), in, s, r, func(out binding.Message) {
-			eventOut := MustToEvent(t, context.Background(), out)
-			assert.Equal(t, binding.EncodingBinary, out.ReadEncoding())
-			AssertEventEquals(t, eventIn, ExToStr(t, eventOut))
-		})
-	})
-}
-
-func TestSendBinaryMessageToBinaryWithoutKey(t *testing.T) {
+func TestSendBinaryMessageToBinary(t *testing.T) {
 	close, s, r := testSenderReceiver(t)
 	defer close()
 	EachEvent(t, Events(), func(t *testing.T, eventIn event.Event) {


### PR DESCRIPTION
After discussion during Serverless WG on Thu, we figure it out that our kafka implementation is wrong. This PR removes the bad code.

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>