### PR TITLE
Add ExtractExtensions TransformerFactory

### DIFF
--- a/v2/binding/transformer/extract_metadata.go
+++ b/v2/binding/transformer/extract_metadata.go
@@ -1,0 +1,41 @@
+package transformer
+
+import (
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+// ExtractExtensions is a TransformerFactory which extracts a set of extensions from transformed mesages. An instance of this transformer should only be used to process a single message, after which the extracted extensions can be read from the map. All extension which are present as keys in the map will be extracted and other extensions will be ignored.
+type ExtractExtensions map[string]interface{}
+
+func (e ExtractExtensions) StructuredTransformer(_ binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (e ExtractExtensions) BinaryTransformer(writer binding.BinaryWriter) binding.BinaryWriter {
+	return extractExtensionsWriter{
+		BinaryWriter: writer,
+		extensions:   e,
+	}
+}
+
+func (e ExtractExtensions) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		for name := range e {
+			e[name] = event.Extensions()[name]
+		}
+		return nil
+	}
+}
+
+type extractExtensionsWriter struct {
+	binding.BinaryWriter
+	extensions ExtractExtensions
+}
+
+func (e extractExtensionsWriter) SetExtension(name string, value interface{}) error {
+	if _, ok := e.extensions[name]; ok {
+		e.extensions[name] = value
+	}
+	return e.BinaryWriter.SetExtension(name, value)
+}

--- a/v2/binding/transformer/extract_metadata_test.go
+++ b/v2/binding/transformer/extract_metadata_test.go
@@ -1,0 +1,124 @@
+package transformer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/test"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleExtractExtensions() {
+	e := event.New("1.0")
+	e.Context = &event.EventContextV1{}
+	e.SetID("id")
+	e.SetSource("source")
+	e.SetType("type")
+	e.SetExtension("someextension", "somevalue")
+	e.SetExtension("otherextension", "othervalue") // extension will be ignored
+	extractor := ExtractExtensions{"someextension": nil}
+	_, err := binding.ToEvent(context.TODO(), binding.ToMessage(&e), extractor)
+	if err != nil {
+		fmt.Printf("Error running extractor: %v", err)
+	}
+	fmt.Println("extractor:", extractor)
+	//Output:
+	//extractor: map[someextension:somevalue]
+}
+
+func TestExtractExtensions(t *testing.T) {
+	t.Parallel()
+
+	e := test.MinEvent()
+	e.Context = e.Context.AsV1()
+	e.SetExtension("extension1", "extension1-val")
+	e.SetExtension("extension2", false)
+
+	tcs := []struct {
+		name      string
+		event     *event.Event
+		extractor ExtractExtensions
+		want      ExtractExtensions
+	}{
+		{
+			name:  "no extensions extracted",
+			event: &e,
+			extractor: ExtractExtensions{
+				"extension3": nil,
+			},
+			want: ExtractExtensions{
+				"extension3": nil,
+			},
+		},
+		{
+			name:  "one extension extracted",
+			event: &e,
+			extractor: ExtractExtensions{
+				"extension3": nil,
+				"extension1": nil,
+			},
+			want: ExtractExtensions{
+				"extension1": "extension1-val",
+				"extension3": nil,
+			},
+		},
+		{
+			name:  "two extensions extracted",
+			event: &e,
+			extractor: ExtractExtensions{
+				"extension1": nil,
+				"extension2": nil,
+				"extension3": nil,
+			},
+			want: ExtractExtensions{
+				"extension1": "extension1-val",
+				"extension2": false,
+				"extension3": nil,
+			},
+		},
+	}
+	for _, tc := range tcs {
+		eventExtractor := make(ExtractExtensions)
+		binaryExtractor := make(ExtractExtensions)
+		structuredExtractor := make(ExtractExtensions)
+		for k, v := range tc.extractor {
+			eventExtractor[k] = v
+			binaryExtractor[k] = v
+			structuredExtractor[k] = v
+		}
+		testArgs := []test.TransformerTestArgs{
+			{
+				Name:         "event",
+				InputEvent:   tc.event.Clone(),
+				AssertFunc:   assertExtractExtensions(tc.event, eventExtractor, tc.want),
+				Transformers: []binding.TransformerFactory{eventExtractor},
+			},
+			{
+				Name:         "binary",
+				InputMessage: test.MustCreateMockBinaryMessage(*tc.event),
+				AssertFunc:   assertExtractExtensions(tc.event, binaryExtractor, tc.want),
+				Transformers: []binding.TransformerFactory{binaryExtractor},
+			},
+			{
+				Name:         "structured",
+				InputMessage: test.MustCreateMockStructuredMessage(*tc.event),
+				AssertFunc:   assertExtractExtensions(tc.event, structuredExtractor, tc.want),
+				Transformers: []binding.TransformerFactory{structuredExtractor},
+			},
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			test.RunTransformerTests(t, context.TODO(), testArgs)
+		})
+	}
+}
+
+func assertExtractExtensions(wantEvent *event.Event, extractor ExtractExtensions, wantExtractor ExtractExtensions) func(*testing.T, event.Event) {
+	return func(t *testing.T, haveEvent event.Event) {
+		test.AssertEventEquals(t, *wantEvent, haveEvent)
+		assert.Equal(t, wantExtractor, extractor)
+	}
+}


### PR DESCRIPTION
ExtractExtensions is a TransformerFactory which extracts a set of
extensions from transformed mesages. An instance of this transformer
should only be used to process a single message, after which the
extracted extensions can be read from the map. All extension which are
present as keys in the map will be extracted and other extensions will
be ignored.

Signed-off-by: Ian Milligan <ianmllgn@gmail.com>