### PR TITLE
kafka receiver ack/nack support 

### DIFF
--- a/v2/client/invoker.go
+++ b/v2/client/invoker.go
@@ -67,7 +67,7 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 
 		// protocol can manual ack by the result
 		if respFn == nil {
-			if result != nil {
+			if !protocol.IsACK(result) {
 				err = m.Finish(result)
 				isFinished = true
 			}

--- a/v2/client/invoker.go
+++ b/v2/client/invoker.go
@@ -37,9 +37,12 @@ type receiveInvoker struct {
 }
 
 func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn protocol.ResponseFn) (err error) {
+	var isFinished bool
 	defer func() {
-		if err2 := m.Finish(err); err2 == nil {
-			err = err2
+		if !isFinished {
+			if err2 := m.Finish(err); err2 == nil {
+				err = err2
+			}
 		}
 	}()
 
@@ -61,14 +64,22 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 				cecontext.LoggerFrom(ctx).Error(fmt.Errorf("cloudevent validation failed on response event: %v, %w", verr, err))
 			}
 		}
-		if respFn != nil {
-			var rm binding.Message
-			if resp != nil {
-				rm = (*binding.EventMessage)(resp)
+		
+		// protocol can manual ack by the result
+		if respFn == nil {
+			if result != nil  {
+				err = m.Finish(result)
+				isFinished = true
 			}
-
-			return respFn(ctx, rm, result) // TODO: there is a chance this never gets called. Is that ok?
+			return
 		}
+
+		var rm binding.Message
+		if resp != nil {
+			rm = (*binding.EventMessage)(resp)
+		}
+
+		return respFn(ctx, rm, result)
 	}
 
 	return nil

--- a/v2/client/invoker.go
+++ b/v2/client/invoker.go
@@ -64,10 +64,10 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 				cecontext.LoggerFrom(ctx).Error(fmt.Errorf("cloudevent validation failed on response event: %v, %w", verr, err))
 			}
 		}
