### PR TITLE
V2 pubsub protocol: don't return error if there is no error

### DIFF
--- a/v2/protocol/pubsub/protocol.go
+++ b/v2/protocol/pubsub/protocol.go
@@ -233,6 +233,10 @@ func (t *Protocol) OpenInbound(ctx context.Context) error {
 	close(quit)
 	close(errc)
 
+	if errs == nil {
+		return nil
+	}
+
 	return errors.New(strings.Join(errs, "\n"))
 }
 


### PR DESCRIPTION
Fixes: https://github.com/cloudevents/sdk-go/issues/470