### PR TITLE
Close lifecycle

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -215,6 +215,11 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 			return nil
 		}
 
+		if err != nil {
+			cecontext.LoggerFrom(ctx).Warn("Error while receiving a message: %s", err.Error())
+			continue
+		}
+
 		if err := c.invoker.Invoke(ctx, msg, respFn); err != nil {
 			return err
 		}

--- a/v2/client/test/test.go
+++ b/v2/client/test/test.go
@@ -26,12 +26,12 @@ func SendReceive(t *testing.T, protocolFactory func() interface{}, in event.Even
 
 	go func() {
 		ctx, cancel := context.WithCancel(context.TODO())
-		ch := make(chan event.Event)
+		inCh := make(chan event.Event)
 		defer func(channel chan event.Event) {
 			cancel()
 			close(channel)
 			wg.Done()
-		}(ch)
+		}(inCh)
 		go func(channel chan event.Event) {
 			err := c.StartReceiver(ctx, func(e event.Event) {
 				channel <- e
@@ -39,8 +39,8 @@ func SendReceive(t *testing.T, protocolFactory func() interface{}, in event.Even
 			if err != nil {
 				require.NoError(t, err)
 			}
-		}(ch)
-		e := <-ch
+		}(inCh)
+		e := <-inCh
 		outAssert(e)
 	}()
 

--- a/v2/cmd/samples/amqp/receiver/main.go
+++ b/v2/cmd/samples/amqp/receiver/main.go
@@ -36,11 +36,16 @@ func sampleConfig() (server, node string, opts []ceamqp.Option) {
 
 func main() {
 	host, node, opts := sampleConfig()
-	t, err := ceamqp.NewProtocol(host, node, []amqp.ConnOption{}, []amqp.SessionOption{}, opts...)
+	p, err := ceamqp.NewProtocol(host, node, []amqp.ConnOption{}, []amqp.SessionOption{}, opts...)
 	if err != nil {
 		log.Fatalf("Failed to create AMQP protocol: %v", err)
 	}
-	c, err := client.New(t)
+
+	// Close the connection when finished
+	defer p.Close(context.Background())
+
+	// Create a new client from the given protocol
+	c, err := client.New(p)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}

--- a/v2/cmd/samples/amqp/sender/main.go
+++ b/v2/cmd/samples/amqp/sender/main.go
@@ -71,11 +71,16 @@ func (d *Demo) Send(eventContext event.EventContext, i int) error {
 
 func main() {
 	host, node, opts := sampleConfig()
-	t, err := ceamqp.NewProtocol(host, node, []amqp.ConnOption{}, []amqp.SessionOption{}, opts...)
+	p, err := ceamqp.NewProtocol(host, node, []amqp.ConnOption{}, []amqp.SessionOption{}, opts...)
 	if err != nil {
 		log.Fatalf("Failed to create amqp protocol: %v", err)
 	}
-	c, err := client.New(t)
+
+	// Close the connection when finished
+	defer p.Close(context.Background())
+
+	// Create a new client from the given protocol
+	c, err := client.New(p)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}

--- a/v2/cmd/samples/httptonats/main.go
+++ b/v2/cmd/samples/httptonats/main.go
@@ -36,6 +36,8 @@ func main() {
 		log.Fatalf("failed to create nats protcol, %s", err.Error())
 	}
 
+	defer natsProtocol.Close(ctx)
+
 	httpProtocol, err := cloudeventshttp.New(cloudeventshttp.WithPort(env.Port))
 	if err != nil {
 		log.Fatalf("failed to create http protocol: %s", err.Error())

--- a/v2/cmd/samples/kafka/receiver/main.go
+++ b/v2/cmd/samples/kafka/receiver/main.go
@@ -19,6 +19,8 @@ func main() {
 		log.Fatalf("failed to create protocol: %s", err.Error())
 	}
 
+	defer receiver.Close(context.Background())
+
 	c, err := cloudevents.NewClient(receiver)
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)

--- a/v2/cmd/samples/kafka/sender/main.go
+++ b/v2/cmd/samples/kafka/sender/main.go
@@ -18,6 +18,8 @@ func main() {
 		log.Fatalf("failed to create protocol: %s", err.Error())
 	}
 
+	defer sender.Close(context.Background())
+
 	c, err := cloudevents.NewClient(sender, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)

--- a/v2/cmd/samples/kafka/sender_and_receiver/main.go
+++ b/v2/cmd/samples/kafka/sender_and_receiver/main.go
@@ -20,6 +20,8 @@ func main() {
 		log.Fatalf("failed to create protocol: %s", err.Error())
 	}
 
+	defer protocol.Close(context.Background())
+
 	c, err := cloudevents.NewClient(protocol, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)

--- a/v2/cmd/samples/nats/receiver/main.go
+++ b/v2/cmd/samples/nats/receiver/main.go
@@ -32,6 +32,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create nats protocol, %s", err.Error())
 	}
+
+	defer p.Close(ctx)
+
 	c, err := client.New(p)
 	if err != nil {
 		log.Fatalf("failed to create client, %s", err.Error())

--- a/v2/cmd/samples/nats/sender/main.go
+++ b/v2/cmd/samples/nats/sender/main.go
@@ -38,18 +38,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	for _, contentType := range []string{"application/json", "application/xml"} {
-		p, err := cloudeventsnats.NewSender(env.NATSServer, env.Subject, cloudeventsnats.NatsOptions())
-		if err != nil {
-			log.Printf("failed to create nats protocol, %s", err.Error())
-			os.Exit(1)
-		}
-		c, err := client.New(p)
-		if err != nil {
-			log.Printf("failed to create client, %s", err.Error())
-			os.Exit(1)
-		}
+	p, err := cloudeventsnats.NewSender(env.NATSServer, env.Subject, cloudeventsnats.NatsOptions())
+	if err != nil {
+		log.Printf("failed to create nats protocol, %s", err.Error())
+		os.Exit(1)
+	}
 
+	defer p.Close(context.Background())
+
+	c, err := client.New(p)
+	if err != nil {
+		log.Printf("failed to create client, %s", err.Error())
+		os.Exit(1)
+	}
+
+	for _, contentType := range []string{"application/json", "application/xml"} {
 		for i := 0; i < count; i++ {
 			now := time.Now()
 			e := event.New()
@@ -70,6 +73,4 @@ func main() {
 			time.Sleep(100 * time.Millisecond)
 		}
 	}
-
-	os.Exit(0)
 }

--- a/v2/cmd/samples/stan/receiver/main.go
+++ b/v2/cmd/samples/stan/receiver/main.go
@@ -14,6 +14,8 @@ func main() {
 		log.Fatalf("failed to create protocol: %v", err)
 	}
 
+	defer receiver.Close(context.Background())
+
 	c, err := cloudevents.NewClient(receiver, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)

--- a/v2/cmd/samples/stan/sender/main.go
+++ b/v2/cmd/samples/stan/sender/main.go
@@ -13,6 +13,8 @@ func main() {
 		log.Fatalf("failed to create protocol: %v", err)
 	}
 
+	defer s.Close(context.Background())
+
 	c, err := cloudevents.NewClient(s, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)

--- a/v2/cmd/samples/stan/sender_and_receiver/main.go
+++ b/v2/cmd/samples/stan/sender_and_receiver/main.go
@@ -15,6 +15,8 @@ func main() {
 		log.Fatalf("failed to create protocol: %v", err)
 	}
 
+	defer protocol.Close(context.Background())
+
 	c, err := cloudevents.NewClient(protocol, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)

--- a/v2/protocol/amqp/protocol.go
+++ b/v2/protocol/amqp/protocol.go
@@ -16,9 +16,10 @@ type Protocol struct {
 	receiverLinkOpts []amqp.LinkOption
 
 	// AMQP
-	Client  *amqp.Client
-	Session *amqp.Session
-	Node    string
+	Client      *amqp.Client
+	Session     *amqp.Session
+	ownedClient bool
+	Node        string
 
 	// Sender
 	Sender                  *sender
@@ -76,7 +77,13 @@ func NewProtocol(server, queue string, connOption []amqp.ConnOption, sessionOpti
 		return nil, err
 	}
 
-	return NewProtocolFromClient(client, session, queue, opts...)
+	p, err := NewProtocolFromClient(client, session, queue, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	p.ownedClient = true
+	return p, nil
 }
 
 func (t *Protocol) applyOptions(opts ...Option) error {
@@ -88,20 +95,24 @@ func (t *Protocol) applyOptions(opts ...Option) error {
 	return nil
 }
 
-func (t *Protocol) Close(ctx context.Context) error {
-	if t.Sender != nil {
-		if err := t.Sender.Close(ctx); err != nil {
-			return err
+func (t *Protocol) Close(ctx context.Context) (err error) {
+	if t.ownedClient {
+		// Closing the client will close at cascade sender and receiver
+		return t.Client.Close()
+	} else {
+		if t.Sender != nil {
+			if err = t.Sender.amqp.Close(ctx); err != nil {
+				return
+			}
 		}
-	}
 
-	if t.Receiver != nil {
-		if err := t.Receiver.Close(ctx); err != nil {
-			return err
+		if t.Receiver != nil {
+			if err = t.Receiver.amqp.Close(ctx); err != nil {
+				return err
+			}
 		}
+		return
 	}
-
-	return t.Client.Close()
 }
 
 func (t *Protocol) Send(ctx context.Context, in binding.Message) error {

--- a/v2/protocol/amqp/receiver.go
+++ b/v2/protocol/amqp/receiver.go
@@ -25,8 +25,6 @@ func (r *receiver) Receive(ctx context.Context) (binding.Message, error) {
 	return NewMessage(m), nil
 }
 
-func (r *receiver) Close(ctx context.Context) error { return r.amqp.Close(ctx) }
-
 // NewReceiver create a new Receiver which wraps an amqp.Receiver in a binding.Receiver
 func NewReceiver(amqp *amqp.Receiver) protocol.Receiver {
 	return &receiver{amqp: amqp}

--- a/v2/protocol/amqp/sender.go
+++ b/v2/protocol/amqp/sender.go
@@ -33,8 +33,6 @@ func (s *sender) Send(ctx context.Context, in binding.Message) error {
 	return err
 }
 
-func (s *sender) Close(ctx context.Context) error { return s.amqp.Close(ctx) }
-
 // NewSender creates a new Sender which wraps an amqp.Sender in a binding.Sender
 func NewSender(amqpSender *amqp.Sender, options ...SenderOptionFunc) protocol.Sender {
 	s := &sender{amqp: amqpSender, transformers: make(binding.Transformers, 0)}

--- a/v2/protocol/gochan/protocol_test.go
+++ b/v2/protocol/gochan/protocol_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"io"
 	"testing"
 	"time"
 )
@@ -60,7 +61,7 @@ func TestReceive(t *testing.T) {
 		},
 		"timeout": {
 			ctx:     context.TODO(),
-			wantErr: "context deadline exceeded",
+			wantErr: io.EOF.Error(),
 		},
 	}
 	for n, tc := range testCases {
@@ -80,7 +81,7 @@ func TestSendReceive(t *testing.T) {
 	}{
 		"nil": {
 			sendErr:    "nil Message",
-			receiveErr: "context deadline exceeded",
+			receiveErr: io.EOF.Error(),
 		},
 		"empty event": {
 			want: func() binding.Message {

--- a/v2/protocol/gochan/receiver.go
+++ b/v2/protocol/gochan/receiver.go
@@ -19,7 +19,7 @@ func (r Receiver) Receive(ctx context.Context) (binding.Message, error) {
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, io.EOF
 	case m, ok := <-r:
 		if !ok {
 			return nil, io.EOF

--- a/v2/protocol/http/options.go
+++ b/v2/protocol/http/options.go
@@ -73,7 +73,7 @@ func WithShutdownTimeout(timeout time.Duration) Option {
 		if t == nil {
 			return fmt.Errorf("http shutdown timeout option can not set nil protocol")
 		}
-		t.ShutdownTimeout = &timeout
+		t.ShutdownTimeout = timeout
 		return nil
 	}
 }

--- a/v2/protocol/http/options_test.go
+++ b/v2/protocol/http/options_test.go
@@ -308,10 +308,6 @@ func TestWithShutdownTimeout(t *testing.T) {
 	}
 }
 
-func durationptr(duration time.Duration) *time.Duration {
-	return &duration
-}
-
 func intptr(i int) *int {
 	return &i
 }

--- a/v2/protocol/http/options_test.go
+++ b/v2/protocol/http/options_test.go
@@ -275,7 +275,7 @@ func TestWithShutdownTimeout(t *testing.T) {
 			t:       &Protocol{},
 			timeout: time.Minute * 4,
 			want: &Protocol{
-				ShutdownTimeout: durationptr(time.Minute * 4),
+				ShutdownTimeout: time.Minute * 4,
 			},
 		},
 		"nil protocol": {

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -32,7 +32,7 @@ type Protocol struct {
 
 	// ShutdownTimeout defines the timeout given to the http.Server when calling Shutdown.
 	// If nil, DefaultShutdownTimeout is used.
-	ShutdownTimeout *time.Duration
+	ShutdownTimeout time.Duration
 
 	// Port is the port to bind the receiver to. Defaults to 8080.
 	Port *int
@@ -68,9 +68,8 @@ func New(opts ...Option) (*Protocol, error) {
 		p.Client.Transport = p.roundTripper
 	}
 
-	if p.ShutdownTimeout == nil {
-		timeout := DefaultShutdownTimeout
-		p.ShutdownTimeout = &timeout
+	if p.ShutdownTimeout == 0 {
+		p.ShutdownTimeout = DefaultShutdownTimeout
 	}
 
 	return p, nil

--- a/v2/protocol/http/protocol_lifecycle.go
+++ b/v2/protocol/http/protocol_lifecycle.go
@@ -53,18 +53,11 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 		errChan <- p.server.Serve(p.listener)
 	}()
 
-	// nil check and default
-	shutdown := DefaultShutdownTimeout
-	if p.ShutdownTimeout != nil {
-		shutdown = *p.ShutdownTimeout
-	}
-
 	// wait for the server to return or ctx.Done().
 	select {
 	case <-ctx.Done():
 		// Try a gracefully shutdown.
-		timeout := shutdown
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), *p.ShutdownTimeout)
 		defer cancel()
 		err := p.server.Shutdown(ctx)
 		<-errChan // Wait for server goroutine to exit

--- a/v2/protocol/http/protocol_lifecycle.go
+++ b/v2/protocol/http/protocol_lifecycle.go
@@ -57,7 +57,7 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		// Try a gracefully shutdown.
-		ctx, cancel := context.WithTimeout(context.Background(), *p.ShutdownTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), p.ShutdownTimeout)
 		defer cancel()
 		err := p.server.Shutdown(ctx)
 		<-errChan // Wait for server goroutine to exit

--- a/v2/protocol/http/protocol_test.go
+++ b/v2/protocol/http/protocol_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 			want: &Protocol{
 				transformers:    binding.Transformers{},
 				Client:          http.DefaultClient,
-				ShutdownTimeout: &dst,
+				ShutdownTimeout: dst,
 			},
 		},
 	}

--- a/v2/protocol/kafka_sarama/protocol.go
+++ b/v2/protocol/kafka_sarama/protocol.go
@@ -18,7 +18,8 @@ const (
 
 type Protocol struct {
 	// Kafka
-	Client sarama.Client
+	Client     sarama.Client
+	ownsClient bool
 
 	// Sender
 	Sender *Sender
@@ -44,7 +45,12 @@ func NewProtocol(brokers []string, saramaConfig *sarama.Config, sendToTopic stri
 		return nil, err
 	}
 
-	return NewProtocolFromClient(client, sendToTopic, receiveFromTopic, opts...)
+	p, err := NewProtocolFromClient(client, sendToTopic, receiveFromTopic, opts...)
+	if err != nil {
+		return nil, err
+	}
+	p.ownsClient = true
+	return p, nil
 }
 
 // NewProtocolFromClient creates a new kafka transport starting from a sarama.Client
@@ -55,6 +61,7 @@ func NewProtocolFromClient(client sarama.Client, sendToTopic string, receiveFrom
 		receiverGroupId:         defaultGroupId,
 		senderTopic:             sendToTopic,
 		receiverTopic:           receiveFromTopic,
+		ownsClient:              false,
 	}
 
 	var err error
@@ -110,6 +117,10 @@ func (p *Protocol) Receive(ctx context.Context) (binding.Message, error) {
 }
 
 func (p *Protocol) Close(ctx context.Context) error {
+	if p.ownsClient {
+		// Just closing the client here closes at cascade consumer and producer
+		return p.Client.Close()
+	}
 	if err := p.Consumer.Close(ctx); err != nil {
 		return err
 	}

--- a/v2/protocol/kafka_sarama/receiver.go
+++ b/v2/protocol/kafka_sarama/receiver.go
@@ -73,8 +73,11 @@ type Consumer struct {
 
 	client    sarama.Client
 	ownClient bool
-	topic     string
-	groupId   string
+
+	topic   string
+	groupId string
+
+	cgMtx sync.Mutex
 }
 
 func NewConsumer(brokers []string, saramaConfig *sarama.Config, groupId string, topic string) (*Consumer, error) {
@@ -102,6 +105,8 @@ func NewConsumerFromClient(client sarama.Client, groupId string, topic string) *
 }
 
 func (c *Consumer) OpenInbound(ctx context.Context) error {
+	c.cgMtx.Lock()
+	defer c.cgMtx.Unlock()
 	cg, err := sarama.NewConsumerGroupFromClient(c.groupId, c.client)
 	if err != nil {
 		return err

--- a/v2/protocol/kafka_sarama/receiver.go
+++ b/v2/protocol/kafka_sarama/receiver.go
@@ -55,11 +55,15 @@ func (r *Receiver) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 }
 
 func (r *Receiver) Receive(ctx context.Context) (binding.Message, error) {
-	msgErr, ok := <-r.incoming
-	if !ok {
-		return nil, io.EOF
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case msgErr, ok := <-r.incoming:
+		if !ok {
+			return nil, io.EOF
+		}
+		return msgErr.msg, msgErr.err
 	}
-	return msgErr.msg, msgErr.err
 }
 
 var _ protocol.Receiver = (*Receiver)(nil)
@@ -67,10 +71,10 @@ var _ protocol.Receiver = (*Receiver)(nil)
 type Consumer struct {
 	Receiver
 
-	client              sarama.Client
-	topic               string
-	groupId             string
-	saramaConsumerGroup sarama.ConsumerGroup
+	client    sarama.Client
+	ownClient bool
+	topic     string
+	groupId   string
 }
 
 func NewConsumer(brokers []string, saramaConfig *sarama.Config, groupId string, topic string) (*Consumer, error) {
@@ -79,7 +83,10 @@ func NewConsumer(brokers []string, saramaConfig *sarama.Config, groupId string, 
 		return nil, err
 	}
 
-	return NewConsumerFromClient(client, groupId, topic), nil
+	consumer := NewConsumerFromClient(client, groupId, topic)
+	consumer.ownClient = true
+
+	return consumer, nil
 }
 
 func NewConsumerFromClient(client sarama.Client, groupId string, topic string) *Consumer {
@@ -87,18 +94,18 @@ func NewConsumerFromClient(client sarama.Client, groupId string, topic string) *
 		Receiver: Receiver{
 			incoming: make(chan msgErr),
 		},
-		client:  client,
-		topic:   topic,
-		groupId: groupId,
+		client:    client,
+		topic:     topic,
+		groupId:   groupId,
+		ownClient: false,
 	}
 }
 
-func (c *Consumer) OpenInbound(ctx context.Context) (err error) {
+func (c *Consumer) OpenInbound(ctx context.Context) error {
 	cg, err := sarama.NewConsumerGroupFromClient(c.groupId, c.client)
 	if err != nil {
-		return
+		return err
 	}
-	c.saramaConsumerGroup = cg
 
 	errCh := make(chan error)
 
@@ -106,24 +113,29 @@ func (c *Consumer) OpenInbound(ctx context.Context) (err error) {
 		errs <- cg.Consume(context.Background(), []string{c.topic}, c)
 	}(errCh)
 
-	for {
-		select {
-		case <-ctx.Done():
-			err = c.Close(context.TODO())
-			return
-		case err = <-errCh:
-			return
+	select {
+	case <-ctx.Done():
+		return cg.Close()
+	case err = <-errCh:
+		// We still need to close this thing
+		err2 := cg.Close()
+		if err == nil {
+			err = err2
 		}
+		// Somebody else closed the client, so no problem here
+		if err == sarama.ErrClosedClient || err == sarama.ErrClosedConsumerGroup {
+			return nil
+		}
+		return err
 	}
 }
 
 func (c *Consumer) Close(ctx context.Context) error {
-	if c.saramaConsumerGroup != nil {
-		if err := c.saramaConsumerGroup.Close(); err != nil {
-			return err
-		}
+	if c.ownClient {
+		return c.client.Close()
 	}
 	return nil
 }
 
 var _ protocol.Opener = (*Consumer)(nil)
+var _ protocol.Closer = (*Consumer)(nil)

--- a/v2/protocol/kafka_sarama/receiver.go
+++ b/v2/protocol/kafka_sarama/receiver.go
@@ -57,7 +57,7 @@ func (r *Receiver) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 func (r *Receiver) Receive(ctx context.Context) (binding.Message, error) {
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, io.EOF
 	case msgErr, ok := <-r.incoming:
 		if !ok {
 			return nil, io.EOF

--- a/v2/protocol/kafka_sarama/sender.go
+++ b/v2/protocol/kafka_sarama/sender.go
@@ -18,12 +18,12 @@ type Sender struct {
 
 // NewSender returns a binding.Sender that sends messages to a specific receiverTopic using sarama.SyncProducer
 func NewSender(brokers []string, saramaConfig *sarama.Config, topic string, options ...SenderOptionFunc) (*Sender, error) {
-	client, err := sarama.NewClient(brokers, saramaConfig)
+	producer, err := sarama.NewSyncProducer(brokers, saramaConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewSenderFromClient(client, topic, options...)
+	return makeSender(producer, topic, options...), nil
 }
 
 // NewSenderFromClient returns a binding.Sender that sends messages to a specific receiverTopic using sarama.SyncProducer
@@ -33,15 +33,18 @@ func NewSenderFromClient(client sarama.Client, topic string, options ...SenderOp
 		return nil, err
 	}
 
+	return makeSender(producer, topic, options...), nil
+}
+
+func makeSender(syncProducer sarama.SyncProducer, topic string, options ...SenderOptionFunc) *Sender {
 	s := &Sender{
 		topic:        topic,
-		syncProducer: producer,
-		transformers: make(binding.Transformers, 0),
+		syncProducer: syncProducer,
 	}
 	for _, o := range options {
 		o(s)
 	}
-	return s, nil
+	return s
 }
 
 func (s *Sender) Send(ctx context.Context, m binding.Message) error {
@@ -55,9 +58,15 @@ func (s *Sender) Send(ctx context.Context, m binding.Message) error {
 	}
 
 	_, _, err = s.syncProducer.SendMessage(&kafkaMessage)
+	// Somebody closed the client while sending the message, so no problem here
+	if err == sarama.ErrClosedClient {
+		return nil
+	}
 	return err
 }
 
 func (s *Sender) Close(ctx context.Context) error {
+	// If the Sender was built with NewSenderFromClient, this Close will close only the producer,
+	// otherwise it will close the whole client
 	return s.syncProducer.Close()
 }

--- a/v2/protocol/lifecycle.go
+++ b/v2/protocol/lifecycle.go
@@ -6,11 +6,13 @@ import (
 
 // Opener is the common interface for things that need to be opened.
 type Opener interface {
-	// Blocking call. Context is used to cancel.
+	// OpenInbound is a blocking call and ctx is used to stop the Inbound message Receiver/Responder.
+	// Closing the context won't close the Receiver/Responder, aka it won't invoke Close(ctx).
 	OpenInbound(ctx context.Context) error
 }
 
 // Closer is the common interface for things that can be closed.
+// After invoking Close(ctx), you cannot reuse the object you closed.
 type Closer interface {
 	Close(ctx context.Context) error
 }

--- a/v2/protocol/nats/protocol.go
+++ b/v2/protocol/nats/protocol.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"context"
 	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
 
 	"github.com/nats-io/nats.go"
 )
@@ -99,3 +100,8 @@ func (p *Protocol) applyOptions(opts ...ProtocolOption) error {
 	}
 	return nil
 }
+
+var _ protocol.Receiver = (*Protocol)(nil)
+var _ protocol.Sender = (*Protocol)(nil)
+var _ protocol.Opener = (*Protocol)(nil)
+var _ protocol.Closer = (*Protocol)(nil)

--- a/v2/protocol/nats/receiver.go
+++ b/v2/protocol/nats/receiver.go
@@ -115,7 +115,7 @@ func (c *Consumer) Close(ctx context.Context) error {
 	// to wait OpenInbound to finish draining the queue
 	c.internalClose <- struct{}{}
 	c.subMtx.Lock()
-	c.subMtx.Unlock()
+	defer c.subMtx.Unlock()
 
 	if c.connOwned {
 		c.Conn.Close()

--- a/v2/protocol/nats/receiver.go
+++ b/v2/protocol/nats/receiver.go
@@ -39,7 +39,7 @@ func (r *Receiver) Receive(ctx context.Context) (binding.Message, error) {
 		}
 		return msgErr.msg, nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, io.EOF
 	}
 }
 

--- a/v2/protocol/nats/sender.go
+++ b/v2/protocol/nats/sender.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+
 	"github.com/nats-io/nats.go"
 )
 
@@ -87,3 +89,6 @@ func (s *Sender) applyOptions(opts ...SenderOption) error {
 	}
 	return nil
 }
+
+var _ protocol.Sender = (*Sender)(nil)
+var _ protocol.Closer = (*Protocol)(nil)

--- a/v2/protocol/stan/options.go
+++ b/v2/protocol/stan/options.go
@@ -78,7 +78,7 @@ func WithSubscriptionOptions(opts ...stan.SubscriptionOption) ConsumerOption {
 	}
 }
 
-// WithUnsubscribeOnClose configures the Protocol to unsubscribe subscriptions on close, rather than just closing.
+// WithUnsubscribeOnClose configures the Consumer to unsubscribe when OpenInbound context is cancelled or when Consumer.Close() is invoked.
 // This causes durable subscriptions to be forgotten by the STAN service and recreated durable subscriptions will
 // act like they are newly created.
 func WithUnsubscribeOnClose() ConsumerOption {

--- a/v2/protocol/stan/options_test.go
+++ b/v2/protocol/stan/options_test.go
@@ -1,21 +1,22 @@
 package stan
 
 import (
-	"github.com/cloudevents/sdk-go/v2/binding"
-	"github.com/cloudevents/sdk-go/v2/binding/transformer"
-	"github.com/nats-io/stan.go"
 	"reflect"
 	"testing"
+
+	"github.com/nats-io/stan.go"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/transformer"
 )
 
 func TestWithQueueSubscriber(t *testing.T) {
-	baseConsumer := Consumer{}
 	type args struct {
 		queue string
 	}
 	type wants struct {
 		err      error
-		consumer Consumer
+		consumer *Consumer
 	}
 	tests := []struct {
 		name  string
@@ -29,7 +30,7 @@ func TestWithQueueSubscriber(t *testing.T) {
 			},
 			wants: wants{
 				err: nil,
-				consumer: Consumer{
+				consumer: &Consumer{
 					Subscriber: &QueueSubscriber{QueueGroup: "my-queue"},
 				},
 			},
@@ -41,13 +42,13 @@ func TestWithQueueSubscriber(t *testing.T) {
 			},
 			wants: wants{
 				err:      ErrInvalidQueueName,
-				consumer: Consumer{},
+				consumer: &Consumer{},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotP := baseConsumer
+			gotP := &Consumer{}
 			gotErr := gotP.applyOptions(WithQueueSubscriber(tt.args.queue))
 			if gotErr != tt.wants.err {
 				t.Errorf("applyOptions(WithQueueSubscriber()) = %v, want %v", gotErr, tt.wants.err)
@@ -61,7 +62,6 @@ func TestWithQueueSubscriber(t *testing.T) {
 }
 
 func TestWithSubscriptionOptions(t *testing.T) {
-	baseConsumer := Consumer{}
 	type args struct {
 		stanSubscriptionOptions []stan.SubscriptionOption
 	}
@@ -99,7 +99,7 @@ func TestWithSubscriptionOptions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotC := baseConsumer
+			gotC := &Consumer{}
 			gotErr := gotC.applyOptions(WithSubscriptionOptions(tt.args.stanSubscriptionOptions...))
 			if gotErr != tt.wants.err {
 				t.Errorf("applyOptions(WithSubscriptionOptions()) = %v, want %v", gotErr, tt.wants.err)
@@ -181,12 +181,11 @@ func TestWithTransformer(t *testing.T) {
 }
 
 func TestWithUnsubscribeOnClose(t *testing.T) {
-	baseConsumer := Consumer{}
 	type args struct {
 	}
 	type wants struct {
 		err      error
-		consumer Consumer
+		consumer *Consumer
 	}
 	tests := []struct {
 		name  string
@@ -198,7 +197,7 @@ func TestWithUnsubscribeOnClose(t *testing.T) {
 			args: args{},
 			wants: wants{
 				err: nil,
-				consumer: Consumer{
+				consumer: &Consumer{
 					UnsubscribeOnClose: true,
 				},
 			},
@@ -206,7 +205,7 @@ func TestWithUnsubscribeOnClose(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotP := baseConsumer
+			gotP := &Consumer{}
 			gotErr := gotP.applyOptions(WithUnsubscribeOnClose())
 			if gotErr != tt.wants.err {
 				t.Errorf("applyOptions(WithUnsubscribeOnClose()) = %v, want %v", gotErr, tt.wants.err)

--- a/v2/protocol/stan/protocol.go
+++ b/v2/protocol/stan/protocol.go
@@ -2,8 +2,8 @@ package stan
 
 import (
 	"context"
-	"errors"
 	"fmt"
+
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/protocol"
 

--- a/v2/protocol/stan/protocol.go
+++ b/v2/protocol/stan/protocol.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+
 	"github.com/nats-io/stan.go"
 )
-
-var ErrSubscriptionAlreadyOpen = errors.New("subscription already open")
 
 // Protocol is a reference implementation for using the CloudEvents binding
 // integration. Protocol acts as both a STAN client and a STAN handler.
@@ -91,18 +91,28 @@ func (p *Protocol) Receive(ctx context.Context) (binding.Message, error) {
 }
 
 // Close implements Closer.Close
-func (p *Protocol) Close(ctx context.Context) error {
-	if err := p.Consumer.Close(ctx); err != nil {
-		return err
-	}
-
-	if err := p.Sender.Close(ctx); err != nil {
-		return err
-	}
-
+func (p *Protocol) Close(ctx context.Context) (err error) {
 	if p.connOwned {
-		return p.Conn.Close()
+		defer func() {
+			err2 := p.Conn.Close()
+			if err == nil {
+				err = err2
+			}
+		}()
 	}
 
-	return nil
+	if err = p.Consumer.Close(ctx); err != nil {
+		return
+	}
+
+	if err = p.Sender.Close(ctx); err != nil {
+		return
+	}
+
+	return
 }
+
+var _ protocol.Receiver = (*Protocol)(nil)
+var _ protocol.Sender = (*Protocol)(nil)
+var _ protocol.Opener = (*Protocol)(nil)
+var _ protocol.Closer = (*Protocol)(nil)

--- a/v2/protocol/stan/receiver.go
+++ b/v2/protocol/stan/receiver.go
@@ -164,7 +164,7 @@ func (c *Consumer) Close(_ context.Context) error {
 	// to wait OpenInbound to finish draining the queue
 	c.internalClose <- struct{}{}
 	c.subMtx.Lock()
-	c.subMtx.Unlock()
+	defer c.subMtx.Unlock()
 
 	if c.connOwned {
 		return c.Conn.Close()

--- a/v2/protocol/stan/receiver.go
+++ b/v2/protocol/stan/receiver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/nats-io/stan.go"
 	"io"
+	"sync"
 )
 
 type msgErr struct {
@@ -79,9 +80,11 @@ type Consumer struct {
 	UnsubscribeOnClose bool
 
 	subscriptionOptions []stan.SubscriptionOption
-	sub                 stan.Subscription
-	connOwned           bool                      // whether this consumer is responsible for closing the connection
 	appliedSubOpts      *stan.SubscriptionOptions // only used locally, stored to avoid recomputing
+
+	subMtx        sync.Mutex
+	internalClose chan struct{}
+	connOwned     bool // whether this consumer is responsible for closing the connection
 }
 
 func NewConsumer(clusterID, clientID, subject string, stanOpts []stan.Option, opts ...ConsumerOption) (*Consumer, error) {
@@ -103,9 +106,10 @@ func NewConsumer(clusterID, clientID, subject string, stanOpts []stan.Option, op
 
 func NewConsumerFromConn(conn stan.Conn, subject string, opts ...ConsumerOption) (*Consumer, error) {
 	c := &Consumer{
-		Conn:       conn,
-		Subject:    subject,
-		Subscriber: &RegularSubscriber{},
+		Conn:          conn,
+		Subject:       subject,
+		Subscriber:    &RegularSubscriber{},
+		internalClose: make(chan struct{}, 1),
 	}
 
 	err := c.applyOptions(opts...)
@@ -129,46 +133,44 @@ func NewConsumerFromConn(conn stan.Conn, subject string, opts ...ConsumerOption)
 
 // OpenInbound implements Opener.OpenInbound.
 func (c *Consumer) OpenInbound(ctx context.Context) error {
-	var err error
-	if c.sub != nil && c.sub.IsValid() {
-		return ErrSubscriptionAlreadyOpen
-	}
+	c.subMtx.Lock()
+	defer c.subMtx.Unlock()
 
-	c.sub, err = c.Subscriber.Subscribe(c.Conn, c.Subject, c.Receiver.MsgHandler, c.subscriptionOptions...)
+	// Subscribe
+	sub, err := c.Subscriber.Subscribe(c.Conn, c.Subject, c.Receiver.MsgHandler, c.subscriptionOptions...)
 	if err != nil {
-		c.sub = nil
 		return err
 	}
-	<-ctx.Done()
 
-	return nil
+	// Wait until external or internal context done
+	select {
+	case <-ctx.Done():
+	case <-c.internalClose:
+	}
+
+	if c.UnsubscribeOnClose {
+		return sub.Unsubscribe()
+	} else {
+		return sub.Close()
+	}
 }
 
 // Close implements Closer.Close.
 // This method only closes the connection if the Consumer opened it. Subscriptions are closed/unsubscribed dependent
 // on the UnsubscribeOnClose field.
 func (c *Consumer) Close(_ context.Context) error {
-	if c.sub == nil || !c.sub.IsValid() {
-		return nil
-	}
-
-	if c.UnsubscribeOnClose {
-		if err := c.sub.Unsubscribe(); err != nil {
-			return err
-		}
-	} else {
-		// c.Conn.Close() would implicitly close any underlying subscriptions but this results in over-complicated
-		// logic, it's easier to just explicitly close like so
-		if err := c.sub.Close(); err != nil {
-			return err
-		}
-	}
-
-	c.sub = nil
+	// Before closing, let's be sure OpenInbound completes
+	// We send a signal to close and then we lock on subMtx in order
+	// to wait OpenInbound to finish draining the queue
+	c.internalClose <- struct{}{}
+	c.subMtx.Lock()
+	c.subMtx.Unlock()
 
 	if c.connOwned {
 		return c.Conn.Close()
 	}
+
+	close(c.internalClose)
 
 	return nil
 }

--- a/v2/protocol/stan/sender.go
+++ b/v2/protocol/stan/sender.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+
 	"github.com/nats-io/stan.go"
 )
 
@@ -89,3 +91,6 @@ func (s *Sender) applyOptions(opts ...SenderOption) error {
 	}
 	return nil
 }
+
+var _ protocol.Sender = (*Sender)(nil)
+var _ protocol.Closer = (*Sender)(nil)

--- a/v2/test/integration/amqp/amqp_test.go
+++ b/v2/test/integration/amqp/amqp_test.go
@@ -25,8 +25,6 @@ func TestSendEvent(t *testing.T) {
 	})
 }
 
-// Ideally add AMQP server support to the binding.
-
 // Some test require an AMQP broker or router. If the connection fails
 // the tests are skipped. The env variable TEST_AMQP_URL can be set to the
 // test URL, otherwise the default is "/test"

--- a/v2/test/integration/amqp_binding/amqp_test.go
+++ b/v2/test/integration/amqp_binding/amqp_test.go
@@ -76,8 +76,6 @@ func TestSendEventReceiveBinary(t *testing.T) {
 	})
 }
 
-// Ideally add AMQP server support to the binding.
-
 // Some test require an AMQP broker or router. If the connection fails
 // the tests are skipped. The env variable TEST_AMQP_URL can be set to the
 // test URL, otherwise the default is "/test"


### PR DESCRIPTION
Fixes #452 

With this PR I try to make the behaviour consistent across all protocols:

* Closing the `ctx` of `OpenInbound(ctx)` doesn't close the persistent connection/client, but just the _message consumer_ created in `OpenInbound(ctx)`
* `Close(ctx)` closes the persistent connection/client only if owned and eventually closes the opened inbound
* `OpenInbound(ctx)` can be invoked only one time. If user needs more consumers/subscription, he/she should create a new message consumer/protocol instance 

Protocol by protocol explanation:

* HTTP protocol doesn't have a persistent connection/client object, so no `Closer` implementation. Closing the `ctx` of `OpenInbound(ctx)` closes the http server
* Kafka/Nats/Stan has persistent connection/client with consumer "callback style", so they implement `Closer` with internal propagation from `Close(ctx)` to `OpenInbound(ctx)`
* Because `amqp.Sender` and `amqp.Receiver` never owns the sender/receiver objects, they don't implement `Closer`. Also amqp doesn't have `OpenInbound(ctx)`, so `Close(ctx)` on `Protocol` just closes the client if owned and closes created sender and receiver 

Also:

* Added logging of errors in `Client.StartReceiver`
* Removed some outdated comments
* Fixed examples to reflect the changes

cc @dan-j 