### PR TITLE
Fixed code coverage script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,6 @@
+# You can locally run this ci script using the circleci CLI https://circleci.com/docs/2.0/local-cli/#section=configuration
+# circleci local execute
+
 version: 2
 jobs:
   build:
@@ -28,10 +31,12 @@ jobs:
 
     environment:
       TEST_RESULTS: /tmp/test-results
+      COVERAGE_RESULTS: /tmp/coverage-results
 
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS
+      - run: mkdir -p $COVERAGE_RESULTS
 
       - restore_cache:
           keys:
@@ -54,6 +59,10 @@ jobs:
           command: |
             TEST_AMQP_URL=amqp://localhost/test ./hack/integration-test.sh | tee ${TEST_RESULTS}/go-integration-test.out
 
+      - run:
+          name: Generate coverage report
+          command: pushd v2; go tool cover -html=coverage.txt -o ${COVERAGE_RESULTS}/coverage.html; popd
+
       - save_cache:
           key: gomod-cache-{{ checksum "v2/go.sum" }}
           paths:
@@ -63,5 +72,6 @@ jobs:
           path: /tmp/test-results
           destination: raw-test-output
 
-      - store_test_results:
-          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/coverage-results
+          destination: coverage-output

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -8,10 +8,13 @@ set -o pipefail
 pushd ./v2
 
 # Run integration tests not in parallel
-touch ./coverage.tmp
-echo 'mode: atomic' > ./coverage.txt
+# Prepare coverage file only if not exists
+if [ ! -f /tmp/foo.txt ]; then
+  touch ./coverage.tmp
+  echo 'mode: atomic' > ./coverage.txt
+fi
 COVERPKG=$(go list ./... | grep -v /vendor | tr "\n" ",")
-for gomodule in $(go list ./test/.... | grep -v /cmd | grep -v /vendor)
+for gomodule in $(go list ./test/... | grep -v /cmd | grep -v /vendor)
 do
   go test -v -parallel 1 -timeout 60s -covermode=atomic -coverprofile=coverage.tmp -coverpkg "$COVERPKG" "$gomodule" 2>&1 | sed 's/ of statements in.*//; /warning: no packages being tested depend on matches for pattern /d'
   tail -n +2 coverage.tmp >> ./coverage.txt

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -9,7 +9,7 @@ pushd ./v2
 
 # Run integration tests not in parallel
 # Prepare coverage file only if not exists
-if [ ! -f /tmp/foo.txt ]; then
+if [ ! -f ./coverage.txt ]; then
   touch ./coverage.tmp
   echo 'mode: atomic' > ./coverage.txt
 fi

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -8,7 +8,15 @@ set -o pipefail
 pushd ./v2
 
 # Run integration tests not in parallel
-go test -v -parallel 1 ./test/... -coverprofile ${TEST_RESULTS:-.}/integration_test_cover.out -timeout 60s
+touch ./coverage.tmp
+echo 'mode: atomic' > ./coverage.txt
+COVERPKG=$(go list ./... | grep -v /vendor | tr "\n" ",")
+for gomodule in $(go list ./test/.... | grep -v /cmd | grep -v /vendor)
+do
+  go test -v -parallel 1 -timeout 60s -covermode=atomic -coverprofile=coverage.tmp -coverpkg "$COVERPKG" "$gomodule" 2>&1 | sed 's/ of statements in.*//; /warning: no packages being tested depend on matches for pattern /d'
+  tail -n +2 coverage.tmp >> ./coverage.txt
+done
+rm coverage.tmp
 
 # Remove test only deps.
 go mod tidy

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -6,14 +6,30 @@ set -o pipefail
 
 # v1
 pushd ./v1
-go test -v ./... -coverprofile ${TEST_RESULTS:-.}/unit_test_cover.out -timeout 15s
+touch ./coverage.tmp
+echo 'mode: atomic' > ./coverage.txt
+COVERPKG=$(go list ./... | grep -v /vendor | tr "\n" ",")
+for gomodule in $(go list ./... | grep -v /cmd | grep -v /vendor)
+do
+  go test -v -timeout 15s -covermode=atomic -coverprofile=coverage.tmp -coverpkg "$COVERPKG" "$gomodule" 2>&1 | sed 's/ of statements in.*//; /warning: no packages being tested depend on matches for pattern /d'
+  tail -n +2 coverage.tmp >> ./coverage.txt
+done
+rm coverage.tmp
 # Remove test only deps.
 go mod tidy
 popd
 
 # v2
 pushd ./v2
-go test -v ./... -coverprofile ${TEST_RESULTS:-.}/unit_test_cover.out -timeout 15s
+touch ./coverage.tmp
+echo 'mode: atomic' > ./coverage.txt
+COVERPKG=$(go list ./... | grep -v /vendor | grep -v /test | tr "\n" ",")
+for gomodule in $(go list ./... | grep -v /cmd | grep -v /vendor | grep -v /test)
+do
+  go test -v -timeout 15s -covermode=atomic -coverprofile=coverage.tmp -coverpkg "$COVERPKG" "$gomodule" 2>&1 | sed 's/ of statements in.*//; /warning: no packages being tested depend on matches for pattern /d'
+  tail -n +2 coverage.tmp >> ./coverage.txt
+done
+rm coverage.tmp
 # Remove test only deps.
 go mod tidy
 popd


### PR DESCRIPTION
Now the code coverage correctly reports cross package code coverage (like explained here https://github.com/ory/go-acc and here https://www.ory.sh/golang-go-code-coverage-accurate/)

The CI script now puts together all coverage (from unit tests and integration tests) and generate a final report in html

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>