-		
+
 		// protocol can manual ack by the result
 		if respFn == nil {
-			if result != nil  {
+			if result != nil {
 				err = m.Finish(result)
 				isFinished = true
 			}

--- a/v2/protocol/kafka_sarama/kafka_internal.go
+++ b/v2/protocol/kafka_sarama/kafka_internal.go
@@ -14,13 +14,6 @@ type kafkaInternal struct {
 	nackProducer sarama.SyncProducer
 }
 
-// NewKafkaInternalFromConsumerMessage new KafkaInternalMessage from ConsumerMessage used for unit test
-func NewKafkaInternalFromConsumerMessage(cm *sarama.ConsumerMessage) *kafkaInternal {
-	return &kafkaInternal{
-		consumerMessage: cm,
-	}
-}
-
 // Ack indicates successful processing of a Message passed to the Subscriber.Receive callback.
 func (i *kafkaInternal) Ack() {
 	if i.session == nil {
@@ -47,4 +40,11 @@ func (i *kafkaInternal) Nack() error {
 
 	_, _, err = i.nackProducer.SendMessage(&kafkaMessage)
 	return err
+}
+
+// NewKafkaInternalFromConsumerMessage new KafkaInternalMessage from ConsumerMessage used for unit test
+func NewKafkaInternalFromConsumerMessage(cm *sarama.ConsumerMessage) *kafkaInternal {
+	return &kafkaInternal{
+		consumerMessage: cm,
+	}
 }

--- a/v2/protocol/kafka_sarama/kafka_internal.go
+++ b/v2/protocol/kafka_sarama/kafka_internal.go
@@ -42,7 +42,7 @@ func (i *kafkaInternal) Nack() error {
 	return err
 }
 
-// NewKafkaInternalFromConsumerMessage new KafkaInternalMessage from ConsumerMessage used for unit test
+// NewKafkaInternalFromConsumerMessage new kafka internal from consumer message used for unit test
 func NewKafkaInternalFromConsumerMessage(cm *sarama.ConsumerMessage) *kafkaInternal {
 	return &kafkaInternal{
 		consumerMessage: cm,

--- a/v2/protocol/kafka_sarama/kafka_internal.go
+++ b/v2/protocol/kafka_sarama/kafka_internal.go
@@ -1,0 +1,50 @@
+package kafka_sarama
+
+import (
+	"github.com/Shopify/sarama"
+)
+
+// kafkaInternal kafka internal of message
+type kafkaInternal struct {
+	topic           string
+	session         sarama.ConsumerGroupSession
+	consumerMessage *sarama.ConsumerMessage
+
+	// used for nack, the nack if put the message to the end of the mq
+	nackProducer sarama.SyncProducer
+}
+
+// NewKafkaInternalFromConsumerMessage new KafkaInternalMessage from ConsumerMessage used for unit test
+func NewKafkaInternalFromConsumerMessage(cm *sarama.ConsumerMessage) *kafkaInternal {
+	return &kafkaInternal{
+		consumerMessage: cm,
+	}
+}
+
+// Ack indicates successful processing of a Message passed to the Subscriber.Receive callback.
+func (i *kafkaInternal) Ack() {
+	if i.session == nil {
+		return
+	}
+	i.session.MarkMessage(i.consumerMessage, "")
+}
+
+// Nack indicates that the client put the message to the end of the mq
+func (i *kafkaInternal) Nack() error {
+	if i.nackProducer == nil {
+		return nil
+	}
+	var err error
+	kafkaMessage := sarama.ProducerMessage{
+		Topic: i.topic,
+		Key:   sarama.ByteEncoder(i.consumerMessage.Key),
+		Value: sarama.ByteEncoder(i.consumerMessage.Value),
+	}
+	for _, v := range i.consumerMessage.Headers {
+		kafkaMessage.Headers = append(kafkaMessage.Headers, *v)
+	}
+	kafkaMessage.Timestamp = i.consumerMessage.Timestamp
+
+	_, _, err = i.nackProducer.SendMessage(&kafkaMessage)
+	return err
+}

--- a/v2/protocol/kafka_sarama/message_benchmark_test.go
+++ b/v2/protocol/kafka_sarama/message_benchmark_test.go
@@ -16,26 +16,26 @@ var Err error
 
 func BenchmarkNewStructuredMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessage)
+		M = kafka_sarama.NewMessageFromConsumerMessage(kafka_sarama.NewKafkaInternalFromConsumerMessage(structuredConsumerMessage))
 	}
 }
 
 func BenchmarkNewBinaryMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessage)
+		M = kafka_sarama.NewMessageFromConsumerMessage(kafka_sarama.NewKafkaInternalFromConsumerMessage(binaryConsumerMessage))
 	}
 }
 
 func BenchmarkNewStructuredMessageToEvent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessage)
+		M = kafka_sarama.NewMessageFromConsumerMessage(kafka_sarama.NewKafkaInternalFromConsumerMessage(structuredConsumerMessage))
 		Event, Err = binding.ToEvent(context.TODO(), M)
 	}
 }
 
 func BenchmarkNewBinaryMessageToEvent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessage)
+		M = kafka_sarama.NewMessageFromConsumerMessage(kafka_sarama.NewKafkaInternalFromConsumerMessage(binaryConsumerMessage))
 		Event, Err = binding.ToEvent(context.TODO(), M)
 	}
 }

--- a/v2/protocol/kafka_sarama/message_test.go
+++ b/v2/protocol/kafka_sarama/message_test.go
@@ -67,7 +67,7 @@ func TestNewMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := kafka_sarama.NewMessageFromConsumerMessage(tt.consumerMessage)
+			got := kafka_sarama.NewMessageFromConsumerMessage(kafka_sarama.NewKafkaInternalFromConsumerMessage(tt.consumerMessage))
 			require.NotNil(t, got)
 			require.Equal(t, tt.expectedEncoding, got.ReadEncoding())
 		})

--- a/v2/protocol/kafka_sarama/protocol.go
+++ b/v2/protocol/kafka_sarama/protocol.go
@@ -97,7 +97,7 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 	defer p.consumerMux.Unlock()
 
 	logger := cecontext.LoggerFrom(ctx)
