### PR TITLE
Fix v1 gomodule path

### DIFF
--- a/v1/alias.go
+++ b/v1/alias.go
@@ -4,12 +4,12 @@ package v1
 // the number of imports for simple HTTP clients.
 
 import (
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/client"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/client"
+	"github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Client

--- a/v1/binding/buffering/acks_before_finish_message.go
+++ b/v1/binding/buffering/acks_before_finish_message.go
@@ -3,7 +3,7 @@ package buffering
 import (
 	"sync/atomic"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 type acksMessage struct {

--- a/v1/binding/buffering/acks_before_finish_message_test.go
+++ b/v1/binding/buffering/acks_before_finish_message_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestWithAcksBeforeFinish(t *testing.T) {

--- a/v1/binding/buffering/binary_buffer_message.go
+++ b/v1/binding/buffering/binary_buffer_message.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/valyala/bytebufferpool"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
 )
 
 var binaryMessagePool bytebufferpool.Pool

--- a/v1/binding/buffering/copy_message.go
+++ b/v1/binding/buffering/copy_message.go
@@ -3,7 +3,7 @@ package buffering
 import (
 	"context"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 // BufferMessage does the same than CopyMessage and it also bounds the original Message

--- a/v1/binding/buffering/copy_message_benchmark_test.go
+++ b/v1/binding/buffering/copy_message_benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/binding/test"
+	"github.com/cloudevents/sdk-go/binding/test"
 )
 
 var err error

--- a/v1/binding/buffering/copy_message_test.go
+++ b/v1/binding/buffering/copy_message_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
+	"github.com/cloudevents/sdk-go/cloudevents"
 )
 
 type copyMessageTestCase struct {

--- a/v1/binding/buffering/struct_buffer_message.go
+++ b/v1/binding/buffering/struct_buffer_message.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/valyala/bytebufferpool"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
 )
 
 var structMessagePool bytebufferpool.Pool

--- a/v1/binding/event_message.go
+++ b/v1/binding/event_message.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 )
 
 // EventMessage type-converts a cloudevents.Event object to implement Message.

--- a/v1/binding/example_implementing_test.go
+++ b/v1/binding/example_implementing_test.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // ExMessage is a json.RawMessage, a byte slice containing a JSON encoded event.

--- a/v1/binding/example_using_test.go
+++ b/v1/binding/example_using_test.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/client"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/client"
 )
 
 const count = 3 // Example ends after this many events.

--- a/v1/binding/finish_message_test.go
+++ b/v1/binding/finish_message_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestWithFinish(t *testing.T) {

--- a/v1/binding/format/format.go
+++ b/v1/binding/format/format.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"strings"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 )
 
 // Format marshals and unmarshals structured events to bytes.

--- a/v1/binding/format/format_test.go
+++ b/v1/binding/format/format_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/binding/format"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestJSON(t *testing.T) {

--- a/v1/binding/interfaces.go
+++ b/v1/binding/interfaces.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
 )
 
 // Encoding enum specifies the type of encodings supported by binding interfaces

--- a/v1/binding/spec/attributes.go
+++ b/v1/binding/spec/attributes.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Kind is a version-independent identifier for a CloudEvent context attribute.

--- a/v1/binding/spec/attributes_test.go
+++ b/v1/binding/spec/attributes_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	"github.com/cloudevents/sdk-go/binding/spec"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )

--- a/v1/binding/spec/spec.go
+++ b/v1/binding/spec/spec.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Version provides meta-data for a single spec-version.

--- a/v1/binding/spec/spec_test.go
+++ b/v1/binding/spec/spec_test.go
@@ -3,8 +3,8 @@ package spec_test
 import (
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/v1/binding/test/benchmark.go
+++ b/v1/binding/test/benchmark.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 // Simple send/receive benchmark.

--- a/v1/binding/test/events.go
+++ b/v1/binding/test/events.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func strptr(s string) *string { return &s }

--- a/v1/binding/test/mock_binary_message.go
+++ b/v1/binding/test/mock_binary_message.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"io/ioutil"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
 )
 
 // MockBinaryMessage implements a binary-mode message as a simple struct.

