### PR TITLE
fix: missing coma in the last example

### DIFF
--- a/README_v1.md
+++ b/README_v1.md
@@ -124,7 +124,7 @@ change:
 ```go
 t, err := cloudevents.NewHTTPTransport(
 	cloudevents.WithPort(8181),
-	cloudevents.WithPath("/events/")
+	cloudevents.WithPath("/events/"),
 )
 // or a custom transport: t := &custom.MyTransport{Cool:opts}
 


### PR DESCRIPTION
This is preventing a copy/paste from working out-of-the-box