### PR TITLE
Fix Package Documentation and Enable Documentation Check in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,10 @@ jobs:
       - run:
           name: "Run go vet"
           command: pushd v2; go vet ./...; popd
+      - run: go get honnef.co/go/tools/cmd/staticcheck
+      - run:
+          name: "Run staticcheck"
+          command: pushd v2; staticcheck --checks=ST1000 ./...; popd
       - run:
           name: Run unit tests
           command: |

--- a/v2/alias.go
+++ b/v2/alias.go
@@ -1,3 +1,4 @@
+// Package v2 reexports a subset of the SDK v2 API.
 package v2
 
 // Package cloudevents alias' common functions and types to improve discoverability and reduce

--- a/v2/binding/buffering/doc.go
+++ b/v2/binding/buffering/doc.go
@@ -1,0 +1,2 @@
+// Package buffering provides APIs for buffered messages.
+package buffering

--- a/v2/binding/doc.go
+++ b/v2/binding/doc.go
@@ -1,5 +1,3 @@
-package binding
-
 /*
 
 Package binding defines interfaces for protocol bindings.
@@ -35,7 +33,7 @@ The encoding process can be customized in order to mutate the final result with 
 A bunch of these are provided directly by the binding/transformer module.
 
 Usually binding.Message implementations can be encoded only one time, because the encoding process drain the message itself.
-In order to consume a message several times, the binding/buffering module provides several APIs to buffer the Message.
+In order to consume a message several times, the binding/buffering package provides several APIs to buffer the Message.
 
 A message can be converted to an event.Event using binding.ToEvent() method.
 An event.Event can be used as Message casting it to binding.EventMessage.
@@ -62,3 +60,4 @@ Transport
 A binding implementation providing Sender and Receiver implementations can be used as a Transport through the BindingTransport adapter.
 
 */
+package binding

--- a/v2/binding/format/doc.go
+++ b/v2/binding/format/doc.go
@@ -1,8 +1,7 @@
-package format
-
 /*
 Package format formats structured events.
 
 The "application/cloudevents+json" format is built-in and always
 available. Other formats may be added.
 */
+package format

--- a/v2/binding/spec/doc.go
+++ b/v2/binding/spec/doc.go
@@ -1,5 +1,3 @@
-package spec
-
 /*
 Package spec provides spec-version metadata.
 
@@ -7,3 +5,4 @@ For use by code that maps events using (prefixed) attribute name strings.
 Supports handling multiple spec versions uniformly.
 
 */
+package spec

--- a/v2/binding/transformer/doc.go
+++ b/v2/binding/transformer/doc.go
@@ -1,0 +1,2 @@
+// Package transformer provides methods for creating event message transformers.
+package transformer

--- a/v2/client/test/test.go
+++ b/v2/client/test/test.go
@@ -1,3 +1,4 @@
+// Package test provides Client test helpers.
 package test
 
 import (

--- a/v2/event/datacodec/text/data.go
+++ b/v2/event/datacodec/text/data.go
@@ -1,10 +1,11 @@
-// Text codec converts []byte or string to string and vice-versa.
 package text
 
 import (
 	"context"
 	"fmt"
 )
+
+// Text codec converts []byte or string to string and vice-versa.
 
 func Decode(_ context.Context, in []byte, out interface{}) error {
 	p, _ := out.(*string)

--- a/v2/event/doc.go
+++ b/v2/event/doc.go
@@ -1,4 +1,4 @@
 /*
-Package cloudevents provides primitives to work with CloudEvents specification: https://github.com/cloudevents/spec.
+Package event provides primitives to work with CloudEvents specification: https://github.com/cloudevents/spec.
 */
 package event

--- a/v2/extensions/doc.go
+++ b/v2/extensions/doc.go
@@ -1,0 +1,2 @@
+// Package extensions provides implementations of common event extensions.
+package extensions

--- a/v2/protocol/amqp/doc.go
+++ b/v2/protocol/amqp/doc.go
@@ -1,4 +1,4 @@
 /*
-Module amqp implements an AMQP binding using pack.ag/amqp module
+Package amqp implements an AMQP binding using pack.ag/amqp module
 */
 package amqp

--- a/v2/protocol/doc.go
+++ b/v2/protocol/doc.go
@@ -1,7 +1,6 @@
 /*
-
-Package transport defines interfaces to decouple the client package
-from transport implementations.
+Package protocol defines interfaces to decouple the client package
+from protocol implementations.
 
 Most event sender and receiver applications should not use this
 package, they should use the client package. This package is for
@@ -19,5 +18,4 @@ Available protocols:
 * Google PubSub
 
 */
-
 package protocol

--- a/v2/protocol/gochan/doc.go
+++ b/v2/protocol/gochan/doc.go
@@ -1,4 +1,4 @@
 /*
-Package channel implements the CloudEvent transport implementation using go chan.
+Package gochan implements the CloudEvent transport implementation using go chan.
 */
 package gochan

--- a/v2/protocol/http/doc.go
+++ b/v2/protocol/http/doc.go
@@ -1,5 +1,4 @@
-package http
-
 /*
-Module http implements an HTTP binding using net/http module
+Package http implements an HTTP binding using net/http module
 */
+package http

--- a/v2/protocol/kafka_sarama/doc.go
+++ b/v2/protocol/kafka_sarama/doc.go
@@ -1,5 +1,4 @@
-package kafka_sarama
-
 /*
-Module kafka_sarama implements a Kafka binding using github.com/Shopify/sarama module
+Package kafka_sarama implements a Kafka binding using github.com/Shopify/sarama module
 */
+package kafka_sarama

--- a/v2/protocol/pubsub/context/context.go
+++ b/v2/protocol/pubsub/context/context.go
@@ -1,3 +1,4 @@
+// Package context provides the pubsub ProtocolContext.
 package context
 
 import (

--- a/v2/protocol/pubsub/doc.go
+++ b/v2/protocol/pubsub/doc.go
@@ -1,5 +1,4 @@
-package pubsub
-
 /*
-Module pubsub implements a Pub/Sub binding using google.cloud.com/go/pubsub module
+Package pubsub implements a Pub/Sub binding using google.cloud.com/go/pubsub module
 */
+package pubsub

--- a/v2/protocol/pubsub/internal/connection.go
+++ b/v2/protocol/pubsub/internal/connection.go
@@ -1,3 +1,4 @@
+// Package internal provides the internal pubsub Connection type.
 package internal
 
 import (

--- a/v2/test/benchmark/e2e/doc.go
+++ b/v2/test/benchmark/e2e/doc.go
@@ -1,0 +1,2 @@
+// Package e2e holds end-to-end eventing benchmarks.
+package e2e

--- a/v2/test/integration/http/doc.go
+++ b/v2/test/integration/http/doc.go
@@ -1,0 +1,2 @@
+// Package http contains HTTP integration test helpers.
+package http


### PR DESCRIPTION
Many packages were not correctly formatting package documentation either because the documentation did not precede the package statement as required or the first line did not correctly reference the package name. A few packages were missing documentation. To prevent regressions this PR enables staticcheck ST1000 to check that every v2 package has valid package docs.