### PR TITLE
Kafka Key Mapping implementation

### DIFF
--- a/v2/protocol/kafka_sarama/write_producer_message.go
+++ b/v2/protocol/kafka_sarama/write_producer_message.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Shopify/sarama"
 
-	ce "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/binding/format"
 	"github.com/cloudevents/sdk-go/v2/binding/spec"
@@ -20,57 +19,40 @@ const (
 
 // WriteProducerMessage fills the provided producerMessage with the message m.
 // Using context you can tweak the encoding processing (more details on binding.Write documentation).
-func WriteProducerMessage(ctx context.Context, m binding.Message, producerMessage *sarama.ProducerMessage, transformers ...binding.Transformer) error {
-	enc := (*kafkaProducerMessageWriter)(producerMessage)
 // By default, this function implements the key mapping, trying to set the key of the message based on partitionKey extension.
 // If you want to disable the Key Mapping, decorate the context with `WithSkipKeyMapping`
-func WriteProducerMessage(ctx context.Context, m binding.Message, producerMessage *sarama.ProducerMessage, transformers ...binding.TransformerFactory) error {
+func WriteProducerMessage(ctx context.Context, m binding.Message, producerMessage *sarama.ProducerMessage, transformers ...binding.Transformer) error {
 	writer := (*kafkaProducerMessageWriter)(producerMessage)
 
 	skipKey := binding.GetOrDefaultFromCtx(ctx, skipKeyKey{}, false).(bool)
 
-	// If skipKey = true, then we can just use the default write algorithm
-	if skipKey {
-		_, err := binding.Write(
-			ctx,
-			m,
-			writer,
-			writer,
-			transformers...,
-		)
-		return err
+	var key string
+
+	// If skipKey = false, then we add a transformer that extracts the key
+	if !skipKey {
+		transformers = append(transformers, binding.TransformerFunc(func(r binding.MessageMetadataReader, w binding.MessageMetadataWriter) error {
+			ext := r.GetExtension(partitionKey)
+			if !types.IsZero(ext) {
+				extStr, err := types.Format(ext)
+				if err != nil {
+					return err
+				}
+				key = extStr
+			}
+			return nil
+		}))
 	}
 
-	// if skipKey = false, we can't accept structured encoding. We can
-	encoding := m.ReadEncoding()
-	var err error
-	// Try direct encoding only if the event is a binary event
-	if encoding == binding.EncodingBinary {
-		// Specialized writer that writes the key
-		writer := (*kafkaProducerMessageWithKeyWriter)(producerMessage)
-		encoding, err = binding.DirectWrite(ctx, m, nil, writer, transformers...)
-		if encoding != binding.EncodingUnknown {
-			// Message directly encoded binary -> binary, nothing else to do here
-			return err
-		}
+	_, err := binding.Write(
+		ctx,
+		m,
+		writer,
+		writer,
+		transformers...,
+	)
+	if key != "" {
+		producerMessage.Key = sarama.StringEncoder(key)
 	}
-
-	var e *ce.Event
-	e, err = binding.ToEvent(ctx, m, transformers...)
-	if err != nil {
-		return err
-	}
-
-	// Let's check if event contains a partitionKey to write
-	if val, ok := e.Extensions()[partitionKey]; ok {
-		s, err := types.Format(val)
-		if err != nil {
-			return err
-		}
-		producerMessage.Key = sarama.StringEncoder(s)
-	}
-
-	_, err = binding.WriteEvent(ctx, e, writer, writer)
 	return err
 }
 
@@ -164,6 +146,12 @@ func (b *kafkaProducerMessageWriter) removeHeader(name string) {
 			return
 		}
 	}
+}
+
+type skipKeyKey struct{}
+
+func WithSkipKeyMapping(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipKeyKey{}, true)
 }
 
 var _ binding.StructuredWriter = (*kafkaProducerMessageWriter)(nil) // Test it conforms to the interface

--- a/v2/protocol/kafka_sarama/write_producer_message_test.go
+++ b/v2/protocol/kafka_sarama/write_producer_message_test.go
@@ -13,40 +13,128 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event"
 )
 
+const testKey = "hello-key"
+
 func TestEncodeKafkaProducerMessage(t *testing.T) {
 	tests := []struct {
 		name             string
 		context          context.Context
+		addPartitionKey  bool
 		messageFactory   func(e event.Event) binding.Message
 		expectedEncoding binding.Encoding
+		expectedKey      bool
 	}{
 		{
-			name:             "Structured to Structured",
-			context:          context.TODO(),
+			name:             "Structured to Structured - skip key mapping",
+			context:          WithSkipKeyMapping(context.TODO()),
 			messageFactory:   test.MustCreateMockStructuredMessage,
 			expectedEncoding: binding.EncodingStructured,
 		},
 		{
-			name:             "Binary to Binary",
+			name:             "Binary to Binary - skip key mapping",
+			context:          WithSkipKeyMapping(context.TODO()),
+			messageFactory:   test.MustCreateMockBinaryMessage,
+			expectedEncoding: binding.EncodingBinary,
+		},
+		{
+			name:             "Event to Structured - skip key mapping",
+			context:          WithSkipKeyMapping(binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured)),
+			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
+			expectedEncoding: binding.EncodingStructured,
+		},
+		{
+			name:             "Event to Binary - skip key mapping",
+			context:          WithSkipKeyMapping(binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary)),
+			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
+			expectedEncoding: binding.EncodingBinary,
+		},
+		{
+			name:             "Structured to Structured - with key & skip key mapping",
+			context:          WithSkipKeyMapping(context.TODO()),
+			addPartitionKey:  true,
+			messageFactory:   test.MustCreateMockStructuredMessage,
+			expectedEncoding: binding.EncodingStructured,
+		},
+		{
+			name:             "Binary to Binary - with key & skip key mapping",
+			context:          WithSkipKeyMapping(context.TODO()),
+			addPartitionKey:  true,
+			messageFactory:   test.MustCreateMockBinaryMessage,
+			expectedEncoding: binding.EncodingBinary,
+		},
+		{
+			name:             "Event to Structured - with key & skip key mapping",
+			context:          WithSkipKeyMapping(binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured)),
+			addPartitionKey:  true,
+			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
+			expectedEncoding: binding.EncodingStructured,
+		},
+		{
+			name:             "Event to Binary - with key & skip key mapping",
+			context:          WithSkipKeyMapping(binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary)),
+			addPartitionKey:  true,
+			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
+			expectedEncoding: binding.EncodingBinary,
+		},
+		{
+			name:             "Structured to Structured - no key",
+			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured),
+			messageFactory:   test.MustCreateMockStructuredMessage,
+			expectedEncoding: binding.EncodingStructured,
+		},
+		{
+			name:             "Binary to Binary - no key",
 			context:          context.TODO(),
 			messageFactory:   test.MustCreateMockBinaryMessage,
 			expectedEncoding: binding.EncodingBinary,
 		},
 		{
-			name:             "Event to Structured",
+			name:             "Event to Structured - no key",
 			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured),
 			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
 			expectedEncoding: binding.EncodingStructured,
 		},
 		{
-			name:             "Event to Binary",
+			name:             "Event to Binary - no key",
 			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary),
 			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
 			expectedEncoding: binding.EncodingBinary,
 		},
