### PR TITLE
Perf improvements in HTTP protocol

### DIFF
--- a/v2/binding/spec/match_exact_version.go
+++ b/v2/binding/spec/match_exact_version.go
@@ -36,7 +36,7 @@ func newMatchExactVersionVersion(
 	return v
 }
 
-// WithPrefix returns a set of versions with prefix added to all attribute names.
+// WithPrefixMatchExact returns a set of versions with prefix added to all attribute names.
 func WithPrefixMatchExact(attributeNameMatchMapper func(string) string, prefix string) *Versions {
 	attr := func(name string, kind Kind) *attribute {
 		return &attribute{accessor: acc[kind], name: name}

--- a/v2/binding/spec/match_exact_version.go
+++ b/v2/binding/spec/match_exact_version.go
@@ -1,0 +1,76 @@
+package spec
+
+import (
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+type matchExactVersion struct {
+	version
+}
+
+func (v *matchExactVersion) Attribute(name string) Attribute { return v.attrMap[name] }
+
+var _ Version = (*matchExactVersion)(nil)
+
+func newMatchExactVersionVersion(
+	prefix string,
+	attributeNameMatchMapper func(string) string,
+	context event.EventContext,
+	convert func(event.EventContextConverter) event.EventContext,
+	attrs ...*attribute,
+) *matchExactVersion {
+	v := &matchExactVersion{
+		version: version{
+			prefix:  prefix,
+			context: context,
+			convert: convert,
+			attrMap: map[string]Attribute{},
+			attrs:   make([]Attribute, len(attrs)),
+		},
+	}
+	for i, a := range attrs {
+		a.version = v
+		v.attrs[i] = a
+		v.attrMap[attributeNameMatchMapper(a.name)] = a
+	}
+	return v
+}
+
+// WithPrefix returns a set of versions with prefix added to all attribute names.
+func WithPrefixMatchExact(attributeNameMatchMapper func(string) string, prefix string) *Versions {
+	attr := func(name string, kind Kind) *attribute {
+		return &attribute{accessor: acc[kind], name: name}
+	}
+	vs := &Versions{
+		m:      map[string]Version{},
+		prefix: prefix,
+		all: []Version{
+			newMatchExactVersionVersion(prefix, attributeNameMatchMapper, event.EventContextV1{}.AsV1(),
+				func(c event.EventContextConverter) event.EventContext { return c.AsV1() },
+				attr("id", ID),
+				attr("source", Source),
+				attr("specversion", SpecVersion),
+				attr("type", Type),
+				attr("datacontenttype", DataContentType),
+				attr("dataschema", DataSchema),
+				attr("subject", Subject),
+				attr("time", Time),
+			),
+			newMatchExactVersionVersion(prefix, attributeNameMatchMapper, event.EventContextV03{}.AsV03(),
+				func(c event.EventContextConverter) event.EventContext { return c.AsV03() },
+				attr("specversion", SpecVersion),
+				attr("type", Type),
+				attr("source", Source),
+				attr("schemaurl", DataSchema),
+				attr("subject", Subject),
+				attr("id", ID),
+				attr("time", Time),
+				attr("datacontenttype", DataContentType),
+			),
+		},
+	}
+	for _, v := range vs.all {
+		vs.m[v.String()] = v
+	}
+	return vs
+}

--- a/v2/binding/spec/match_exact_version_test.go
+++ b/v2/binding/spec/match_exact_version_test.go
@@ -1,0 +1,36 @@
+package spec_test
+
+import (
+	"net/textproto"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
+	"github.com/cloudevents/sdk-go/v2/binding/test"
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+func TestMatchExactVersion(t *testing.T) {
+	test.EachEvent(t, test.AllVersions([]event.Event{test.FullEvent()}), func(t *testing.T, e event.Event) {
+		e = e.Clone()
+		s := spec.WithPrefixMatchExact(
+			func(s string) string {
+				if s == "datacontenttype" {
+					return "Content-Type"
+				} else {
+					return textproto.CanonicalMIMEHeaderKey("Ce-" + s)
+				}
+			},
+			"Ce-",
+		)
+		sv := s.Version(e.SpecVersion())
+		require.NotNil(t, sv)
+
+		require.Equal(t, e.ID(), sv.Attribute("Ce-Id").Get(e.Context))
+		require.Equal(t, "id", sv.Attribute("Ce-Id").Name())
+
+		require.Equal(t, e.DataContentType(), sv.Attribute("Content-Type").Get(e.Context))
+		require.Equal(t, "datacontenttype", sv.Attribute("Content-Type").Name())
+	})
+}

--- a/v2/protocol/http/headers.go
+++ b/v2/protocol/http/headers.go
@@ -1,0 +1,22 @@
+package http
+
+import (
+	"net/textproto"
+
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
+)
+
+var attributeHeadersMapping map[string]string
+
+func init() {
+	attributeHeadersMapping = make(map[string]string)
+	for _, v := range specs.Versions() {
+		for _, a := range v.Attributes() {
+			if a.Kind() == spec.DataContentType {
+				attributeHeadersMapping[a.Name()] = ContentType
+			} else {
+				attributeHeadersMapping[a.Name()] = textproto.CanonicalMIMEHeaderKey(prefix + a.Name())
+			}
+		}
+	}
+}

--- a/v2/protocol/http/message.go
+++ b/v2/protocol/http/message.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	nethttp "net/http"
 	"strings"
+	"unicode"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/binding/format"
@@ -99,7 +100,12 @@ func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) 
 			if attr != nil {
 				err = encoder.SetAttribute(attr, v[0])
 			} else {
-				err = encoder.SetExtension(strings.ToLower(strings.TrimPrefix(k, prefix)), v[0])
+				// Trim Prefix + To lower
+				var b strings.Builder
+				b.Grow(len(k) - len(prefix))
+				b.WriteRune(unicode.ToLower(rune(k[len(prefix)])))
+				b.WriteString(k[len(prefix)+1:])
+				err = encoder.SetExtension(b.String(), v[0])
 			}
 		} else if k == ContentType {
 			err = encoder.SetAttribute(m.version.AttributeFromKind(spec.DataContentType), v[0])

--- a/v2/protocol/http/write_request.go
+++ b/v2/protocol/http/write_request.go
@@ -109,11 +109,8 @@ func (b *httpRequestWriter) SetAttribute(attribute spec.Attribute, value interfa
 		return err
 	}
 
-	if attribute.Kind() == spec.DataContentType {
-		b.Header.Add(ContentType, s)
-	} else {
-		b.Header.Add(prefix+attribute.Name(), s)
-	}
+	mapping := attributeHeadersMapping[attribute.Name()]
+	b.Header[mapping] = append(b.Header[mapping], s)
 	return nil
 }
 

--- a/v2/protocol/http/write_responsewriter.go
+++ b/v2/protocol/http/write_responsewriter.go
@@ -55,11 +55,8 @@ func (b *httpResponseWriter) SetAttribute(attribute spec.Attribute, value interf
 		return err
 	}
 
-	if attribute.Kind() == spec.DataContentType {
-		b.rw.Header().Add(ContentType, s)
-	} else {
-		b.rw.Header().Add(prefix+attribute.Name(), s)
-	}
+	mapping := attributeHeadersMapping[attribute.Name()]
+	b.rw.Header()[mapping] = append(b.rw.Header()[mapping], s)
 	return nil
 }
 


### PR DESCRIPTION
Because `net/http.Header` states that headers are keyed by their canonical mime header representation (https://golang.org/pkg/net/http/#Header), I optimized on avoiding any middle allocations for accessing the attributes map and i pre-compute the header names for the various attributes.

I've also rewrote the computation of the extension key, in order to allocate only one new string.

## Results

```
benchmark                                   old ns/op     new ns/op     delta
BenchmarkHttpWithToEvent-8                  17220         15179         -11.85%
BenchmarkNoDataHttpWithToEvent-8            16575         14101         -14.93%
BenchmarkHttpWithBuffering-8                10642         8703          -18.22%
BenchmarkHttpWithDirect-8                   9080          7613          -16.16%
BenchmarkNoDataHttpWithBuffering-8          10041         8613          -14.22%
BenchmarkNoDataHttpWithDirect-8             9225          7785          -15.61%

benchmark                                   old allocs     new allocs     delta
BenchmarkHttpWithToEvent-8                  136            108            -20.59%
BenchmarkNoDataHttpWithToEvent-8            130            102            -21.54%
BenchmarkHttpWithBuffering-8                108            80             -25.93%
BenchmarkHttpWithDirect-8                   101            73             -27.72%
BenchmarkNoDataHttpWithBuffering-8          106            78             -26.42%
BenchmarkNoDataHttpWithDirect-8             99             71             -28.28%

benchmark                                   old bytes     new bytes     delta
BenchmarkHttpWithToEvent-8                  8385          8061          -3.86%
BenchmarkNoDataHttpWithToEvent-8            7759          7430          -4.24%
BenchmarkHttpWithBuffering-8                5816          5498          -5.47%
BenchmarkHttpWithDirect-8                   4502          4173          -7.31%
BenchmarkNoDataHttpWithBuffering-8          5777          5460          -5.49%
BenchmarkNoDataHttpWithDirect-8             4467          4151          -7.07%
```