### PR TITLE
Fix error message spelling error: unnknown => unknown

### DIFF
--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -31,7 +31,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 	case CloudEventsVersionV1:
 		b, err = JsonEncode(e)
 	default:
-		return nil, fmt.Errorf("unnknown spec version: %q", e.SpecVersion())
+		return nil, fmt.Errorf("unknown spec version: %q", e.SpecVersion())
 	}
 
 	// Report the observable
@@ -64,7 +64,7 @@ func (e *Event) UnmarshalJSON(b []byte) error {
 	case CloudEventsVersionV1:
 		err = e.JsonDecodeV1(b, raw)
 	default:
-		return fmt.Errorf("unnknown spec version: %q", version)
+		return fmt.Errorf("unknown spec version: %q", version)
 	}
 
 	// Report the observable


### PR DESCRIPTION
There are spots in both v1 and v2 marshaling code where `unknown` is spelled with an extra `n`. This PR fixes it in v2 on the assumption that v1 error messages should not be changed.

Skipping filing an issue to save time on overhead, since I do not see a CONTRIBUTING that states a firm rule to always file first, hopefully this works for the community. 