+		{
+			name:             "Structured to Structured - with key",
+			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured),
+			addPartitionKey:  true,
+			messageFactory:   test.MustCreateMockStructuredMessage,
+			expectedEncoding: binding.EncodingStructured,
+			expectedKey:      true,
+		},
+		{
+			name:             "Binary to Binary - with key",
+			context:          context.TODO(),
+			addPartitionKey:  true,
+			messageFactory:   test.MustCreateMockBinaryMessage,
+			expectedEncoding: binding.EncodingBinary,
+			expectedKey:      true,
+		},
+		{
+			name:             "Event to Structured - with key",
+			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingStructured),
+			addPartitionKey:  true,
+			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
+			expectedEncoding: binding.EncodingStructured,
+			expectedKey:      true,
+		},
+		{
+			name:             "Event to Binary - with key",
+			context:          binding.WithPreferredEventEncoding(context.TODO(), binding.EncodingBinary),
+			addPartitionKey:  true,
+			messageFactory:   func(e event.Event) binding.Message { return (*binding.EventMessage)(&e) },
+			expectedEncoding: binding.EncodingBinary,
+			expectedKey:      true,
+		},
 	}
-	for _, tt := range tests {
-		test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+	test.EachEvent(t, test.Events(), func(t *testing.T, e event.Event) {
+		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				ctx := tt.context
 
@@ -54,7 +142,10 @@ func TestEncodeKafkaProducerMessage(t *testing.T) {
 					Topic: "aaa",
 				}
 
-				eventIn = test.ExToStr(t, eventIn)
+				eventIn := test.ExToStr(t, e.Clone())
+				if tt.addPartitionKey {
+					eventIn.SetExtension(partitionKey, testKey)
+				}
 				messageIn := tt.messageFactory(eventIn)
 
 				err := WriteProducerMessage(ctx, messageIn, kafkaMessage)
@@ -78,7 +169,17 @@ func TestEncodeKafkaProducerMessage(t *testing.T) {
 				eventOut, err := binding.ToEvent(context.TODO(), messageOut)
 				require.NoError(t, err)
 				test.AssertEventEquals(t, eventIn, *eventOut)
+
+				if !tt.expectedKey {
+					require.Nil(t, kafkaMessage.Key)
+				} else {
+					require.NotNil(t, kafkaMessage.Key)
+					val, err := kafkaMessage.Key.Encode()
+					require.NoError(t, err)
+					require.Equal(t, testKey, string(val))
+				}
 			})
-		})
-	}
+		}
+	})
+
 }


### PR DESCRIPTION
Also splitted a part of `binding.Write` to `binding.WriteEvent`

I have implemented the mapping from `partitionkey` to Kafka Message key, but I didn't **intentionally** added any custom key mapper function, because I think this adds unnecessary complexity to the method `WriteProducerMessage`.
If the user wants a custom mapping, he can do it by itself by taking the message, converting to event, doing whatever he wants to calculate the key from the event, and then pass the event message to the `WriteProducerMessage`. Maybe there is room for the custom key mapper in the kafka sender?

Let's keep this on hold until https://github.com/cloudevents/spec/pull/599 is merged.

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>