-	logger.Infof("Starting consumer group to topic {} and group id {}", p.receiverTopic, p.receiverGroupId)
+	logger.Infof("Starting consumer group to topic %s and group id %s", p.receiverTopic, p.receiverGroupId)
 
 	return p.Consumer.OpenInbound(ctx)
 }

--- a/v2/protocol/kafka_sarama/protocol.go
+++ b/v2/protocol/kafka_sarama/protocol.go
@@ -74,7 +74,11 @@ func NewProtocolFromClient(client sarama.Client, sendToTopic string, receiveFrom
 	if p.receiverTopic == "" {
 		return nil, errors.New("you didn't specify the topic to receive from")
 	}
-	p.Consumer = NewConsumerFromClient(p.Client, p.receiverGroupId, p.receiverTopic)
+	nackProducer, err := sarama.NewSyncProducerFromClient(client)
+	if err != nil {
+		return nil, err
+	}
+	p.Consumer = NewConsumerFromClient(p.Client, p.receiverGroupId, p.receiverTopic, nackProducer)
 
 	return p, nil
 }

--- a/v2/protocol/kafka_sarama/receiver.go
+++ b/v2/protocol/kafka_sarama/receiver.go
@@ -99,7 +99,7 @@ func NewConsumer(brokers []string, saramaConfig *sarama.Config, groupId string, 
 		return nil, err
 	}
 	consumer := NewConsumerFromClient(client, groupId, topic, nackProducer)
-  consumer.ownClient = true
+	consumer.ownClient = true
 	return consumer, nil
 }
 

--- a/v2/protocol/kafka_sarama/write_producer_message_test.go
+++ b/v2/protocol/kafka_sarama/write_producer_message_test.go
@@ -72,7 +72,14 @@ func TestEncodeKafkaProducerMessage(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				messageOut := NewMessage(value, string(headers[contentTypeHeader]), headers)
+				internal := &kafkaInternal{
+					topic:           "aaa",
+					session:         nil,
+					consumerMessage: nil,
+					nackProducer:    nil,
+				}
+
+				messageOut := NewMessage(value, string(headers[contentTypeHeader]), headers, internal)
 				require.Equal(t, tt.expectedEncoding, messageOut.ReadEncoding())
 
 				eventOut, err := binding.ToEvent(context.TODO(), messageOut)

--- a/v2/test/benchmark/kafka_sarama_to_http_request_encode/benchmark_test.go
+++ b/v2/test/benchmark/kafka_sarama_to_http_request_encode/benchmark_test.go
@@ -56,7 +56,7 @@ var Err error
 
 func BenchmarkStructured(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M = kafka_sarama.NewMessageFromConsumerMessage(structuredConsumerMessage)
+		M = kafka_sarama.NewMessageFromConsumerMessage(kafka_sarama.NewKafkaInternalFromConsumerMessage(structuredConsumerMessage))
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
 		Err = http.WriteRequest(context.TODO(), M, Req)
 	}
@@ -64,7 +64,7 @@ func BenchmarkStructured(b *testing.B) {
 
 func BenchmarkBinary(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		M = kafka_sarama.NewMessageFromConsumerMessage(binaryConsumerMessage)
+		M = kafka_sarama.NewMessageFromConsumerMessage(kafka_sarama.NewKafkaInternalFromConsumerMessage(binaryConsumerMessage))
 		Req, Err = nethttp.NewRequest("POST", "http://localhost", nil)
 		Err = http.WriteRequest(context.TODO(), M, Req)
 	}


### PR DESCRIPTION
refer to the https://github.com/cloudevents/sdk-go/pull/459, in many cases, we want Receiver ack/nack by the event handler result, like this:

```go
c.StartReceiver(ctx, func(ctx context.Context, event cloudevents.Event) protocol.Result {
        // ack or nack by the event handler result
	err := doSomething(event)
	if err != nil {
		return protocol.ResultNACK
	}
	if err == IgnoreError {
	    return protocol.ResultACK
	}
	return err
})
```

This merge request is the implement for kafka.