--- a/v1/binding/test/mock_structured_message.go
+++ b/v1/binding/test/mock_structured_message.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"io/ioutil"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
 )
 
 // MockStructuredMessage implements a structured-mode message as a simple struct.

--- a/v1/binding/test/test.go
+++ b/v1/binding/test/test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // NameOf generates a string test name from x, esp. for ce.Event and ce.Message.

--- a/v1/binding/test/test_test.go
+++ b/v1/binding/test/test_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
 )
 
 func TestEvent(t *testing.T) {

--- a/v1/binding/test/transcoder.go
+++ b/v1/binding/test/transcoder.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 type TranscoderTestArgs struct {

--- a/v1/binding/to_event.go
+++ b/v1/binding/to_event.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"io"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 var ErrCannotConvertToEvent = errors.New("cannot convert message to event")

--- a/v1/binding/to_event_test.go
+++ b/v1/binding/to_event_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
+	"github.com/cloudevents/sdk-go/cloudevents"
 )
 
 type toEventTestCase struct {

--- a/v1/binding/transcoder.go
+++ b/v1/binding/transcoder.go
@@ -1,6 +1,6 @@
 package binding
 
-import ce "github.com/cloudevents/sdk-go/v1"
+import ce "github.com/cloudevents/sdk-go"
 
 // Implements a transformation process while transferring the event from the Message implementation
 // to the provided encoder

--- a/v1/binding/transcoder/add_metadata.go
+++ b/v1/binding/transcoder/add_metadata.go
@@ -1,9 +1,9 @@
 package transcoder
 
 import (
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
 )
 
 // Add cloudevents attribute (if missing) during the encoding process

--- a/v1/binding/transcoder/add_metadata_test.go
+++ b/v1/binding/transcoder/add_metadata_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/binding/test"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestAddAttribute(t *testing.T) {

--- a/v1/binding/transcoder/delete_metadata.go
+++ b/v1/binding/transcoder/delete_metadata.go
@@ -1,9 +1,9 @@
 package transcoder
 
 import (
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
 )
 
 // Delete cloudevents attribute during the encoding process

--- a/v1/binding/transcoder/delete_metadata_test.go
+++ b/v1/binding/transcoder/delete_metadata_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/binding/test"
 )
 
 func TestDeleteAttribute(t *testing.T) {

--- a/v1/binding/transcoder/update_metadata.go
+++ b/v1/binding/transcoder/update_metadata.go
@@ -1,9 +1,9 @@
 package transcoder
 
 import (
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
 )
 
 // Update cloudevents attribute (if present) using the provided function during the encoding process

--- a/v1/binding/transcoder/update_metadata_test.go
+++ b/v1/binding/transcoder/update_metadata_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/binding/test"
 )
 
 func TestUpdateAttribute(t *testing.T) {

--- a/v1/binding/transcoder/version.go
+++ b/v1/binding/transcoder/version.go
@@ -1,9 +1,9 @@
 package transcoder
 
 import (
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 )
 
 // Returns a TransformerFactory that converts the event context version to the specified one.

--- a/v1/binding/transcoder/version_test.go
+++ b/v1/binding/transcoder/version_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/binding/test"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestVersionTranscoder(t *testing.T) {

--- a/v1/binding/translate.go
+++ b/v1/binding/translate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	ce "github.com/cloudevents/sdk-go/v1"
+	ce "github.com/cloudevents/sdk-go"
 )
 
 const (

--- a/v1/binding/transport.go
+++ b/v1/binding/transport.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"io"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // BindingTransport implements transport.Transport using a Sender and Receiver.

--- a/v1/binding/transport_test.go
+++ b/v1/binding/transport_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
 )
 
 func TestTransportSend(t *testing.T) {

--- a/v1/bindings/amqp/amqp_test.go
+++ b/v1/bindings/amqp/amqp_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"pack.ag/amqp"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 )
 
 func TestSendSkipBinary(t *testing.T) {

--- a/v1/bindings/amqp/encoder.go
+++ b/v1/bindings/amqp/encoder.go
@@ -7,10 +7,10 @@ import (
 
 	"pack.ag/amqp"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Fill the provided amqpMessage with the message m.

--- a/v1/bindings/amqp/message.go
+++ b/v1/bindings/amqp/message.go
@@ -9,9 +9,9 @@ import (
 
 	"pack.ag/amqp"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
 )
 
 const prefix = "cloudEvents:" // Name prefix for AMQP properties that hold CE attributes.

--- a/v1/bindings/amqp/option.go
+++ b/v1/bindings/amqp/option.go
@@ -1,6 +1,6 @@
 package amqp
 
-import "github.com/cloudevents/sdk-go/v1/binding"
+import "github.com/cloudevents/sdk-go/binding"
 
 type SenderOptionFunc func(sender *Sender)
 

--- a/v1/bindings/amqp/receiver.go
+++ b/v1/bindings/amqp/receiver.go
@@ -3,7 +3,7 @@ package amqp
 import (
 	"context"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 	"pack.ag/amqp"
 )
 

--- a/v1/bindings/amqp/sender.go
+++ b/v1/bindings/amqp/sender.go
@@ -5,7 +5,7 @@ import (
 
 	"pack.ag/amqp"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 // Sender wraps an amqp.Sender as a binding.Sender

--- a/v1/bindings/amqp/types.go
+++ b/v1/bindings/amqp/types.go
@@ -1,6 +1,6 @@
 package amqp
 
-import "github.com/cloudevents/sdk-go/v1/cloudevents/types"
+import "github.com/cloudevents/sdk-go/cloudevents/types"
 
 func safeAMQPPropertiesUnwrap(val interface{}) (interface{}, error) {
 	v, err := types.Validate(val)

--- a/v1/bindings/http/http_test.go
+++ b/v1/bindings/http/http_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	"github.com/cloudevents/sdk-go/v1/bindings/http"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
+	"github.com/cloudevents/sdk-go/bindings/http"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 )
 
 func TestSendSkipBinary(t *testing.T) {

--- a/v1/bindings/http/message.go
+++ b/v1/bindings/http/message.go
@@ -6,9 +6,9 @@ import (
 	nethttp "net/http"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
 )
 
 const prefix = "Ce-"

--- a/v1/bindings/http/option.go
+++ b/v1/bindings/http/option.go
@@ -1,6 +1,6 @@
 package http
 
-import "github.com/cloudevents/sdk-go/v1/binding"
+import "github.com/cloudevents/sdk-go/binding"
 
 type SenderOptionFunc func(sender *Sender)
 

--- a/v1/bindings/http/receiver.go
+++ b/v1/bindings/http/receiver.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	nethttp "net/http"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 type msgErr struct {

--- a/v1/bindings/http/request_encoder.go
+++ b/v1/bindings/http/request_encoder.go
@@ -6,10 +6,10 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Fill the provided req with the message m.

--- a/v1/bindings/http/response_encoder.go
+++ b/v1/bindings/http/response_encoder.go
@@ -6,10 +6,10 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Fill the provided res with the message m.

--- a/v1/bindings/http/response_encoder_test.go
+++ b/v1/bindings/http/response_encoder_test.go
@@ -8,10 +8,10 @@ import (
 
 	"net/http"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 )
 
 func TestEncodeHttpResponse(t *testing.T) {

--- a/v1/bindings/http/sender.go
+++ b/v1/bindings/http/sender.go
@@ -7,7 +7,7 @@ import (
 	nethttp "net/http"
 	"net/url"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 type Sender struct {

--- a/v1/bindings/kafka_sarama/kafka_test.go
+++ b/v1/bindings/kafka_sarama/kafka_test.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/Shopify/sarama"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
 )
 
 const (

--- a/v1/bindings/kafka_sarama/message.go
+++ b/v1/bindings/kafka_sarama/message.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"strings"
 
-	ce "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
+	ce "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
 
 	"github.com/Shopify/sarama"
 )

--- a/v1/bindings/kafka_sarama/message_benchmark_test.go
+++ b/v1/bindings/kafka_sarama/message_benchmark_test.go
@@ -6,9 +6,9 @@ import (
 	"context"
 	"testing"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/bindings/kafka_sarama"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/bindings/kafka_sarama"
 )
 
 // Avoid DCE

--- a/v1/bindings/kafka_sarama/option.go
+++ b/v1/bindings/kafka_sarama/option.go
@@ -1,6 +1,6 @@
 package kafka_sarama
 
-import "github.com/cloudevents/sdk-go/v1/binding"
+import "github.com/cloudevents/sdk-go/binding"
 
 type SenderOptionFunc func(sender *Sender)
 

--- a/v1/bindings/kafka_sarama/producer_message_encoder.go
+++ b/v1/bindings/kafka_sarama/producer_message_encoder.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/Shopify/sarama"
 
-	ce "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/format"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/format"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 const (

--- a/v1/bindings/kafka_sarama/producer_message_encoder_benchmark_test.go
+++ b/v1/bindings/kafka_sarama/producer_message_encoder_benchmark_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/Shopify/sarama"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	"github.com/cloudevents/sdk-go/v1/bindings/kafka_sarama"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
+	"github.com/cloudevents/sdk-go/bindings/kafka_sarama"
 )
 
 // Avoid DCE

--- a/v1/bindings/kafka_sarama/producer_message_encoder_test.go
+++ b/v1/bindings/kafka_sarama/producer_message_encoder_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/require"
 
-	cloudevents "github.com/cloudevents/sdk-go/v1"
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/test"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 )
 
 func TestEncodeKafkaProducerMessage(t *testing.T) {

--- a/v1/bindings/kafka_sarama/receiver.go
+++ b/v1/bindings/kafka_sarama/receiver.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Shopify/sarama"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 type msgErr struct {

--- a/v1/bindings/kafka_sarama/sender.go
+++ b/v1/bindings/kafka_sarama/sender.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Shopify/sarama"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
+	"github.com/cloudevents/sdk-go/binding"
 )
 
 type Sender struct {

--- a/v1/cloudevents/client/client.go
+++ b/v1/cloudevents/client/client.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/extensions"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/extensions"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/http"
 	"go.opencensus.io/trace"
 )
 

--- a/v1/cloudevents/client/client_test.go
+++ b/v1/cloudevents/client/client_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/client"
-	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/client"
+	cehttp "github.com/cloudevents/sdk-go/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/lightstep/tracecontext.go/traceparent"
 	"go.opencensus.io/trace"
 

--- a/v1/cloudevents/client/defaulters.go
+++ b/v1/cloudevents/client/defaulters.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/google/uuid"
 )
 

--- a/v1/cloudevents/client/defaulters_test.go
+++ b/v1/cloudevents/client/defaulters_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/client/observability.go
+++ b/v1/cloudevents/client/observability.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"

--- a/v1/cloudevents/client/options_test.go
+++ b/v1/cloudevents/client/options_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/client/receiver.go
+++ b/v1/cloudevents/client/receiver.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // Receive is the signature of a fn to be invoked for incoming cloudevents.

--- a/v1/cloudevents/client/receiver_test.go
+++ b/v1/cloudevents/client/receiver_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/content_type_test.go
+++ b/v1/cloudevents/content_type_test.go
@@ -3,7 +3,7 @@ package cloudevents_test
 import (
 	"testing"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/context/context_test.go
+++ b/v1/cloudevents/context/context_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/data_content_encoding_test.go
+++ b/v1/cloudevents/data_content_encoding_test.go
@@ -3,7 +3,7 @@ package cloudevents_test
 import (
 	"testing"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/datacodec/codec.go
+++ b/v1/cloudevents/datacodec/codec.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/datacodec/json"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/datacodec/text"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/datacodec/xml"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/datacodec/json"
+	"github.com/cloudevents/sdk-go/cloudevents/datacodec/text"
+	"github.com/cloudevents/sdk-go/cloudevents/datacodec/xml"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 )
 
 // Decoder is the expected function signature for decoding `in` to `out`. What

--- a/v1/cloudevents/datacodec/codec_test.go
+++ b/v1/cloudevents/datacodec/codec_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/datacodec"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/datacodec"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/datacodec/json/data.go
+++ b/v1/cloudevents/datacodec/json/data.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 )
 
 // Decode takes `in` as []byte, or base64 string, normalizes in to unquoted and

--- a/v1/cloudevents/datacodec/json/data_test.go
+++ b/v1/cloudevents/datacodec/json/data_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	cej "github.com/cloudevents/sdk-go/v1/cloudevents/datacodec/json"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	cej "github.com/cloudevents/sdk-go/cloudevents/datacodec/json"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/datacodec/json/observability.go
+++ b/v1/cloudevents/datacodec/json/observability.go
@@ -1,7 +1,7 @@
 package json
 
 import (
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 )

--- a/v1/cloudevents/datacodec/observability.go
+++ b/v1/cloudevents/datacodec/observability.go
@@ -1,7 +1,7 @@
 package datacodec
 
 import (
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 )

--- a/v1/cloudevents/datacodec/text/text_test.go
+++ b/v1/cloudevents/datacodec/text/text_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/datacodec/text"
+	"github.com/cloudevents/sdk-go/cloudevents/datacodec/text"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/v1/cloudevents/datacodec/xml/data.go
+++ b/v1/cloudevents/datacodec/xml/data.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 )
 
 // Decode takes `in` as []byte, or base64 string, normalizes in to unquoted and

--- a/v1/cloudevents/datacodec/xml/data_test.go
+++ b/v1/cloudevents/datacodec/xml/data_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	cex "github.com/cloudevents/sdk-go/v1/cloudevents/datacodec/xml"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	cex "github.com/cloudevents/sdk-go/cloudevents/datacodec/xml"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/datacodec/xml/observability.go
+++ b/v1/cloudevents/datacodec/xml/observability.go
@@ -1,7 +1,7 @@
 package xml
 
 import (
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 )

--- a/v1/cloudevents/event_data.go
+++ b/v1/cloudevents/event_data.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/datacodec"
+	"github.com/cloudevents/sdk-go/cloudevents/datacodec"
 )
 
 // Data is special. Break it out into it's own file.

--- a/v1/cloudevents/event_data_test.go
+++ b/v1/cloudevents/event_data_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/event_marshal.go
+++ b/v1/cloudevents/event_marshal.go
@@ -11,7 +11,7 @@ import (
 
 	errors2 "github.com/pkg/errors"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 )
 
 // MarshalJSON implements a custom json marshal method used when this type is

--- a/v1/cloudevents/event_marshal_test.go
+++ b/v1/cloudevents/event_marshal_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 //type DataExample struct {

--- a/v1/cloudevents/event_observability.go
+++ b/v1/cloudevents/event_observability.go
@@ -3,7 +3,7 @@ package cloudevents
 import (
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 )

--- a/v1/cloudevents/event_reader_writer_test.go
+++ b/v1/cloudevents/event_reader_writer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/event_test.go
+++ b/v1/cloudevents/event_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestGetDataContentType(t *testing.T) {

--- a/v1/cloudevents/eventcontext_test.go
+++ b/v1/cloudevents/eventcontext_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )

--- a/v1/cloudevents/eventcontext_v01.go
+++ b/v1/cloudevents/eventcontext_v01.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 const (

--- a/v1/cloudevents/eventcontext_v01_test.go
+++ b/v1/cloudevents/eventcontext_v01_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/eventcontext_v01_writer.go
+++ b/v1/cloudevents/eventcontext_v01_writer.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Adhere to EventContextWriter

--- a/v1/cloudevents/eventcontext_v02.go
+++ b/v1/cloudevents/eventcontext_v02.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 const (

--- a/v1/cloudevents/eventcontext_v02_test.go
+++ b/v1/cloudevents/eventcontext_v02_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/eventcontext_v02_writer.go
+++ b/v1/cloudevents/eventcontext_v02_writer.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Adhere to EventContextWriter

--- a/v1/cloudevents/eventcontext_v03.go
+++ b/v1/cloudevents/eventcontext_v03.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 const (

--- a/v1/cloudevents/eventcontext_v03_test.go
+++ b/v1/cloudevents/eventcontext_v03_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/eventcontext_v03_writer.go
+++ b/v1/cloudevents/eventcontext_v03_writer.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Adhere to EventContextWriter

--- a/v1/cloudevents/eventcontext_v1.go
+++ b/v1/cloudevents/eventcontext_v1.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // WIP: AS OF SEP 20, 2019

--- a/v1/cloudevents/eventcontext_v1_test.go
+++ b/v1/cloudevents/eventcontext_v1_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/eventcontext_v1_writer.go
+++ b/v1/cloudevents/eventcontext_v1_writer.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Adhere to EventContextWriter

--- a/v1/cloudevents/extensions/distributed_tracing_extension.go
+++ b/v1/cloudevents/extensions/distributed_tracing_extension.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/lightstep/tracecontext.go/traceparent"
 	"github.com/lightstep/tracecontext.go/tracestate"
 	"go.opencensus.io/trace"

--- a/v1/cloudevents/extensions/distributed_tracing_extension_test.go
+++ b/v1/cloudevents/extensions/distributed_tracing_extension_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/extensions"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/extensions"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/tracestate"

--- a/v1/cloudevents/transport/amqp/message.go
+++ b/v1/cloudevents/transport/amqp/message.go
@@ -3,7 +3,7 @@ package amqp
 import (
 	"encoding/json"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // type check that this transport message impl matches the contract

--- a/v1/cloudevents/transport/amqp/transport.go
+++ b/v1/cloudevents/transport/amqp/transport.go
@@ -5,12 +5,12 @@ import (
 
 	"pack.ag/amqp"
 
-	"github.com/cloudevents/sdk-go/v1/binding"
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/binding/transcoder"
-	bindings_amqp "github.com/cloudevents/sdk-go/v1/bindings/amqp"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/binding"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/binding/transcoder"
+	bindings_amqp "github.com/cloudevents/sdk-go/bindings/amqp"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // Transport adheres to transport.Transport.

--- a/v1/cloudevents/transport/amqp/transport_test.go
+++ b/v1/cloudevents/transport/amqp/transport_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cloudevents/sdk-go/v1/binding/spec"
-	"github.com/cloudevents/sdk-go/v1/binding/test"
-	ce "github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/amqp"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/binding/spec"
+	"github.com/cloudevents/sdk-go/binding/test"
+	ce "github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/amqp"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // Requires an external AMQP broker or router, skip if not available.

--- a/v1/cloudevents/transport/codec.go
+++ b/v1/cloudevents/transport/codec.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents"
 )
 
 // Codec is the interface for transport codecs to convert between transport

--- a/v1/cloudevents/transport/http/codec.go
+++ b/v1/cloudevents/transport/http/codec.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // Codec is the wrapper for all versions of codecs supported by the http

--- a/v1/cloudevents/transport/http/codec_structured.go
+++ b/v1/cloudevents/transport/http/codec_structured.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // CodecStructured represents an structured http transport codec for all versions.

--- a/v1/cloudevents/transport/http/codec_test.go
+++ b/v1/cloudevents/transport/http/codec_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/http/codec_v01.go
+++ b/v1/cloudevents/transport/http/codec_v01.go
@@ -8,11 +8,11 @@ import (
 	"net/textproto"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // CodecV01 represents a http transport codec that uses CloudEvents spec v0.1

--- a/v1/cloudevents/transport/http/codec_v01_test.go
+++ b/v1/cloudevents/transport/http/codec_v01_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/http/codec_v02.go
+++ b/v1/cloudevents/transport/http/codec_v02.go
@@ -8,11 +8,11 @@ import (
 	"net/textproto"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // CodecV02 represents a http transport codec that uses CloudEvents spec v0.2

--- a/v1/cloudevents/transport/http/codec_v02_test.go
+++ b/v1/cloudevents/transport/http/codec_v02_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/http/codec_v03.go
+++ b/v1/cloudevents/transport/http/codec_v03.go
@@ -8,11 +8,11 @@ import (
 	"net/textproto"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // CodecV03 represents a http transport codec that uses CloudEvents spec v0.3

--- a/v1/cloudevents/transport/http/codec_v03_test.go
+++ b/v1/cloudevents/transport/http/codec_v03_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/http/codec_v1.go
+++ b/v1/cloudevents/transport/http/codec_v1.go
@@ -7,11 +7,11 @@ import (
 	"net/textproto"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 // CodecV1 represents a http transport codec that uses CloudEvents spec v1.0

--- a/v1/cloudevents/transport/http/codec_v1_test.go
+++ b/v1/cloudevents/transport/http/codec_v1_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestCodecV1_Encode(t *testing.T) {

--- a/v1/cloudevents/transport/http/context_test.go
+++ b/v1/cloudevents/transport/http/context_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )

--- a/v1/cloudevents/transport/http/encoding.go
+++ b/v1/cloudevents/transport/http/encoding.go
@@ -3,8 +3,8 @@ package http
 import (
 	"context"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
 )
 
 // Encoding to use for HTTP transport.

--- a/v1/cloudevents/transport/http/message.go
+++ b/v1/cloudevents/transport/http/message.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // type check that this transport message impl matches the contract

--- a/v1/cloudevents/transport/http/message_test.go
+++ b/v1/cloudevents/transport/http/message_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
+	cehttp "github.com/cloudevents/sdk-go/cloudevents/transport/http"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/http/observability.go
+++ b/v1/cloudevents/transport/http/observability.go
@@ -3,7 +3,7 @@ package http
 import (
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 )

--- a/v1/cloudevents/transport/http/options_test.go
+++ b/v1/cloudevents/transport/http/options_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )

--- a/v1/cloudevents/transport/http/transport.go
+++ b/v1/cloudevents/transport/http/transport.go
@@ -17,10 +17,10 @@ import (
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"go.uber.org/zap"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/observability"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/observability"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // Transport adheres to transport.Transport.

--- a/v1/cloudevents/transport/http/transport_test.go
+++ b/v1/cloudevents/transport/http/transport_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cehttp "github.com/cloudevents/sdk-go/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/v1/cloudevents/transport/nats/codec.go
+++ b/v1/cloudevents/transport/nats/codec.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 type Codec struct {

--- a/v1/cloudevents/transport/nats/codec_structured.go
+++ b/v1/cloudevents/transport/nats/codec_structured.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // CodecStructured represents an structured http transport codec for all versions.

--- a/v1/cloudevents/transport/nats/codec_test.go
+++ b/v1/cloudevents/transport/nats/codec_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/nats"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/nats"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/nats/codec_v02.go
+++ b/v1/cloudevents/transport/nats/codec_v02.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 type CodecV02 struct {

--- a/v1/cloudevents/transport/nats/codec_v02_test.go
+++ b/v1/cloudevents/transport/nats/codec_v02_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/nats"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/nats"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/nats/codec_v03.go
+++ b/v1/cloudevents/transport/nats/codec_v03.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 type CodecV03 struct {

--- a/v1/cloudevents/transport/nats/codec_v03_test.go
+++ b/v1/cloudevents/transport/nats/codec_v03_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/nats"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/nats"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestCodecV03_Encode(t *testing.T) {

--- a/v1/cloudevents/transport/nats/codec_v1.go
+++ b/v1/cloudevents/transport/nats/codec_v1.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 type CodecV1 struct {

--- a/v1/cloudevents/transport/nats/codec_v1_test.go
+++ b/v1/cloudevents/transport/nats/codec_v1_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/nats"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/nats"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestCodecV1_Encode(t *testing.T) {

--- a/v1/cloudevents/transport/nats/message.go
+++ b/v1/cloudevents/transport/nats/message.go
@@ -3,7 +3,7 @@ package nats
 import (
 	"encoding/json"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // type check that this transport message impl matches the contract

--- a/v1/cloudevents/transport/nats/transport.go
+++ b/v1/cloudevents/transport/nats/transport.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	context2 "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	context2 "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 	"github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 )

--- a/v1/cloudevents/transport/pubsub/codec.go
+++ b/v1/cloudevents/transport/pubsub/codec.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 type Codec struct {

--- a/v1/cloudevents/transport/pubsub/codec_structured.go
+++ b/v1/cloudevents/transport/pubsub/codec_structured.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // CodecStructured represents an structured http transport codec for all versions.

--- a/v1/cloudevents/transport/pubsub/codec_test.go
+++ b/v1/cloudevents/transport/pubsub/codec_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/pubsub"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/pubsub"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/pubsub/codec_v03.go
+++ b/v1/cloudevents/transport/pubsub/codec_v03.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 const (

--- a/v1/cloudevents/transport/pubsub/codec_v03_test.go
+++ b/v1/cloudevents/transport/pubsub/codec_v03_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/pubsub"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/pubsub"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/transport/pubsub/codec_v1.go
+++ b/v1/cloudevents/transport/pubsub/codec_v1.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 type CodecV1 struct {

--- a/v1/cloudevents/transport/pubsub/codec_v1_test.go
+++ b/v1/cloudevents/transport/pubsub/codec_v1_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/pubsub"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/pubsub"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 )
 
 func TestCodecV1_Encode(t *testing.T) {

--- a/v1/cloudevents/transport/pubsub/encoding.go
+++ b/v1/cloudevents/transport/pubsub/encoding.go
@@ -3,7 +3,7 @@ package pubsub
 import (
 	"context"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents"
 )
 
 // Encoding to use for pubsub transport.

--- a/v1/cloudevents/transport/pubsub/internal/connection.go
+++ b/v1/cloudevents/transport/pubsub/internal/connection.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	pscontext "github.com/cloudevents/sdk-go/v1/cloudevents/transport/pubsub/context"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	pscontext "github.com/cloudevents/sdk-go/cloudevents/transport/pubsub/context"
 )
 
 // Connection acts as either a pubsub topic or a pubsub subscription .

--- a/v1/cloudevents/transport/pubsub/message.go
+++ b/v1/cloudevents/transport/pubsub/message.go
@@ -3,7 +3,7 @@ package pubsub
 import (
 	"encoding/json"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
 )
 
 // type check that this transport message impl matches the contract

--- a/v1/cloudevents/transport/pubsub/transport.go
+++ b/v1/cloudevents/transport/pubsub/transport.go
@@ -11,10 +11,10 @@ import (
 
 	"cloud.google.com/go/pubsub"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
-	cecontext "github.com/cloudevents/sdk-go/v1/cloudevents/context"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport"
-	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/pubsub/internal"
+	"github.com/cloudevents/sdk-go/cloudevents"
+	cecontext "github.com/cloudevents/sdk-go/cloudevents/context"
+	"github.com/cloudevents/sdk-go/cloudevents/transport"
+	"github.com/cloudevents/sdk-go/cloudevents/transport/pubsub/internal"
 )
 
 // Transport adheres to transport.Transport.

--- a/v1/cloudevents/transport/transport.go
+++ b/v1/cloudevents/transport/transport.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"context"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents"
+	"github.com/cloudevents/sdk-go/cloudevents"
 )
 
 // Transport is the interface for transport sender to send the converted Message

--- a/v1/cloudevents/types/allocate_test.go
+++ b/v1/cloudevents/types/allocate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/types/timestamp_test.go
+++ b/v1/cloudevents/types/timestamp_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/v1/cloudevents/types/uri_test.go
+++ b/v1/cloudevents/types/uri_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/types/uriref_test.go
+++ b/v1/cloudevents/types/uriref_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/types/urlref_test.go
+++ b/v1/cloudevents/types/urlref_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/v1/cloudevents/types/value_test.go
+++ b/v1/cloudevents/types/value_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v1/cloudevents/types"
+	"github.com/cloudevents/sdk-go/cloudevents/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/v1/go.mod
+++ b/v1/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudevents/sdk-go/v1
+module github.com/cloudevents/sdk-go
 
 require (
 	cloud.google.com/go v0.40.0


### PR DESCRIPTION
According to https://github.com/golang/go/wiki/Modules#semantic-import-versioning:
```
If the module is version v0 or v1, do not include the major version in either the module path or the import path.
```
More details can be found in https://github.com/golang/go/issues/24301#issuecomment-371228664.

If the module path is `github.com/cloudevents/sdk-go/v1`, we won't be able to switch knative/eventing to use Go modules as there will be an error:
```
github.com/cloudevents/sdk-go/v1/cloudevents: module github.com/cloudevents/sdk-go@latest found (v1.1.2), but does not contain package github.com/cloudevents/sdk-go/v1/cloudevents
```
And it seems there is no workaround.

This PR removes `v1` from the module path, and update all import paths.