### PR TITLE
Reworking datacodec package

### DIFF
--- a/v2/event/datacodec/codec.go
+++ b/v2/event/datacodec/codec.go
@@ -9,10 +9,10 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event/datacodec/xml"
 )
 
-// Decoder is the expected function signature for decoding `in` to `out`. What
-// `in` is could be decoder dependent. For example, `in` could be bytes, or a
-// base64 string.
-type Decoder func(ctx context.Context, in, out interface{}) error
+// Decoder is the expected function signature for decoding `in` to `out`.
+// If Event sent the payload as base64, Decoder assumes that `in` is the
+// decoded base64 byte array.
+type Decoder func(ctx context.Context, in []byte, out interface{}) error
 
 // Encoder is the expected function signature for encoding `in` to bytes.
 // Returns an error if the encoder has an issue encoding `in`.
@@ -55,7 +55,7 @@ func AddEncoder(contentType string, fn Encoder) {
 // Decode looks up and invokes the decoder registered for the given content
 // type. An error is returned if no decoder is registered for the given
 // content type.
-func Decode(ctx context.Context, contentType string, in, out interface{}) error {
+func Decode(ctx context.Context, contentType string, in []byte, out interface{}) error {
 	if fn, ok := decoder[contentType]; ok {
 		return fn(ctx, in, out)
 	}

--- a/v2/event/datacodec/codec_observed.go
+++ b/v2/event/datacodec/codec_observed.go
@@ -26,7 +26,7 @@ func SetObservedCodecs() {
 }
 
 // DecodeObserved calls Decode and records the result.
-func DecodeObserved(ctx context.Context, contentType string, in, out interface{}) error {
+func DecodeObserved(ctx context.Context, contentType string, in []byte, out interface{}) error {
 	_, r := observability.NewReporter(ctx, reportDecode)
 	err := Decode(ctx, contentType, in, out)
 	if err != nil {

--- a/v2/event/datacodec/json/data_observed.go
+++ b/v2/event/datacodec/json/data_observed.go
@@ -6,7 +6,7 @@ import (
 )
 
 // DecodeObserved calls Decode and records the results.
-func DecodeObserved(ctx context.Context, in, out interface{}) error {
+func DecodeObserved(ctx context.Context, in []byte, out interface{}) error {
 	_, r := observability.NewReporter(ctx, reportDecode)
 	err := Decode(ctx, in, out)
 	if err != nil {

--- a/v2/event/datacodec/json/data_test.go
+++ b/v2/event/datacodec/json/data_test.go
@@ -30,33 +30,33 @@ func TestCodecDecode(t *testing.T) {
 	now := time.Now()
 
 	testCases := map[string]struct {
-		in      interface{}
+		in      []byte
 		want    interface{}
 		wantErr string
 	}{
 		"empty": {},
 		"out nil": {
-			in:      "not nil",
+			in:      []byte{},
 			wantErr: "out is nil",
 		},
-		"not a []byte": {
-			in: "something that is not a map",
+		"wrong unmarshalling receiver": {
+			in: []byte("\"something that is not a map\""),
 			want: &map[string]string{
 				"an": "error",
 			},
 			wantErr: `[json] found bytes ""something that is not a map"", but failed to unmarshal: json: cannot unmarshal string into Go value of type map[string]string`,
 		},
-		"BadMarshal": {
-			in:      BadMarshal{},
-			want:    &BadMarshal{},
-			wantErr: "[json] failed to marshal in: json: error calling MarshalJSON for type json_test.BadMarshal: BadMashal Error",
+		"wrong string": {
+			in:      []byte("a non json string"),
+			want:    "a non json string",
+			wantErr: `[json] found bytes "a non json string", but failed to unmarshal: invalid character 'a' looking for beginning of value`,
 		},
 		"Bad Quotes": {
-			in: []byte{'\\', '"'},
+			in: []byte("\""),
 			want: &map[string]string{
 				"an": "error",
 			},
-			wantErr: "[json] failed to unquote in: invalid syntax",
+			wantErr: `[json] found bytes """, but failed to unmarshal: unexpected end of JSON input`,
 		},
 		"simple": {
 			in: []byte(`{"a":"apple","b":"banana"}`),
@@ -71,13 +71,6 @@ func TestCodecDecode(t *testing.T) {
 		},
 		"simple array": {
 			in: []byte(`["apple","banana"]`),
-			want: &[]string{
-				"apple",
-				"banana",
-			},
-		},
-		"simple quoted array": {
-			in: []byte(`"[\"apple\",\"banana\"]"`),
 			want: &[]string{
 				"apple",
 				"banana",
@@ -111,14 +104,6 @@ func TestCodecDecode(t *testing.T) {
 				AString: "Hello, World!",
 				ATime:   &now,
 				AnArray: []string{"Anne", "Bob", "Chad"},
-			},
-		},
-		"object in": {
-			in: &DataExample{
-				AnInt: 42,
-			},
-			want: &DataExample{
-				AnInt: 42,
 			},
 		},
 	}

--- a/v2/event/datacodec/text/data.go
+++ b/v2/event/datacodec/text/data.go
@@ -6,21 +6,12 @@ import (
 	"fmt"
 )
 
-func Decode(_ context.Context, in, out interface{}) error {
+func Decode(_ context.Context, in []byte, out interface{}) error {
 	p, _ := out.(*string)
 	if p == nil {
 		return fmt.Errorf("text.Decode out: want *string, got %T", out)
 	}
-	switch s := in.(type) {
-	case string:
-		*p = s
-	case []byte:
-		*p = string(s)
-	case nil: // treat nil like []byte{}
-		*p = ""
-	default:
-		return fmt.Errorf("text.Decode in: want []byte or string, got %T", in)
-	}
+	*p = string(in)
 	return nil
 }
 

--- a/v2/event/datacodec/text/data_observed.go
+++ b/v2/event/datacodec/text/data_observed.go
@@ -6,7 +6,7 @@ import (
 )
 
 // DecodeObserved calls Decode and records the results.
-func DecodeObserved(ctx context.Context, in, out interface{}) error {
+func DecodeObserved(ctx context.Context, in []byte, out interface{}) error {
 	_, r := observability.NewReporter(ctx, reportDecode)
 	err := Decode(ctx, in, out)
 	if err != nil {

--- a/v2/event/datacodec/text/data_observed_test.go
+++ b/v2/event/datacodec/text/data_observed_test.go
@@ -27,7 +27,7 @@ func TestEncodeObserved(t *testing.T) {
 func TestDecodeObserved(t *testing.T) {
 	assert := assert.New(t)
 	var s string
-	assert.NoError(text.DecodeObserved(ctx, "hello", &s))
+	assert.NoError(text.DecodeObserved(ctx, []byte("hello"), &s))
 	assert.Equal("hello", s)
 	assert.NoError(text.DecodeObserved(ctx, []byte("bye"), &s))
 	assert.Equal("bye", s)
@@ -36,8 +36,4 @@ func TestDecodeObserved(t *testing.T) {
 	s = "xxx"
 	assert.NoError(text.DecodeObserved(ctx, nil, &s))
 	assert.Equal("", s)
-
-	assert.EqualError(text.DecodeObserved(ctx, 123, &s), "text.Decode in: want []byte or string, got int")
-	assert.EqualError(text.DecodeObserved(ctx, "", nil), "text.Decode out: want *string, got <nil>")
-	assert.EqualError(text.DecodeObserved(ctx, "", 1), "text.Decode out: want *string, got int")
 }

--- a/v2/event/datacodec/text/data_test.go
+++ b/v2/event/datacodec/text/data_test.go
@@ -30,8 +30,6 @@ func TestEncode(t *testing.T) {
 func TestDecode(t *testing.T) {
 	assert := assert.New(t)
 	var s string
-	assert.NoError(text.Decode(ctx, "hello", &s))
-	assert.Equal("hello", s)
 	assert.NoError(text.Decode(ctx, []byte("bye"), &s))
 	assert.Equal("bye", s)
 	assert.NoError(text.Decode(ctx, []byte{}, &s))
@@ -39,8 +37,4 @@ func TestDecode(t *testing.T) {
 	s = "xxx"
 	assert.NoError(text.Decode(ctx, nil, &s))
 	assert.Equal("", s)
-
-	assert.EqualError(text.Decode(ctx, 123, &s), "text.Decode in: want []byte or string, got int")
-	assert.EqualError(text.Decode(ctx, "", nil), "text.Decode out: want *string, got <nil>")
-	assert.EqualError(text.Decode(ctx, "", 1), "text.Decode out: want *string, got int")
 }

--- a/v2/event/datacodec/xml/data.go
+++ b/v2/event/datacodec/xml/data.go
@@ -2,51 +2,20 @@ package xml
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"strconv"
 )
 
-// Decode takes `in` as []byte, or base64 string, normalizes in to unquoted and
-// base64 decoded []byte if required, and then attempts to use xml.Unmarshal
-// to convert those bytes to `out`. Returns and error if this process fails.
-func Decode(ctx context.Context, in, out interface{}) error {
+// Decode takes `in` as []byte.
+// If Event sent the payload as base64, Decoder assumes that `in` is the
+// decoded base64 byte array.
+func Decode(ctx context.Context, in []byte, out interface{}) error {
 	if in == nil {
 		return nil
 	}
 
-	b, ok := in.([]byte)
-	if !ok {
-		var err error
-		b, err = xml.Marshal(in)
-		if err != nil {
-			return fmt.Errorf("[xml] failed to marshal in: %s", err.Error())
-		}
-	}
-
-	// If the message is encoded as a base64 block as a string, we need to
-	// decode that first before trying to unmarshal the bytes
-	if len(b) > 1 && (b[0] == byte('"') || (b[0] == byte('\\') && b[1] == byte('"'))) {
-		s, err := strconv.Unquote(string(b))
-		if err != nil {
-			return fmt.Errorf("[xml] failed to unquote quoted data: %s", err.Error())
-		}
-		if len(s) > 0 && s[0] == '<' {
-			// looks like xml, use it
-			b = []byte(s)
-		} else if len(s) > 0 {
-			// looks like base64, decode
-			bs, err := base64.StdEncoding.DecodeString(s)
-			if err != nil {
-				return fmt.Errorf("[xml] failed to decode base64 encoded string: %s", err.Error())
-			}
-			b = bs
-		}
-	}
-
-	if err := xml.Unmarshal(b, out); err != nil {
-		return fmt.Errorf("[xml] found bytes, but failed to unmarshal: %s %s", err.Error(), string(b))
+	if err := xml.Unmarshal(in, out); err != nil {
+		return fmt.Errorf("[xml] found bytes, but failed to unmarshal: %s %s", err.Error(), string(in))
 	}
 	return nil
 }

--- a/v2/event/datacodec/xml/data_observed.go
+++ b/v2/event/datacodec/xml/data_observed.go
@@ -6,7 +6,7 @@ import (
 )
 
 // DecodeObserved calls Decode and records the result.
-func DecodeObserved(ctx context.Context, in, out interface{}) error {
+func DecodeObserved(ctx context.Context, in []byte, out interface{}) error {
 	_, r := observability.NewReporter(ctx, reportDecode)
 	err := Decode(ctx, in, out)
 	if err != nil {

--- a/v2/event/datacodec/xml/data_test.go
+++ b/v2/event/datacodec/xml/data_test.go
@@ -37,34 +37,18 @@ func TestCodecDecode(t *testing.T) {
 	now := time.Now()
 
 	testCases := map[string]struct {
-		in      interface{}
+		in      []byte
 		want    interface{}
 		wantErr string
 	}{
 		"empty": {},
-		"not bytes": {
-			in:      &BadDataExample{},
-			wantErr: "[xml] failed to marshal in: unit test",
-		},
-		"structured type encoding, escaped": {
-			in:   []byte(`"<Example><Sequence>7</Sequence><Message>Hello, Structured Encoding v0.2!</Message></Example>"`),
+		"structured type encoding": {
+			in:   []byte(`<Example><Sequence>7</Sequence><Message>Hello, Structured Encoding v0.2!</Message></Example>`),
 			want: &Example{Sequence: 7, Message: "Hello, Structured Encoding v0.2!"},
 		},
 		"structured type encoding, escaped error": {
 			in:      []byte(`"<Example><Sequence>7</Sequence></Message>Hello, Structured Encoding v0.2!</Message></Example>"`),
-			wantErr: "[xml] found bytes, but failed to unmarshal: non-pointer passed to Unmarshal <Example><Sequence>7</Sequence></Message>Hello, Structured Encoding v0.2!</Message></Example>",
-		},
-		"structured type encoding, base64": {
-			in:   []byte(`"PEV4YW1wbGU+PFNlcXVlbmNlPjc8L1NlcXVlbmNlPjxNZXNzYWdlPkhlbGxvLCBTdHJ1Y3R1cmVkIEVuY29kaW5nIHYwLjIhPC9NZXNzYWdlPjwvRXhhbXBsZT4="`),
-			want: &Example{Sequence: 7, Message: "Hello, Structured Encoding v0.2!"},
-		},
-		"structured type encoding, bad quote base64": {
-			in:      []byte(`"PEV4YW1wbGU+PFNlcXVlbmNlPjc8L1NlcXVlbmNlPjxNZXNzYWdlPkhlbGxvLCBTdHJ1Y3R1cmVkIEVuY29kaW5nIHYwLjIhPC9NZXNzYWdlPjwvRXhhbXBsZT4=`),
-			wantErr: "[xml] failed to unquote quoted data: invalid syntax",
-		},
-		"structured type encoding, bad base64": {
-			in:      []byte(`"?EV4YW1wbGU+PFNlcXVlbmNlPjc8L1NlcXVlbmNlPjxNZXNzYWdlPkhlbGxvLCBTdHJ1Y3R1cmVkIEVuY29kaW5nIHYwLjIhPC9NZXNzYWdlPjwvRXhhbXBsZT4="`),
-			wantErr: "[xml] failed to decode base64 encoded string: illegal base64 data at input byte 0",
+			wantErr: `[xml] found bytes, but failed to unmarshal: non-pointer passed to Unmarshal "<Example><Sequence>7</Sequence></Message>Hello, Structured Encoding v0.2!</Message></Example>"`,
 		},
 		"complex filled": {
 			in: func() []byte {
@@ -87,14 +71,6 @@ func TestCodecDecode(t *testing.T) {
 				AString: "Hello, World!",
 				ATime:   &now,
 				AnArray: []string{"Anne", "Bob", "Chad"},
-			},
-		},
-		"object in": {
-			in: &DataExample{
-				AnInt: 42,
-			},
-			want: &DataExample{
-				AnInt: 42,
 			},
 		},
 	}

--- a/v2/event/event.go
+++ b/v2/event/event.go
@@ -11,7 +11,10 @@ import (
 type Event struct {
 	Context     EventContext
 	DataEncoded []byte
-	DataBinary  bool //TODO rename
+	// DataBase64 indicates if the event, when serialized, represents
+	// the data field using the base64 encoding.
+	// In v0.3, this field is superseded by DataContentEncoding
+	DataBase64  bool
 	FieldErrors map[string]error
 }
 
@@ -102,7 +105,7 @@ func (e Event) String() string {
 	b.WriteString(e.Context.String())
 
 	if e.DataEncoded != nil {
-		if e.DataBinary {
+		if e.DataBase64 {
 			b.WriteString("Data (binary),\n  ")
 		} else {
 			b.WriteString("Data,\n  ")
@@ -129,7 +132,7 @@ func (e Event) Clone() Event {
 	out := Event{}
 	out.Context = e.Context.Clone()
 	out.DataEncoded = cloneBytes(e.DataEncoded)
-	out.DataBinary = e.DataBinary
+	out.DataBase64 = e.DataBase64
 	out.FieldErrors = e.cloneFieldErrors()
 	return out
 }

--- a/v2/event/event.go
+++ b/v2/event/event.go
@@ -11,7 +11,7 @@ import (
 type Event struct {
 	Context     EventContext
 	DataEncoded []byte
-	DataBinary  bool
+	DataBinary  bool //TODO rename
 	FieldErrors map[string]error
 }
 

--- a/v2/event/event_data.go
+++ b/v2/event/event_data.go
@@ -24,14 +24,14 @@ func (e *Event) SetData(contentType string, obj interface{}) error {
 	switch obj := obj.(type) {
 	case []byte:
 		e.DataEncoded = obj
-		e.DataBinary = true
+		e.DataBase64 = true
 	default:
 		data, err := datacodec.Encode(context.Background(), e.DataMediaType(), obj)
 		if err != nil {
 			return err
 		}
 		e.DataEncoded = data
-		e.DataBinary = false
+		e.DataBase64 = false
 	}
 
 	return nil
@@ -47,14 +47,14 @@ func (e *Event) legacySetData(obj interface{}) error {
 		buf := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
 		base64.StdEncoding.Encode(buf, data)
 		e.DataEncoded = buf
-		e.DataBinary = false
+		e.DataBase64 = false
 	} else {
 		data, err := datacodec.Encode(context.Background(), e.DataMediaType(), obj)
 		if err != nil {
 			return err
 		}
 		e.DataEncoded = data
-		e.DataBinary = false
+		e.DataBase64 = false
 	}
 	return nil
 }

--- a/v2/event/event_data.go
+++ b/v2/event/event_data.go
@@ -9,9 +9,10 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event/datacodec"
 )
 
-// Data is special. Break it out into it's own file.
-
-// SetData implements EventWriter.SetData
+// SetData encodes the given payload with the given content type.
+// If the provided payload is a byte array, when marshalled to json it will be encoded as base64.
+// If the provided payload is different from byte array, datacodec.Encode is invoked to attempt a
+// marshalling to byte array.
 func (e *Event) SetData(contentType string, obj interface{}) error {
 	e.SetDataContentType(contentType)
 

--- a/v2/event/event_data_test.go
+++ b/v2/event/event_data_test.go
@@ -2,15 +2,15 @@ package event_test
 
 import (
 	"context"
-	"encoding/base64"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/event/datacodec"
 	"github.com/cloudevents/sdk-go/v2/types"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 )
 
 type DataTest struct {
@@ -161,7 +161,7 @@ func TestEventSetData_binary_v1(t *testing.T) {
 
 	require.NoError(t, e.SetData(event.ApplicationJSON, encodedPayload))
 
-	require.True(t, e.DataBinary)
+	require.True(t, e.DataBase64)
 	require.Equal(t, encodedPayload, e.Data())
 
 	actual := map[string]interface{}{}
@@ -307,10 +307,4 @@ func mustEncodeWithDataCodec(t *testing.T, ct string, in interface{}) []byte {
 	data, err := datacodec.Encode(context.TODO(), ct, in)
 	require.NoError(t, err)
 	return data
-}
-
-func encodeBase64(in []byte) []byte {
-	data := make([]byte, base64.StdEncoding.EncodedLen(len(in)))
-	base64.StdEncoding.Encode(data, in)
-	return in
 }

--- a/v2/event/event_interface.go
+++ b/v2/event/event_interface.go
@@ -50,12 +50,12 @@ type EventReader interface {
 
 	// Data Attribute
 
-	// Data returns the raw data buffer, it might be encoded depending on data
-	// content type.
+	// Data returns the raw data buffer
+	// If the event was encoded with base64 encoding, Data returns the already decoded
+	// byte array
 	Data() []byte
 
 	// DataAs attempts to populate the provided data object with the event payload.
-	// data should be a pointer type.
 	DataAs(interface{}) error
 }
 
@@ -90,5 +90,8 @@ type EventWriter interface {
 	SetExtension(string, interface{})
 
 	// SetData encodes the given payload with the given content type.
+	// If the provided payload is a byte array, when marshalled to json it will be encoded as base64.
+	// If the provided payload is different from byte array, datacodec.Encode is invoked to attempt a
+	// marshalling to byte array.
 	SetData(string, interface{}) error
 }

--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -2,11 +2,9 @@ package event
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	errors2 "github.com/pkg/errors"
@@ -99,10 +97,10 @@ func JsonEncode(e Event) ([]byte, error) {
 // JsonEncodeLegacy
 func JsonEncodeLegacy(e Event) ([]byte, error) {
 	isBase64 := e.Context.DeprecatedGetDataContentEncoding() == Base64
-	return jsonEncode(e.Context, e.Data(), isBase64)
+	return jsonEncode(e.Context, e.DataEncoded, isBase64)
 }
 
-func jsonEncode(ctx EventContextReader, data []byte, isBase64 bool) ([]byte, error) {
+func jsonEncode(ctx EventContextReader, data []byte, shouldEncodeToBase64 bool) ([]byte, error) {
 	var b map[string]json.RawMessage
 	var err error
 
@@ -112,34 +110,32 @@ func jsonEncode(ctx EventContextReader, data []byte, isBase64 bool) ([]byte, err
 	}
 
 	if data != nil {
-		// data is passed in as an encoded []byte. That slice might be any
-		// number of things but for json encoding of the envelope all we care
-		// is if the payload is either a string or a json object. If it is a
-		// json object, it can be inserted into the body without modification.
-		// Otherwise we need to quote it if not already quoted.
+		// data here is a serialized version of whatever payload.
+		// If we need to write the payload as base64, shouldEncodeToBase64 is true.
 		mediaType, err := ctx.GetDataMediaType()
 		if err != nil {
 			return nil, err
 		}
 		isJson := mediaType == "" || mediaType == ApplicationJSON || mediaType == TextJSON
-		if isJson && !isBase64 {
+		// If isJson and no encoding to base64, we don't need to perform additional steps
+		if isJson && !shouldEncodeToBase64 {
 			b["data"] = data
 		} else {
-			var dataKey string
-			if ctx.GetSpecVersion() == CloudEventsVersionV1 {
+			var dataKey = "data"
+			if ctx.GetSpecVersion() == CloudEventsVersionV1 && shouldEncodeToBase64 {
 				dataKey = "data_base64"
-				buf := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
-				base64.StdEncoding.Encode(buf, data)
-				data = buf
-			} else {
-				dataKey = "data"
 			}
-			if data[0] != byte('"') {
-				b[dataKey] = []byte(strconv.QuoteToASCII(string(data)))
+			var dataPointer []byte
+			if shouldEncodeToBase64 {
+				dataPointer, err = json.Marshal(data)
 			} else {
-				// already quoted
-				b[dataKey] = data
+				dataPointer, err = json.Marshal(string(data))
 			}
+			if err != nil {
+				return nil, err
+			}
+
+			b[dataKey] = dataPointer
 		}
 	}
 
@@ -172,6 +168,19 @@ func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error
 	var data []byte
 	if d, ok := raw["data"]; ok {
 		data = d
+
+		// Decode the Base64 if we have a base64 payload
+		if ec.DeprecatedGetDataContentEncoding() == Base64 {
+			var tmp []byte
+			if err := json.Unmarshal(d, &tmp); err != nil {
+				return err
+			}
+			e.DataBinary = true
+			e.DataEncoded = tmp
+		} else {
+			e.DataEncoded = data
+			e.DataBinary = false
+		}
 	}
 	delete(raw, "data")
 
@@ -191,7 +200,6 @@ func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error
 	}
 
 	e.Context = &ec
-	e.DataEncoded = data
 
 	return nil
 }
@@ -226,8 +234,20 @@ func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error 
 			return err
 		}
 		dataBase64 = tmp
+
 	}
 	delete(raw, "data_base64")
+
+	if data != nil && dataBase64 != nil {
+		return errors.New("parsing error: JSON decoder found both 'data', and 'data_base64' in JSON payload")
+	}
+	if data != nil {
+		e.DataEncoded = data
+		e.DataBinary = false
+	} else if dataBase64 != nil {
+		e.DataEncoded = dataBase64
+		e.DataBinary = true
+	}
 
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
@@ -245,16 +265,6 @@ func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error 
 	}
 
 	e.Context = &ec
-	if data != nil && dataBase64 != nil {
-		return errors.New("parsing error: JSON decoder found both 'data', and 'data_base64' in JSON payload")
-	}
-	if data != nil {
-		e.DataEncoded = data
-		e.DataBinary = false
-	} else if dataBase64 != nil {
-		e.DataEncoded = dataBase64
-		e.DataBinary = true
-	}
 
 	return nil
 }

--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -91,7 +91,7 @@ func versionFromRawMessage(raw map[string]json.RawMessage) string {
 
 // JsonEncode
 func JsonEncode(e Event) ([]byte, error) {
-	return jsonEncode(e.Context, e.DataEncoded, e.DataBinary)
+	return jsonEncode(e.Context, e.DataEncoded, e.DataBase64)
 }
 
 // JsonEncodeLegacy
@@ -175,11 +175,11 @@ func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error
 			if err := json.Unmarshal(d, &tmp); err != nil {
 				return err
 			}
-			e.DataBinary = true
+			e.DataBase64 = true
 			e.DataEncoded = tmp
 		} else {
 			e.DataEncoded = data
-			e.DataBinary = false
+			e.DataBase64 = false
 		}
 	}
 	delete(raw, "data")
@@ -243,10 +243,10 @@ func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error 
 	}
 	if data != nil {
 		e.DataEncoded = data
-		e.DataBinary = false
+		e.DataBase64 = false
 	} else if dataBase64 != nil {
 		e.DataEncoded = dataBase64
-		e.DataBinary = true
+		e.DataBase64 = true
 	}
 
 	if len(raw) > 0 {

--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -178,6 +178,18 @@ func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error
 			e.DataBase64 = true
 			e.DataEncoded = tmp
 		} else {
+			if ec.DataContentType != nil {
+				ct := *ec.DataContentType
+				if ct != ApplicationJSON && ct != TextJSON {
+					var dataStr string
+					err := json.Unmarshal(d, dataStr)
+					if err != nil {
+						return err
+					}
+
+					data = []byte(dataStr)
+				}
+			}
 			e.DataEncoded = data
 			e.DataBase64 = false
 		}
@@ -224,6 +236,18 @@ func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error 
 	var data []byte
 	if d, ok := raw["data"]; ok {
 		data = d
+		if ec.DataContentType != nil {
+			ct := *ec.DataContentType
+			if ct != ApplicationJSON && ct != TextJSON {
+				var dataStr string
+				err := json.Unmarshal(d, &dataStr)
+				if err != nil {
+					return err
+				}
+
+				data = []byte(dataStr)
+			}
+		}
 	}
 	delete(raw, "data")
 

--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -182,7 +182,7 @@ func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error
 				ct := *ec.DataContentType
 				if ct != ApplicationJSON && ct != TextJSON {
 					var dataStr string
-					err := json.Unmarshal(d, dataStr)
+					err := json.Unmarshal(d, &dataStr)
 					if err != nil {
 						return err
 					}

--- a/v2/event/event_marshal_test.go
+++ b/v2/event/event_marshal_test.go
@@ -645,7 +645,7 @@ func TestUnmarshal(t *testing.T) {
 					DataContentType: event.StringOfApplicationJSON(),
 				}.AsV1(),
 				DataEncoded: mustJsonMarshal(t, map[string]interface{}{"hello": "world"}),
-				DataBinary:  true,
+				DataBase64:  true,
 			},
 		},
 		"base64 xml encoded data v1.0": {
@@ -669,7 +669,7 @@ func TestUnmarshal(t *testing.T) {
 					DataContentType: event.StringOfApplicationJSON(),
 				}.AsV1(),
 				DataEncoded: mustEncodeWithDataCodec(t, event.ApplicationXML, &XMLDataExample{AnInt: 10}),
-				DataBinary:  true,
+				DataBase64:  true,
 			},
 		},
 		"xml data v1.0": {
@@ -693,7 +693,7 @@ func TestUnmarshal(t *testing.T) {
 						Time:            &now,
 						DataContentType: event.StringOfApplicationJSON(),
 					}.AsV1(),
-					DataBinary: false,
+					DataBase64: false,
 				}
 
 				// We need this stuff hack because json module enforces escaping the angular brackets

--- a/v2/event/event_marshal_test.go
+++ b/v2/event/event_marshal_test.go
@@ -675,7 +675,7 @@ func TestUnmarshal(t *testing.T) {
 		"xml data v1.0": {
 			body: mustJsonMarshal(t, map[string]interface{}{
 				"specversion":     "1.0",
-				"datacontenttype": "application/json",
+				"datacontenttype": event.ApplicationXML,
 				"data":            string(mustEncodeWithDataCodec(t, event.ApplicationXML, XMLDataExample{AnInt: 5, AString: "aaa"})),
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
@@ -683,26 +683,18 @@ func TestUnmarshal(t *testing.T) {
 				"dataschema":      "http://example.com/schema",
 				"source":          "http://example.com/source",
 			}),
-			want: func() *event.Event {
-				ev := &event.Event{
-					Context: event.EventContextV1{
-						Type:            "com.example.test",
-						Source:          *sourceV1,
-						DataSchema:      schemaV1,
-						ID:              "ABC-123",
-						Time:            &now,
-						DataContentType: event.StringOfApplicationJSON(),
-					}.AsV1(),
-					DataBase64: false,
-				}
-
-				// We need this stuff hack because json module enforces escaping the angular brackets
-				// and doesn't give any way to disable this setting
-				b := mustEncodeWithDataCodec(t, event.ApplicationXML, &XMLDataExample{AnInt: 5, AString: "aaa"})
-				ev.DataEncoded = mustJsonMarshal(t, string(b))
-
-				return ev
-			}(),
+			want: &event.Event{
+				Context: event.EventContextV1{
+					Type:            "com.example.test",
+					Source:          *sourceV1,
+					DataSchema:      schemaV1,
+					ID:              "ABC-123",
+					Time:            &now,
+					DataContentType: event.StringOfApplicationXML(),
+				}.AsV1(),
+				DataBase64:  false,
+				DataEncoded: mustEncodeWithDataCodec(t, event.ApplicationXML, &XMLDataExample{AnInt: 5, AString: "aaa"}),
+			},
 		},
 		"nil data v1.0": {
 			body: mustJsonMarshal(t, map[string]interface{}{

--- a/v2/event/event_test.go
+++ b/v2/event/event_test.go
@@ -564,7 +564,7 @@ func TestEvent_Clone(t *testing.T) {
 	require.NotSame(t, original.Data(), clone.Data())
 
 	require.Equal(t, original.DataEncoded, clone.DataEncoded)
-	require.Equal(t, original.DataBinary, clone.DataBinary)
+	require.Equal(t, original.DataBase64, clone.DataBase64)
 
 	require.Equal(t, original.FieldErrors, clone.FieldErrors)
 	require.NotSame(t, original.FieldErrors, clone.FieldErrors)

--- a/v2/test/integration/http/loopback_v1_test.go
+++ b/v2/test/integration/http/loopback_v1_test.go
@@ -188,7 +188,7 @@ func TestClientLoopback_structured_base64_v03tov1(t *testing.T) {
 					Source: *cloudevents.ParseURIRef("/unit/test/client"),
 				}.AsV1(),
 				DataEncoded: bytes(map[string]string{"unittest": "response"}),
-				DataBinary:  true,
+				DataBase64:  true,
 			},
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV1{
@@ -243,7 +243,7 @@ func TestClientLoopback_structured_base64_v1tov1(t *testing.T) {
 					Source: *cloudevents.ParseURIRef("/unit/test/client"),
 				}.AsV1(),
 				DataEncoded: toBytes(map[string]interface{}{"hello": "unittest"}),
-				DataBinary:  true,
+				DataBase64:  true,
 			},
 			resp: &cloudevents.Event{
 				Context: cloudevents.EventContextV1{
@@ -252,7 +252,7 @@ func TestClientLoopback_structured_base64_v1tov1(t *testing.T) {
 					Source: *cloudevents.ParseURIRef("/unit/test/client"),
 				}.AsV1(),
 				DataEncoded: toBytes(map[string]interface{}{"hello": "unittest"}),
-				DataBinary:  true,
+				DataBase64:  true,
 			},
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV1{

--- a/v2/test/integration/http/validation.go
+++ b/v2/test/integration/http/validation.go
@@ -34,7 +34,7 @@ func toBytes(body map[string]interface{}) []byte {
 }
 
 func assertEventEqualityExact(t *testing.T, ctx string, expected, actual *cloudevents.Event) {
-	if diff := cmp.Diff(expected, actual, cmpopts.IgnoreFields(cloudevents.Event{}, "DataEncoded", "DataBinary")); diff != "" {
+	if diff := cmp.Diff(expected, actual, cmpopts.IgnoreFields(cloudevents.Event{}, "DataEncoded", "DataBase64")); diff != "" {
 		t.Errorf("Unexpected difference in %s (-want, +got): %v", ctx, diff)
 	}
 	if expected == nil || actual == nil {
@@ -46,7 +46,7 @@ func assertEventEqualityExact(t *testing.T, ctx string, expected, actual *cloude
 }
 
 func assertEventEquality(t *testing.T, ctx string, expected, actual *cloudevents.Event) {
-	if diff := cmp.Diff(expected, actual, cmpopts.IgnoreFields(cloudevents.Event{}, "DataEncoded", "DataBinary")); diff != "" {
+	if diff := cmp.Diff(expected, actual, cmpopts.IgnoreFields(cloudevents.Event{}, "DataEncoded", "DataBase64")); diff != "" {
 		t.Errorf("Unexpected difference in %s (-want, +got): %v", ctx, diff)
 	}
 	if expected == nil || actual == nil {


### PR DESCRIPTION
With this PR `datacodec` package doesn't handle the base64 encoding, this is left to the event marshaller/unmarshaller which injects into the `Data` field directly the decoded byte array.

Also improves documentation of `SetData` and `Data` explaining the various behaviours.

