### PR TITLE
NATS protocol improvements

### DIFF
--- a/v2/cmd/samples/httptonats/main.go
+++ b/v2/cmd/samples/httptonats/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 	ctx := context.Background()
 
-	natsProtocol, err := cloudeventsnats.New(env.NATSServer, env.Subject)
+	natsProtocol, err := cloudeventsnats.NewSender(env.NATSServer, env.Subject, cloudeventsnats.NatsOptions())
 	if err != nil {
 		log.Fatalf("failed to create nats protcol, %s", err.Error())
 	}

--- a/v2/cmd/samples/nats/receiver/main.go
+++ b/v2/cmd/samples/nats/receiver/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 	ctx := context.Background()
 
-	p, err := cloudeventsnats.New(env.NATSServer, env.Subject)
+	p, err := cloudeventsnats.NewConsumer(env.NATSServer, env.Subject, cloudeventsnats.NatsOptions())
 	if err != nil {
 		log.Fatalf("failed to create nats protocol, %s", err.Error())
 	}

--- a/v2/cmd/samples/nats/sender/main.go
+++ b/v2/cmd/samples/nats/sender/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	for _, contentType := range []string{"application/json", "application/xml"} {
-		p, err := cloudeventsnats.New(env.NATSServer, env.Subject)
+		p, err := cloudeventsnats.NewSender(env.NATSServer, env.Subject, cloudeventsnats.NatsOptions())
 		if err != nil {
 			log.Printf("failed to create nats protocol, %s", err.Error())
 			os.Exit(1)

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -10,14 +10,17 @@ require (
 	github.com/gorilla/mux v1.6.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac
-	github.com/nats-io/nats-server/v2 v2.1.2
+	github.com/nats-io/nats-server/v2 v2.1.4 // indirect
 	github.com/nats-io/nats.go v1.9.1
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/procfs v0.0.8 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/valyala/bytebufferpool v1.0.0
 	go.opencensus.io v0.22.0
 	go.uber.org/zap v1.10.0
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/crypto v0.0.0-20200206161412-a0c6ece9d31a // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	google.golang.org/api v0.15.0
 	google.golang.org/grpc v1.26.0
 	pack.ag/amqp v0.11.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -81,6 +81,7 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -126,6 +127,8 @@ github.com/nats-io/jwt v0.3.2 h1:+RB5hMpXUUA2dfxuhBTEkMOrYmM+gKIZYS1KjSostMI=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/nats-server/v2 v2.1.2 h1:i2Ly0B+1+rzNZHHWtD4ZwKi+OU5l+uQo1iDHZ2PmiIc=
 github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
+github.com/nats-io/nats-server/v2 v2.1.4 h1:BILRnsJ2Yb/fefiFbBWADpViGF69uh4sxe8poVDQ06g=
+github.com/nats-io/nats-server/v2 v2.1.4/go.mod h1:Jw1Z28soD/QasIA2uWjXyM9El1jly3YwyFOuR8tH1rg=
 github.com/nats-io/nats.go v1.9.1 h1:ik3HbLhZ0YABLto7iX80pZLPw/6dx3T+++MZJwLnMrQ=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
@@ -166,6 +169,8 @@ github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nL
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 h1:/K3IL0Z1quvmJ7X0A1AwNEK7CRkVK3YwfOU/QAL4WGg=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
+github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -198,6 +203,8 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49N
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72 h1:+ELyKg6m8UBf0nPFSqD0mi7zUfwPyXo23HNjMnXPz7w=
 golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200206161412-a0c6ece9d31a h1:aczoJ0HPNE92XKa7DrIzkNN6esOKO2TBwiiYoKcINhA=
+golang.org/x/crypto v0.0.0-20200206161412-a0c6ece9d31a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -230,6 +237,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -243,6 +252,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qd
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/v2/protocol/nats/message.go
+++ b/v2/protocol/nats/message.go
@@ -9,8 +9,6 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-const prefix = "cloudEvents:" // Name prefix for AMQP properties that hold CE attributes.
-
 // Message implements binding.Message by wrapping an *nats.Msg.
 // This message *can* be read several times safely
 type Message struct {

--- a/v2/protocol/nats/options_test.go
+++ b/v2/protocol/nats/options_test.go
@@ -1,40 +1,131 @@
 package nats
 
 import (
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/transformer"
+	"reflect"
 	"testing"
-	"time"
-
-	natsd "github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 )
 
-func TestWithConnOptions(t *testing.T) {
-	opts := []nats.Option{
-		nats.DontRandomize(),
-		nats.NoEcho(),
+func TestWithQueueSubscriber(t *testing.T) {
+	type args struct {
+		consumer *Consumer
+		queue    string
 	}
-
-	srv, err := natsd.NewServer(&natsd.Options{Port: -1})
-	if err != nil {
-		t.Errorf("could not start nats server: %s", err)
+	type wants struct {
+		err      error
+		consumer *Consumer
 	}
-	go srv.Start()
-	defer srv.Shutdown()
-
-	if !srv.ReadyForConnections(10 * time.Second) {
-		t.Errorf("nats server did not start")
+	tests := []struct {
+		name  string
+		args  args
+		wants wants
+	}{
+		{
+			name: "valid queue",
+			args: args{
+				consumer: &Consumer{},
+				queue:    "my-queue",
+			},
+			wants: wants{
+				err: nil,
+				consumer: &Consumer{
+					Subscriber: &QueueSubscriber{Queue: "my-queue"},
+				},
+			},
+		},
+		{
+			name: "invalid queue",
+			args: args{
+				consumer: &Consumer{},
+				queue:    "",
+			},
+			wants: wants{
+				err:      ErrInvalidQueueName,
+				consumer: &Consumer{},
+			},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := tt.args.consumer.applyOptions(WithQueueSubscriber(tt.args.queue))
+			if gotErr != tt.wants.err {
+				t.Errorf("applyOptions(WithQueueSubscriber()) = %v, want %v", gotErr, tt.wants.err)
+			}
 
-	tr, err := New(srv.Addr().String(), "testing", WithConnOptions(opts...))
-	if err != nil {
-		t.Errorf("connection failed: %s", err)
+			if !reflect.DeepEqual(tt.args.consumer, tt.wants.consumer) {
+				t.Errorf("p = %v, want %v", tt.args.consumer, tt.wants.consumer)
+			}
+		})
 	}
+}
 
-	if !tr.Conn.Opts.NoRandomize {
-		t.Errorf("NoRandomize option was not set")
+func TestWithTransformer(t *testing.T) {
+	type args struct {
+		sender      *Sender
+		transformer binding.TransformerFactory
 	}
+	type wants struct {
+		err    error
+		sender *Sender
+	}
+	tests := []struct {
+		name  string
+		args  args
+		wants wants
+	}{
+		{
+			name: "nested transformer factories",
+			args: args{
+				sender:      &Sender{},
+				transformer: binding.TransformerFactories{transformer.SetUUID, transformer.AddTimeNow},
+			},
+			wants: wants{
+				err: nil,
+				sender: &Sender{
+					Transformers: binding.TransformerFactories{
+						binding.TransformerFactories{transformer.SetUUID, transformer.AddTimeNow},
+					},
+				},
+			},
+		},
+		{
+			name: "empty transformers",
+			args: args{
+				sender:      &Sender{},
+				transformer: transformer.SetUUID,
+			},
+			wants: wants{
+				err: nil,
+				sender: &Sender{
+					Transformers: binding.TransformerFactories{transformer.SetUUID},
+				},
+			},
+		},
+		{
+			name: "no transformer",
+			args: args{
+				sender:      &Sender{},
+				transformer: nil,
+			},
+			wants: wants{
+				err: nil,
+				sender: &Sender{
+					Transformers: binding.TransformerFactories{nil},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := tt.args.sender.applyOptions(WithTransformer(tt.args.transformer))
+			if gotErr != tt.wants.err {
+				t.Errorf("applyOptions(WithTransformer()) = %v, want %v", gotErr, tt.wants.err)
+			}
 
-	if !tr.Conn.Opts.NoEcho {
-		t.Errorf("NoEcho option was not set")
+			if !reflect.DeepEqual(tt.args.sender, tt.wants.sender) {
+				t.Errorf("p = %v, want %v", tt.args.sender, tt.wants.sender)
+			}
+		})
 	}
 }

--- a/v2/protocol/nats/protocol.go
+++ b/v2/protocol/nats/protocol.go
@@ -2,8 +2,6 @@ package nats
 
 import (
 	"context"
-	"time"
-
 	"github.com/cloudevents/sdk-go/v2/binding"
 
 	"github.com/nats-io/nats.go"
@@ -12,95 +10,92 @@ import (
 // Protocol is a reference implementation for using the CloudEvents binding
 // integration. Protocol acts as both a NATS client and a NATS handler.
 type Protocol struct {
-	Conn         *nats.Conn
-	ConnOptions  []nats.Option
-	NatsURL      string
-	Subject      string
-	Transformers binding.TransformerFactories
+	Conn *nats.Conn
 
-	subscription *nats.Subscription
+	Consumer        *Consumer
+	consumerOptions []ConsumerOption
+
+	Sender        *Sender
+	senderOptions []SenderOption
+
+	connOwned bool // whether this protocol created the stan connection
 }
 
-// New creates a new NATS protocol.
-func New(natsURL, subject string, opts ...Option) (*Protocol, error) {
-	t := &Protocol{
-		Subject:      subject,
-		NatsURL:      natsURL,
-		ConnOptions:  []nats.Option{},
-		Transformers: make(binding.TransformerFactories, 0),
-	}
-
-	err := t.applyOptions(opts...)
+// NewProtocol creates a new NATS protocol.
+func NewProtocol(url, sendSubject, receiveSubject string, natsOpts []nats.Option, opts ...ProtocolOption) (*Protocol, error) {
+	conn, err := nats.Connect(url, natsOpts...)
 	if err != nil {
 		return nil, err
 	}
 
-	err = t.connect()
+	p, err := NewProtocolFromConn(conn, sendSubject, receiveSubject, opts...)
 	if err != nil {
+		conn.Close()
 		return nil, err
 	}
 
-	return t, nil
+	p.connOwned = true
+
+	return p, nil
 }
 
-func (t *Protocol) connect() error {
+func NewProtocolFromConn(conn *nats.Conn, sendSubject, receiveSubject string, opts ...ProtocolOption) (*Protocol, error) {
 	var err error
-
-	t.Conn, err = nats.Connect(t.NatsURL, t.ConnOptions...)
-
-	return err
-}
-
-func (t *Protocol) applyOptions(opts ...Option) error {
-	for _, fn := range opts {
-		if err := fn(t); err != nil {
-			return err
-		}
+	p := &Protocol{
+		Conn: conn,
 	}
-	return nil
+
+	if err := p.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+
+	if p.Consumer, err = NewConsumerFromConn(conn, receiveSubject, p.consumerOptions...); err != nil {
+		return nil, err
+	}
+
+	if p.Sender, err = NewSenderFromConn(conn, sendSubject, p.senderOptions...); err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }
 
 // Send implements Sender.Send
-func (t *Protocol) Send(ctx context.Context, in binding.Message) error {
-	var err error
-	defer in.Finish(err)
-	msg := &nats.Msg{}
-	if err = WriteMsg(ctx, in, msg, t.Transformers); err != nil {
-		return err
-	}
-	msg.Subject = t.Subject
-	err = t.Conn.PublishMsg(msg)
-	return err
+func (p *Protocol) Send(ctx context.Context, in binding.Message) error {
+	return p.Sender.Send(ctx, in)
+}
+
+func (p *Protocol) OpenInbound(ctx context.Context) error {
+	return p.Consumer.OpenInbound(ctx)
 }
 
 // Receive implements Receiver.Receive
-func (t *Protocol) Receive(ctx context.Context) (binding.Message, error) {
-	var err error
-	if t.subscription == nil {
-		t.subscription, err = t.Conn.SubscribeSync(t.Subject)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// TODO: allow to pass in a timeout
-	timeout := time.Second * 60
-
-	msg, err := t.subscription.NextMsg(timeout)
-	if err != nil {
-		return nil, err
-	}
-	return NewMessage(msg), nil
+func (p *Protocol) Receive(ctx context.Context) (binding.Message, error) {
+	return p.Consumer.Receive(ctx)
 }
 
 // Close implements Closer.Close
-func (t *Protocol) Close(ctx context.Context) error {
-	defer t.Conn.Close()
-	if t.subscription != nil {
-		if err := t.subscription.Unsubscribe(); err != nil {
+func (p *Protocol) Close(ctx context.Context) error {
+	if p.connOwned {
+		defer p.Conn.Close()
+	}
+
+	if err := p.Consumer.Close(ctx); err != nil {
+		return err
+	}
+
+	if err := p.Sender.Close(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Protocol) applyOptions(opts ...ProtocolOption) error {
+	for _, fn := range opts {
+		if err := fn(p); err != nil {
 			return err
 		}
-		t.subscription = nil
 	}
 	return nil
 }

--- a/v2/protocol/nats/receiver.go
+++ b/v2/protocol/nats/receiver.go
@@ -1,0 +1,140 @@
+package nats
+
+import (
+	"context"
+	"errors"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/nats-io/nats.go"
+	"io"
+	"sync"
+)
+
+var ErrSubscriptionAlreadyOpen = errors.New("subscription already open")
+
+type msgErr struct {
+	msg binding.Message
+}
+
+type Receiver struct {
+	incoming chan msgErr
+}
+
+func NewReceiver() *Receiver {
+	return &Receiver{
+		incoming: make(chan msgErr),
+	}
+}
+
+// MsgHandler implements nats.MsgHandler and publishes messages onto our internal incoming channel to be delivered
+// via r.Receive(ctx)
+func (r *Receiver) MsgHandler(msg *nats.Msg) {
+	r.incoming <- msgErr{msg: NewMessage(msg)}
+}
+
+func (r *Receiver) Receive(ctx context.Context) (binding.Message, error) {
+	select {
+	case msgErr, ok := <-r.incoming:
+		if !ok {
+			return nil, io.EOF
+		}
+		return msgErr.msg, nil
+	case <-ctx.Done():
+		return nil, io.EOF
+	}
+}
+
+type Consumer struct {
+	Receiver
+
+	Conn       *nats.Conn
+	Subject    string
+	Subscriber Subscriber
+
+	sub       *nats.Subscription
+	subMtx    sync.Mutex
+	connOwned bool
+}
+
+func NewConsumer(url, subject string, natsOpts []nats.Option, opts ...ConsumerOption) (*Consumer, error) {
+	conn, err := nats.Connect(url, natsOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := NewConsumerFromConn(conn, subject, opts...)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	c.connOwned = true
+
+	return c, err
+}
+
+func NewConsumerFromConn(conn *nats.Conn, subject string, opts ...ConsumerOption) (*Consumer, error) {
+	c := &Consumer{
+		Receiver:   *NewReceiver(),
+		Conn:       conn,
+		Subject:    subject,
+		Subscriber: &RegularSubscriber{},
+	}
+
+	err := c.applyOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (c *Consumer) OpenInbound(ctx context.Context) error {
+	var err error
+	c.subMtx.Lock()
+	if c.sub != nil && c.sub.IsValid() {
+		return ErrSubscriptionAlreadyOpen
+	}
+
+	c.sub, err = c.Subscriber.Subscribe(c.Conn, c.Subject, c.MsgHandler)
+	if err != nil {
+		c.sub = nil
+		c.subMtx.Unlock()
+		return err
+	}
+	c.subMtx.Unlock()
+
+	<-ctx.Done()
+
+	return nil
+}
+
+// Receive consumes a message from the subscription
+func (c *Consumer) Receive(ctx context.Context) (binding.Message, error) {
+	return c.Receiver.Receive(ctx)
+}
+
+func (c *Consumer) Close(ctx context.Context) error {
+	c.subMtx.Lock()
+	defer c.subMtx.Unlock()
+
+	if c.connOwned {
+		defer c.Conn.Close()
+	}
+
+	if c.sub != nil {
+		if err := c.sub.Unsubscribe(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Consumer) applyOptions(opts ...ConsumerOption) error {
+	for _, fn := range opts {
+		if err := fn(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/v2/protocol/nats/sender.go
+++ b/v2/protocol/nats/sender.go
@@ -1,0 +1,89 @@
+package nats
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/nats-io/nats.go"
+)
+
+type Sender struct {
+	Conn         *nats.Conn
+	Subject      string
+	Transformers binding.TransformerFactories
+
+	connOwned bool
+}
+
+// NewSender creates a new protocol.Sender responsible for opening and closing the STAN connection
+func NewSender(url, subject string, natsOpts []nats.Option, opts ...SenderOption) (*Sender, error) {
+	conn, err := nats.Connect(url, natsOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := NewSenderFromConn(conn, subject, opts...)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	s.connOwned = true
+
+	return s, nil
+}
+
+// NewSenderFromConn creates a new protocol.Sender which leaves responsibility for opening and closing the STAN
+// connection to the caller
+func NewSenderFromConn(conn *nats.Conn, subject string, opts ...SenderOption) (*Sender, error) {
+	s := &Sender{
+		Conn:         conn,
+		Subject:      subject,
+		Transformers: make(binding.TransformerFactories, 0),
+	}
+
+	err := s.applyOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (s *Sender) Send(ctx context.Context, in binding.Message) (err error) {
+	defer func() {
+		if err2 := in.Finish(err); err2 != nil {
+			if err == nil {
+				err = err2
+			} else {
+				err = fmt.Errorf("failed to call in.Finish() when error already occurred: %s: %w", err2.Error(), err)
+			}
+		}
+	}()
+
+	writer := new(bytes.Buffer)
+	if err = WriteMsg(ctx, in, writer, s.Transformers); err != nil {
+		return err
+	}
+	return s.Conn.Publish(s.Subject, writer.Bytes())
+}
+
+// Close implements Closer.Close
+// This method only closes the connection if the Sender opened it
+func (s *Sender) Close(_ context.Context) error {
+	if s.connOwned {
+		s.Conn.Close()
+	}
+
+	return nil
+}
+
+func (s *Sender) applyOptions(opts ...SenderOption) error {
+	for _, fn := range opts {
+		if err := fn(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/v2/protocol/nats/subscriber.go
+++ b/v2/protocol/nats/subscriber.go
@@ -1,0 +1,33 @@
+package nats
+
+import (
+	"github.com/nats-io/nats.go"
+)
+
+// The Subscriber interface allows us to configure how the subscription is created
+type Subscriber interface {
+	Subscribe(conn *nats.Conn, subject string, cb nats.MsgHandler) (*nats.Subscription, error)
+}
+
+// RegularSubscriber creates regular subscriptions
+type RegularSubscriber struct {
+}
+
+// Subscribe implements Subscriber.Subscribe
+func (s *RegularSubscriber) Subscribe(conn *nats.Conn, subject string, cb nats.MsgHandler) (*nats.Subscription, error) {
+	return conn.Subscribe(subject, cb)
+}
+
+var _ Subscriber = (*RegularSubscriber)(nil)
+
+// QueueSubscriber creates queue subscriptions
+type QueueSubscriber struct {
+	Queue string
+}
+
+// Subscribe implements Subscriber.Subscribe
+func (s *QueueSubscriber) Subscribe(conn *nats.Conn, subject string, cb nats.MsgHandler) (*nats.Subscription, error) {
+	return conn.QueueSubscribe(subject, s.Queue, cb)
+}
+
+var _ Subscriber = (*QueueSubscriber)(nil)

--- a/v2/test/integration/nats/nats_test.go
+++ b/v2/test/integration/nats/nats_test.go
@@ -1,0 +1,109 @@
+package nats
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	. "github.com/cloudevents/sdk-go/v2/binding/test"
+	"github.com/cloudevents/sdk-go/v2/event"
+	bindings "github.com/cloudevents/sdk-go/v2/protocol"
+	ce_nats "github.com/cloudevents/sdk-go/v2/protocol/nats"
+	"github.com/cloudevents/sdk-go/v2/protocol/test"
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestSendStructuredMessagedToStructures(t *testing.T) {
+	conn := testConn(t)
+	defer conn.Close()
+
+	type args struct {
+		opts []ce_nats.ProtocolOption
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "regular subscriber",
+			args: args{},
+		}, {
+			name: "queue subscriber",
+			args: args{
+				opts: []ce_nats.ProtocolOption{
+					ce_nats.WithConsumerOptions(
+						ce_nats.WithQueueSubscriber(uuid.New().String()),
+					),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup, s, r := testProtocol(t, conn, tt.args.opts...)
+			defer cleanup()
+			EachEvent(t, Events(), func(t *testing.T, eventIn event.Event) {
+				eventIn = ExToStr(t, eventIn)
+
+				in := MustCreateMockStructuredMessage(eventIn)
+
+				test.SendReceive(t, binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured), in, s, r, func(out binding.Message) {
+					eventOut := MustToEvent(t, context.Background(), out)
+					assert.Equal(t, binding.EncodingStructured, out.ReadEncoding())
+					AssertEventEquals(t, eventIn, ExToStr(t, eventOut))
+				})
+			})
+		})
+	}
+}
+
+func testConn(t testing.TB) *nats.Conn {
+	t.Helper()
+	// STAN connections actually connect to NATS, so the env var is named appropriately
+	s := os.Getenv("TEST_NATS_SERVER")
+	if s == "" {
+		s = "nats://localhost:4222"
+	}
+
+	conn, err := nats.Connect(s)
+	if err != nil {
+		t.Skipf("Cannot create STAN client to NATS server [%s]: %v", s, err)
+	}
+
+	return conn
+}
+
+func testProtocol(t testing.TB, natsConn *nats.Conn, opts ...ce_nats.ProtocolOption) (func(), bindings.Sender,
+	bindings.Receiver) {
+	// STAN connections actually connect to NATS, so the env var is named appropriately
+	s := os.Getenv("TEST_NATS_SERVER")
+	if s == "" {
+		s = "nats://localhost:4222"
+	}
+
+	subject := "test-ce-client-" + uuid.New().String()
+
+	// use NewProtocol rather than individual Consumer and Sender since this gives us more coverage
+	p, err := ce_nats.NewProtocol(s, subject, subject, ce_nats.NatsOptions(), opts...)
+	require.NoError(t, err)
+
+	go func() {
+		require.NoError(t, p.OpenInbound(context.TODO()))
+	}()
+
+	return func() {
+		err = p.Close(context.TODO())
+		require.NoError(t, err)
+	}, p.Sender, p.Consumer
+}
+
+func BenchmarkSendReceive(b *testing.B) {
+	conn := testConn(b)
+	defer conn.Close()
+	c, s, r := testProtocol(b, conn)
+	defer c() // Cleanup
+	test.BenchmarkSendReceive(b, s, r)
+}


### PR DESCRIPTION
Addresses:

- #258: You can create Consumers with the `WithQueueSubscriber("queue-name")` option
- #257: With the v2 refactor, you no longer need to wait for subscriptions to be created because calls to `Receive(ctx)` will block until either messages are received or `ctx` is closed
- #316: Follows the same pattern as kafka and STAN, with two constructors for one with an existing connection and one without.

Added integration tests for NATS, and updated the sample cmds
