### PR TITLE
Fixed various Message.Finish() invocations

### DIFF
--- a/v2/protocol/amqp/sender.go
+++ b/v2/protocol/amqp/sender.go
@@ -19,7 +19,8 @@ func (s *sender) Send(ctx context.Context, in binding.Message) error {
 	var err error
 	defer func() { _ = in.Finish(err) }()
 	if m, ok := in.(*Message); ok { // Already an AMQP message.
-		return s.amqp.Send(ctx, m.AMQP)
+		err = s.amqp.Send(ctx, m.AMQP)
+		return err
 	}
 
 	var amqpMessage amqp.Message

--- a/v2/protocol/amqp/sender.go
+++ b/v2/protocol/amqp/sender.go
@@ -28,7 +28,8 @@ func (s *sender) Send(ctx context.Context, in binding.Message) error {
 		return err
 	}
 
-	return s.amqp.Send(ctx, &amqpMessage)
+	err = s.amqp.Send(ctx, &amqpMessage)
+	return err
 }
 
 func (s *sender) Close(ctx context.Context) error { return s.amqp.Close(ctx) }

--- a/v2/protocol/kafka_sarama/sender.go
+++ b/v2/protocol/kafka_sarama/sender.go
@@ -45,13 +45,16 @@ func NewSenderFromClient(client sarama.Client, topic string, options ...SenderOp
 }
 
 func (s *Sender) Send(ctx context.Context, m binding.Message) error {
+	var err error
+	defer m.Finish(err)
+
 	kafkaMessage := sarama.ProducerMessage{Topic: s.topic}
 
-	if err := WriteProducerMessage(ctx, m, &kafkaMessage, s.transformers); err != nil {
+	if err = WriteProducerMessage(ctx, m, &kafkaMessage, s.transformers); err != nil {
 		return err
 	}
 
-	_, _, err := s.syncProducer.SendMessage(&kafkaMessage)
+	_, _, err = s.syncProducer.SendMessage(&kafkaMessage)
 	return err
 }
 

--- a/v2/protocol/nats/protocol.go
+++ b/v2/protocol/nats/protocol.go
@@ -62,12 +62,15 @@ func (t *Protocol) applyOptions(opts ...Option) error {
 
 // Send implements Sender.Send
 func (t *Protocol) Send(ctx context.Context, in binding.Message) error {
+	var err error
+	defer in.Finish(err)
 	msg := &nats.Msg{}
-	if err := WriteMsg(ctx, in, msg, t.Transformers); err != nil {
+	if err = WriteMsg(ctx, in, msg, t.Transformers); err != nil {
 		return err
 	}
 	msg.Subject = t.Subject
-	return t.Conn.PublishMsg(msg)
+	err = t.Conn.PublishMsg(msg)
+	return err
 }
 
 // Receive implements Receiver.Receive

--- a/v2/protocol/outbound.go
+++ b/v2/protocol/outbound.go
@@ -13,9 +13,10 @@ type Sender interface {
 	// Send returns when the "outbound" message has been sent. The Sender may
 	// still be expecting acknowledgment or holding other state for the message.
 	//
-	// m.Finish() is called when sending is finished: expected acknowledgments (or
-	// errors) have been received, the Sender is no longer holding any state for
-	// the message. m.Finish() may be called during or after Send().
+	// m.Finish() is called when sending is finished (both succeeded or failed):
+	// expected acknowledgments (or errors) have been received, the Sender is
+	// no longer holding any state for the message.
+	// m.Finish() may be called during or after Send().
 	Send(ctx context.Context, m binding.Message) error
 }
 

--- a/v2/protocol/test/test.go
+++ b/v2/protocol/test/test.go
@@ -30,8 +30,14 @@ func SendReceive(t *testing.T, ctx context.Context, in binding.Message, s protoc
 
 	go func() {
 		defer wg.Done()
+		finished := false
+		in = binding.WithFinish(in, func(err error) {
+			require.NoError(t, err)
+			finished = true
+		})
 		err := s.Send(ctx, in)
 		require.NoError(t, err)
+		require.True(t, finished)
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
The integration tests that uses `protocol/test.SendReceive` now correctly test this behaviour

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>