### PR TITLE
Fix Respond lifecycle in HTTP protocol

### DIFF
--- a/v2/client/test/mock_client.go
+++ b/v2/client/test/mock_client.go
@@ -125,6 +125,7 @@ func NewMockResponderClient(t *testing.T, chanSize int, opts ...client.Option) (
 			if m.Message != nil {
 				e, err := binding.ToEvent(context.TODO(), m.Message)
 				require.NoError(t, err)
+				require.NoError(t, m.Message.Finish(nil))
 				eventCh <- ClientMockResponse{
 					Event:  *e,
 					Result: m.Result,

--- a/v2/protocol/gochan/responder.go
+++ b/v2/protocol/gochan/responder.go
@@ -15,6 +15,7 @@ type ChanResponderResponse struct {
 }
 
 // Responder implements Responder by receiving Messages from a channel and outputting the result in an output channel.
+// All message received in the `Out` channel must be finished
 type Responder struct {
 	In  <-chan binding.Message
 	Out chan<- ChanResponderResponse

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -191,11 +191,15 @@ func (p *Protocol) Receive(ctx context.Context) (binding.Message, error) {
 
 	msg, fn, err := p.Respond(ctx)
 	// No-op the response when finish is invoked.
-	return binding.WithFinish(msg, func(err error) {
-		if fn != nil {
-			_ = fn(ctx, nil, nil)
-		}
-	}), err
+	if msg != nil {
+		return binding.WithFinish(msg, func(err error) {
+			if fn != nil {
+				_ = fn(ctx, nil, nil)
+			}
+		}), err
+	} else {
+		return nil, err
+	}
 }
 
 // Respond receives the next incoming HTTP request as a CloudEvent and waits

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -190,13 +190,12 @@ func (p *Protocol) Receive(ctx context.Context) (binding.Message, error) {
 	}
 
 	msg, fn, err := p.Respond(ctx)
-	// No-op the response.
-	defer func() {
+	// No-op the response when finish is invoked.
+	return binding.WithFinish(msg, func(err error) {
 		if fn != nil {
 			_ = fn(ctx, nil, nil)
 		}
-	}()
-	return msg, err
+	}), err
 }
 
 // Respond receives the next incoming HTTP request as a CloudEvent and waits
@@ -226,25 +225,31 @@ type msgErr struct {
 }
 
 // ServeHTTP implements http.Handler.
-// Blocks until Message.Finish is called.
+// Blocks until ResponseFn is invoked.
 func (p *Protocol) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-
 	m := NewMessageFromHttpRequest(req)
 	if m == nil || m.ReadEncoding() == binding.EncodingUnknown {
 		p.incoming <- msgErr{msg: nil, err: binding.ErrUnknownEncoding}
 		return // if there was no message, return.
 	}
 
-	done := make(chan error)
+	done := make(chan struct{})
+	var finishErr error
 
 	m.OnFinish = func(err error) error {
-		done <- err
+		finishErr = err
 		return nil
 	}
 
 	var fn protocol.ResponseFn = func(ctx context.Context, resp binding.Message, er protocol.Result) error {
-
+		// Unblock the ServeHTTP after the reply is written
+		defer func() {
+			done <- struct{}{}
+		}()
 		status := http.StatusOK
+		if finishErr != nil {
+			http.Error(rw, fmt.Sprintf("cannot forward CloudEvent: %v", finishErr), http.StatusInternalServerError)
+		}
 		if er != nil {
 			var result *Result
 			if protocol.ResultAs(er, &result) {
@@ -262,8 +267,6 @@ func (p *Protocol) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	p.incoming <- msgErr{msg: m, respFn: fn} // Send to Request
-	if err := <-done; err != nil {
-		fmt.Println("attempting to write an error out on response writer:", err)
-		http.Error(rw, fmt.Sprintf("cannot forward CloudEvent: %v", err), http.StatusInternalServerError)
-	}
+	// Block until ResponseFn is invoked
+	<-done
 }

--- a/v2/protocol/http/protocol_test.go
+++ b/v2/protocol/http/protocol_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+
 	"net/http"
 	"testing"
 	"time"
@@ -207,7 +209,7 @@ func TestServeHTTP_Receive(t *testing.T) {
 		rw  http.ResponseWriter
 		req *http.Request
 		// Receive
-		want    *Message
+		want    binding.Message
 		wantErr string
 	}{
 		"nil": {
@@ -240,7 +242,9 @@ func ReceiveTest(t *testing.T, p *Protocol, ctx context.Context, want binding.Me
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("unexpected diff (-want, +got) = %v", diff)
+	if want == nil {
+		require.Nil(t, want)
+	} else {
+		require.IsType(t, want, got)
 	}
 }

--- a/v2/protocol/inbound.go
+++ b/v2/protocol/inbound.go
@@ -12,6 +12,7 @@ type Receiver interface {
 	//
 	// A non-nil error means the receiver is closed.
 	// io.EOF means it closed cleanly, any other value indicates an error.
+	// The caller is responsible for `Finish()` the returned message
 	Receive(ctx context.Context) (binding.Message, error)
 }
 
@@ -31,6 +32,10 @@ type Responder interface {
 	//
 	// A non-nil error means the receiver is closed.
 	// io.EOF means it closed cleanly, any other value indicates an error.
+	// The caller is responsible for `Finish()` the returned message,
+	// while the protocol implementation is responsible for `Finish()` the response message.
+	// The caller MUST invoke ResponseFn, in order to avoid leaks.
+	// The correct flow for the caller is to finish the received message and then invoke the ResponseFn
 	Respond(ctx context.Context) (binding.Message, ResponseFn, error)
 }
 


### PR DESCRIPTION
Fix #433

Made explicit in the Responder godoc the lifecycle of Respond method

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>