### PR TITLE
 ack manually by the the fn result

### DIFF
--- a/v2/client/invoker.go
+++ b/v2/client/invoker.go
@@ -67,7 +67,7 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 
 		// protocol can manual ack by the result
 		if respFn == nil {
-			if result != nil {
+			if !protocol.IsACK(result) {
 				err = m.Finish(result)
 				isFinished = true
 			}

--- a/v2/client/invoker.go
+++ b/v2/client/invoker.go
@@ -37,9 +37,12 @@ type receiveInvoker struct {
 }
 
 func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn protocol.ResponseFn) (err error) {
+	var isFinished bool
 	defer func() {
-		if err2 := m.Finish(err); err2 == nil {
-			err = err2
+		if !isFinished {
+			if err2 := m.Finish(err); err2 == nil {
+				err = err2
+			}
 		}
 	}()
 
@@ -61,14 +64,22 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 				cecontext.LoggerFrom(ctx).Error(fmt.Errorf("cloudevent validation failed on response event: %v, %w", verr, err))
 			}
 		}
-		if respFn != nil {
-			var rm binding.Message
-			if resp != nil {
-				rm = (*binding.EventMessage)(resp)
+		
+		// protocol can manual ack by the result
+		if respFn == nil {
+			if result != nil  {
+				err = m.Finish(result)
+				isFinished = true
 			}
-
-			return respFn(ctx, rm, result) // TODO: there is a chance this never gets called. Is that ok?
+			return
 		}
+
+		var rm binding.Message
+		if resp != nil {
+			rm = (*binding.EventMessage)(resp)
+		}
+
+		return respFn(ctx, rm, result)
 	}
 
 	return nil

--- a/v2/client/invoker.go
+++ b/v2/client/invoker.go
@@ -64,10 +64,10 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 				cecontext.LoggerFrom(ctx).Error(fmt.Errorf("cloudevent validation failed on response event: %v, %w", verr, err))
 			}
 		}
-		
+
 		// protocol can manual ack by the result
 		if respFn == nil {
-			if result != nil  {
+			if result != nil {
 				err = m.Finish(result)
 				isFinished = true
 			}


### PR DESCRIPTION
In the most MQ case, we just ack when there is no errors, but the  sdk v2 code does not transfer the ReceiverFn result context to MQ protocol `(m *Message) Finish(err error) error` method, so i add this pull request.

in my case:

```go
// The ReceiverFn
fn := func(ctx context.Context, event cloudevents.Event) protocol.Result {
	// ack or nack by the event handler result
	err := doSomething(event)
	if err != nil {
		return protocol.ResultNACK
	}
	if err == IgnoreError {
		return protocol.ResultACK
	}
	return err
}
c.StartReceiver(ctx, fn)
```

in the message Finish function

```go
// Finish marks if there is no error
func (m *Message) Finish(err error) error {
	if protocol.IsACK(err) {
		m.internal.Ack()
	} else {
		m.internal.Nack()
	}
	return nil
}

```
the full version of kafka implement: https://github.com/cloudevents/sdk-go/pull/462