### PR TITLE
HTTP: set a default POST to request if template is nil

### DIFF
--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -116,6 +116,7 @@ func (p *Protocol) Request(ctx context.Context, m binding.Message) (binding.Mess
 func (p *Protocol) makeRequest(ctx context.Context) *http.Request {
 	// TODO: support custom headers from context?
 	req := &http.Request{
+		Method: http.MethodPost,
 		Header: make(http.Header),
 		// TODO: HeaderFrom(ctx),
 	}


### PR DESCRIPTION
fixes: https://github.com/cloudevents/sdk-go/issues/400

Signed-off-by: Scott Nichols <snichols@vmware.com>