### PR TITLE
Pubsub Topic and Subscription object creation can be retried

### DIFF
--- a/v1/cloudevents/transport/pubsub/internal/connection.go
+++ b/v1/cloudevents/transport/pubsub/internal/connection.go
@@ -12,6 +12,20 @@ import (
 	pscontext "github.com/cloudevents/sdk-go/v1/cloudevents/transport/pubsub/context"
 )
 
+type topicInfo struct {
+	topic      *pubsub.Topic
+	wasCreated bool
+	once       sync.Once
+	err        error
+}
+
+type subInfo struct {
+	sub        *pubsub.Subscription
+	wasCreated bool
+	once       sync.Once
+	err        error
+}
+
 // Connection acts as either a pubsub topic or a pubsub subscription .
 type Connection struct {
 	// AllowCreateTopic controls if the transport can create a topic if it does
@@ -26,24 +40,29 @@ type Connection struct {
 
 	Client *pubsub.Client
 
-	TopicID         string
-	topic           *pubsub.Topic
-	topicWasCreated bool
-	topicOnce       sync.Once
+	TopicID   string
+	topicInfo *topicInfo
 
 	SubscriptionID string
-	sub            *pubsub.Subscription
-	subWasCreated  bool
-	subOnce        sync.Once
+	subInfo        *subInfo
+
+	// Held when reading or writing topicInfo and subInfo. This is only
+	// held while reading the pointer, the structure internally manage
+	// their own internal concurrency.  This also controls
+	// the update of AckDeadline and RetentionDuration if those are
+	// nil on start.
+	initLock sync.Mutex
 
 	// ReceiveSettings is used to configure Pubsub pull subscription.
 	ReceiveSettings *pubsub.ReceiveSettings
 
 	// AckDeadline is Pub/Sub AckDeadline.
 	// Default is 30 seconds.
+	// This can only be set prior to first call of any function.
 	AckDeadline *time.Duration
 	// RetentionDuration is Pub/Sub RetentionDuration.
 	// Default is 25 hours.
+	// This can only be set prior to first call of any function.
 	RetentionDuration *time.Duration
 }
 
@@ -63,129 +82,210 @@ var DefaultReceiveSettings = pubsub.ReceiveSettings{
 	Synchronous:   false,
 }
 
-func (c *Connection) getOrCreateTopic(ctx context.Context) (*pubsub.Topic, error) {
-	var err error
-	c.topicOnce.Do(func() {
+func (c *Connection) getOrCreateTopicInfo(ctx context.Context, getAlreadyOpenOnly bool) (*topicInfo, error) {
+	// See if a topic has already been created or is in the process of being created.
+	// If not, start creating one.
+	c.initLock.Lock()
+	ti := c.topicInfo
+	if ti == nil && !getAlreadyOpenOnly {
+		c.topicInfo = &topicInfo{}
+		ti = c.topicInfo
+	}
+	c.initLock.Unlock()
+	if ti == nil {
+		return nil, fmt.Errorf("no already open topic")
+	}
+
+	// Make sure the topic structure is initialized at most once.
+	ti.once.Do(func() {
 		var ok bool
 		// Load the topic.
 		topic := c.Client.Topic(c.TopicID)
-		ok, err = topic.Exists(ctx)
-		if err != nil {
+		ok, ti.err = topic.Exists(ctx)
+		if ti.err != nil {
 			return
 		}
 		// If the topic does not exist, create a new topic with the given name.
 		if !ok {
 			if !c.AllowCreateTopic {
-				err = fmt.Errorf("transport not allowed to create topic %q", c.TopicID)
+				ti.err = fmt.Errorf("transport not allowed to create topic %q", c.TopicID)
 				return
 			}
-			topic, err = c.Client.CreateTopic(ctx, c.TopicID)
-			if err != nil {
+			topic, ti.err = c.Client.CreateTopic(ctx, c.TopicID)
+			if ti.err != nil {
 				return
 			}
-			c.topicWasCreated = true
+			ti.wasCreated = true
 		}
 		// Success.
-		c.topic = topic
+		ti.topic = topic
 	})
-	if c.topic == nil {
-		return nil, fmt.Errorf("unable to create topic %q, %v", c.TopicID, err)
+	if ti.topic == nil {
+		// Initialization failed, remove this attempt so that future callers
+		// will try to initialize again.
+		c.initLock.Lock()
+		if c.topicInfo == ti {
+			c.topicInfo = nil
+		}
+		c.initLock.Unlock()
+
+		return nil, fmt.Errorf("unable to get or create topic %q, %v", c.TopicID, ti.err)
 	}
-	return c.topic, err
+	return ti, nil
+}
+
+func (c *Connection) getOrCreateTopic(ctx context.Context, getAlreadyOpenOnly bool) (*pubsub.Topic, error) {
+	ti, err := c.getOrCreateTopicInfo(ctx, getAlreadyOpenOnly)
+	if ti != nil {
+		return ti.topic, nil
+	} else {
+		return nil, err
+	}
 }
 
 // DeleteTopic
 func (c *Connection) DeleteTopic(ctx context.Context) error {
-	if !c.topicWasCreated {
+	ti, err := c.getOrCreateTopicInfo(ctx, true)
+
+	if err != nil {
+		return errors.New("topic not open")
+	}
+	if !ti.wasCreated {
 		return errors.New("topic was not created by pubsub transport")
 	}
-	if err := c.topic.Delete(ctx); err != nil {
+	if err := ti.topic.Delete(ctx); err != nil {
 		return err
 	}
-	c.topic = nil
-	c.topicWasCreated = false
-	c.topicOnce = sync.Once{}
+
+	ti.topic.Stop()
+
+	c.initLock.Lock()
+	if ti == c.topicInfo {
+		c.topicInfo = nil
+	}
+	c.initLock.Unlock()
+
 	return nil
 }
 
-func (c *Connection) getOrCreateSubscription(ctx context.Context) (*pubsub.Subscription, error) {
-	var err error
-	c.subOnce.Do(func() {
+func (c *Connection) getOrCreateSubscriptionInfo(ctx context.Context, getAlreadyOpenOnly bool) (*subInfo, error) {
+	c.initLock.Lock()
+	// Default the ack deadline and retention duration config.
+	// We only do this once.
+	if c.AckDeadline == nil {
+		ackDeadline := DefaultAckDeadline
+		c.AckDeadline = &(ackDeadline)
+	}
+	if c.RetentionDuration == nil {
+		retentionDuration := DefaultRetentionDuration
+		c.RetentionDuration = &retentionDuration
+	}
+	// See if a subscription has already been created or is in the process of being created.
+	// If not, start creating one.
+	si := c.subInfo
+	if si == nil && !getAlreadyOpenOnly {
+		c.subInfo = &subInfo{}
+		si = c.subInfo
+	}
+	c.initLock.Unlock()
+	if si == nil {
+		return nil, fmt.Errorf("no already open subscription")
+	}
+
+	// Make sure the subscription structure is initialized at most once.
+	si.once.Do(func() {
 		// Load the subscription.
 		var ok bool
 		sub := c.Client.Subscription(c.SubscriptionID)
-		ok, err = sub.Exists(ctx)
-		if err != nil {
+		ok, si.err = sub.Exists(ctx)
+		if si.err != nil {
 			return
 		}
 		// If subscription doesn't exist, create it.
 		if !ok {
 			if !c.AllowCreateSubscription {
-				err = fmt.Errorf("transport not allowed to create subscription %q", c.SubscriptionID)
+				si.err = fmt.Errorf("transport not allowed to create subscription %q", c.SubscriptionID)
 				return
 			}
 
 			// Load the topic.
 			var topic *pubsub.Topic
-			topic, err = c.getOrCreateTopic(ctx)
-			if err != nil {
+			topic, si.err = c.getOrCreateTopic(ctx, false)
+			if si.err != nil {
 				return
-			}
-			// Default the ack deadline and retention duration config.
-			if c.AckDeadline == nil {
-				ackDeadline := DefaultAckDeadline
-				c.AckDeadline = &(ackDeadline)
-			}
-			if c.RetentionDuration == nil {
-				retentionDuration := DefaultRetentionDuration
-				c.RetentionDuration = &retentionDuration
 			}
 
 			// Create a new subscription to the previously created topic
 			// with the given name.
 			// TODO: allow to use push config + allow setting the SubscriptionConfig.
-			sub, err = c.Client.CreateSubscription(ctx, c.SubscriptionID, pubsub.SubscriptionConfig{
+			sub, si.err = c.Client.CreateSubscription(ctx, c.SubscriptionID, pubsub.SubscriptionConfig{
 				Topic:             topic,
 				AckDeadline:       *c.AckDeadline,
 				RetentionDuration: *c.RetentionDuration,
 			})
-			if err != nil {
-				_ = c.Client.Close()
+			if si.err != nil {
 				return
 			}
-			if c.ReceiveSettings == nil {
-				sub.ReceiveSettings = DefaultReceiveSettings
-			} else {
-				sub.ReceiveSettings = *c.ReceiveSettings
-			}
-			c.subWasCreated = true
+
+			si.wasCreated = true
+		}
+		if c.ReceiveSettings == nil {
+			sub.ReceiveSettings = DefaultReceiveSettings
+		} else {
+			sub.ReceiveSettings = *c.ReceiveSettings
 		}
 		// Success.
-		c.sub = sub
+		si.sub = sub
 	})
-	if c.sub == nil {
-		return nil, fmt.Errorf("unable to create sunscription %q, %v", c.SubscriptionID, err)
+	if si.sub == nil {
+		// Initialization failed, remove this attempt so that future callers
+		// will try to initialize again.
+		c.initLock.Lock()
+		if c.subInfo == si {
+			c.subInfo = nil
+		}
+		c.initLock.Unlock()
+		return nil, fmt.Errorf("unable to create subscription %q, %v", c.SubscriptionID, si.err)
 	}
-	return c.sub, err
+	return si, nil
+}
+
+func (c *Connection) getOrCreateSubscription(ctx context.Context, getAlreadyOpenOnly bool) (*pubsub.Subscription, error) {
+	si, err := c.getOrCreateSubscriptionInfo(ctx, getAlreadyOpenOnly)
+	if si != nil {
+		return si.sub, nil
+	} else {
+		return nil, err
+	}
 }
 
 // DeleteSubscription
 func (c *Connection) DeleteSubscription(ctx context.Context) error {
-	if !c.subWasCreated {
+	si, err := c.getOrCreateSubscriptionInfo(ctx, true)
+
+	if err != nil {
+		return errors.New("subscription not open")
+	}
+
+	if !si.wasCreated {
 		return errors.New("subscription was not created by pubsub transport")
 	}
-	if err := c.sub.Delete(ctx); err != nil {
+	if err := si.sub.Delete(ctx); err != nil {
 		return err
 	}
-	c.sub = nil
-	c.subWasCreated = false
-	c.subOnce = sync.Once{}
+
+	c.initLock.Lock()
+	if si == c.subInfo {
+		c.subInfo = nil
+	}
+	c.initLock.Unlock()
+
 	return nil
 }
 
 // Publish
 func (c *Connection) Publish(ctx context.Context, msg *pubsub.Message) (*cloudevents.Event, error) {
-	topic, err := c.getOrCreateTopic(ctx)
+	topic, err := c.getOrCreateTopic(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +298,7 @@ func (c *Connection) Publish(ctx context.Context, msg *pubsub.Message) (*cloudev
 // Start
 // NOTE: This is a blocking call.
 func (c *Connection) Receive(ctx context.Context, fn func(context.Context, *pubsub.Message)) error {
-	sub, err := c.getOrCreateSubscription(ctx)
+	sub, err := c.getOrCreateSubscription(ctx, false)
 	if err != nil {
 		return err
 	}

--- a/v1/cloudevents/transport/pubsub/internal/connection_test.go
+++ b/v1/cloudevents/transport/pubsub/internal/connection_test.go
@@ -112,9 +112,9 @@ func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 		t.Errorf("subscription id=%s got exists=%v want=true, err=%v", subID, ok, err)
 	}
 
-	if psconn.sub.ReceiveSettings.NumGoroutines != DefaultReceiveSettings.NumGoroutines {
+	if psconn.subInfo.sub.ReceiveSettings.NumGoroutines != DefaultReceiveSettings.NumGoroutines {
 		t.Errorf("subscription receive settings have NumGoroutines=%d, want %d",
-			psconn.sub.ReceiveSettings.NumGoroutines, DefaultReceiveSettings.NumGoroutines)
+			psconn.subInfo.sub.ReceiveSettings.NumGoroutines, DefaultReceiveSettings.NumGoroutines)
 	}
 
 	cancel()

--- a/v1/cloudevents/transport/pubsub/internal/connection_test.go
+++ b/v1/cloudevents/transport/pubsub/internal/connection_test.go
@@ -19,9 +19,31 @@ type testPubsubClient struct {
 	conn *grpc.ClientConn
 }
 
-func (pc *testPubsubClient) New(ctx context.Context, projectID string) (*pubsub.Client, error) {
+type pubSubClientFailureInject struct {
+	*pubsub.Client
+}
+
+type failPattern struct {
+	// Error to return.  nil for no injected error
+	ErrReturn error
+	// Times to return this error (or non-error).  0 for infinite.
+	Count int
+	// Duration to block prior to making the call
+	Delay time.Duration
+}
+
+// Create a pubsub client.  If failureMap is provided, it gives a set of failures to induce in specific methods.
+// failureMap is modified by the event processor and should not be read or modified after calling New()
+func (pc *testPubsubClient) New(ctx context.Context, projectID string, failureMap map[string][]failPattern) (*pubsub.Client, error) {
 	pc.srv = pstest.NewServer()
-	conn, err := grpc.Dial(pc.srv.Addr, grpc.WithInsecure())
+	var err error
+	var conn *grpc.ClientConn
+	if len(failureMap) == 0 {
+		conn, err = grpc.Dial(pc.srv.Addr, grpc.WithInsecure())
+	} else {
+		conn, err = grpc.Dial(pc.srv.Addr, grpc.WithInsecure(), grpc.WithUnaryInterceptor(makeFailureIntercept(failureMap)))
+
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -34,13 +56,85 @@ func (pc *testPubsubClient) Close() {
 	pc.conn.Close()
 }
 
+// Make a grpc failure injector that failes the specified methods with the
+// specified rates.
+func makeFailureIntercept(failureMap map[string][]failPattern) grpc.UnaryClientInterceptor {
+	var lock sync.Mutex
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		var injectedErr error
+		var delay time.Duration
+
+		lock.Lock()
+		if failureMap != nil {
+			fpArr := failureMap[method]
+			if len(fpArr) != 0 {
+				injectedErr = fpArr[0].ErrReturn
+				delay = fpArr[0].Delay
+				if fpArr[0].Count != 0 {
+					fpArr[0].Count--
+					if fpArr[0].Count == 0 {
+						failureMap[method] = fpArr[1:]
+					}
+				}
+			}
+		}
+		lock.Unlock()
+		if delay != 0 {
+			time.Sleep(delay)
+		}
+		if injectedErr != nil {
+			return injectedErr
+		} else {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+	}
+
+}
+
+// Verify that the topic exists prior to the call, deleting it via psconn succeeds, and
+// the topic does not exist after the call.
+func verifyTopicDeleteWorks(t *testing.T, client *pubsub.Client, psconn *Connection, topicID string) {
+	ctx := context.Background()
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
+		t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
+	}
+
+	if err := psconn.DeleteTopic(ctx); err != nil {
+		t.Errorf("delete topic failed: %v", err)
+	}
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || ok {
+		t.Errorf("topic id=%s got exists=%v want=false, err=%v", topicID, ok, err)
+	}
+}
+
+// Verify that the topic exists before and after the call, and that deleting it via psconn fails
+func verifyTopicDeleteFails(t *testing.T, client *pubsub.Client, psconn *Connection, topicID string) {
+	ctx := context.Background()
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
+		t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
+	}
+
+	if err := psconn.DeleteTopic(ctx); err == nil {
+		t.Errorf("delete topic succeeded unexpectedly")
+	}
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
+		t.Errorf("topic id=%s after delete got exists=%v want=true, err=%v", topicID, ok, err)
+	}
+}
+
+// Test that publishing creates a topic
 func TestPublishCreateTopic(t *testing.T) {
 	ctx := context.Background()
 	pc := &testPubsubClient{}
 	defer pc.Close()
 
 	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
-	client, err := pc.New(ctx, projectID)
+
+	client, err := pc.New(ctx, projectID, nil)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client: %v", err)
 	}
@@ -63,26 +157,258 @@ func TestPublishCreateTopic(t *testing.T) {
 		t.Errorf("failed to publish message: %v", err)
 	}
 
-	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
-		t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
+	verifyTopicDeleteWorks(t, client, psconn, topicID)
+}
+
+// Test that publishing to an already created topic works and doesn't allow topic deletion
+func TestPublishExistingTopic(t *testing.T) {
+	for _, allowCreate := range []bool{true, false} {
+		t.Run(fmt.Sprintf("allowCreate_%v", allowCreate), func(t *testing.T) {
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+			client, err := pc.New(ctx, projectID, nil)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: true,
+				AllowCreateTopic:        allowCreate,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			topic, err := client.CreateTopic(ctx, topicID)
+			if err != nil {
+				t.Fatalf("failed to pre-create topic: %v", err)
+			}
+			topic.Stop()
+
+			msg := &pubsub.Message{
+				ID:   "msg-id-1",
+				Data: []byte("msg-data-1"),
+			}
+			if _, err := psconn.Publish(ctx, msg); err != nil {
+				t.Errorf("failed to publish message: %v", err)
+			}
+
+			verifyTopicDeleteFails(t, client, psconn, topicID)
+		})
+	}
+}
+
+// Make sure that Publishing works if the original publish failed due to an
+// error in one of the pubsub calls.
+func TestPublishAfterPublishFailure(t *testing.T) {
+	for _, failureMethod := range []string{
+		"/google.pubsub.v1.Publisher/GetTopic",
+		"/google.pubsub.v1.Publisher/CreateTopic",
+		"/google.pubsub.v1.Publisher/Publish"} {
+		t.Run(fmt.Sprintf("%s", failureMethod), func(t *testing.T) {
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+			failureMap := make(map[string][]failPattern)
+			failureMap[failureMethod] = []failPattern{{
+				ErrReturn: fmt.Errorf("Injected error"),
+				Count:     1,
+				Delay:     0}}
+			client, err := pc.New(ctx, projectID, failureMap)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: true,
+				AllowCreateTopic:        true,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			msg := &pubsub.Message{
+				ID:   "msg-id-1",
+				Data: []byte("msg-data-1"),
+			}
+			// Fails due to injected failure
+			if _, err := psconn.Publish(ctx, msg); err == nil {
+				t.Errorf("Expected publish failure, but didn't see it: %v", err)
+			}
+			// Succeeds
+			if _, err := psconn.Publish(ctx, msg); err != nil {
+				t.Errorf("failed to publish message: %v", err)
+			}
+			verifyTopicDeleteWorks(t, client, psconn, topicID)
+		})
+	}
+}
+
+// Test Publishing after Deleting a first version of a topic
+func TestPublishCreateTopicAfterDelete(t *testing.T) {
+	ctx := context.Background()
+	pc := &testPubsubClient{}
+	defer pc.Close()
+
+	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+	client, err := pc.New(ctx, projectID, nil)
+	if err != nil {
+		t.Fatalf("failed to create pubsub client: %v", err)
+	}
+	defer client.Close()
+
+	psconn := &Connection{
+		AllowCreateSubscription: true,
+		AllowCreateTopic:        true,
+		Client:                  client,
+		ProjectID:               projectID,
+		TopicID:                 topicID,
+		SubscriptionID:          subID,
 	}
 
-	if err := psconn.DeleteTopic(ctx); err != nil {
-		t.Errorf("delete topic failed: %v", err)
+	msg := &pubsub.Message{
+		ID:   "msg-id-1",
+		Data: []byte("msg-data-1"),
+	}
+	if _, err := psconn.Publish(ctx, msg); err != nil {
+		t.Errorf("failed to publish message: %v", err)
 	}
 
-	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || ok {
+	verifyTopicDeleteWorks(t, client, psconn, topicID)
+
+	if _, err := psconn.Publish(ctx, msg); err != nil {
+		t.Errorf("failed to publish message: %v", err)
+	}
+
+	verifyTopicDeleteWorks(t, client, psconn, topicID)
+}
+
+// Test that publishing fails if a toic doesn't exist and topic creation isn't allowed
+func TestPublishCreateTopicNotAllowedFails(t *testing.T) {
+	ctx := context.Background()
+	pc := &testPubsubClient{}
+	defer pc.Close()
+
+	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+	client, err := pc.New(ctx, projectID, nil)
+	if err != nil {
+		t.Fatalf("failed to create pubsub client: %v", err)
+	}
+	defer client.Close()
+
+	psconn := &Connection{
+		AllowCreateSubscription: true,
+		AllowCreateTopic:        false,
+		Client:                  client,
+		ProjectID:               projectID,
+		TopicID:                 topicID,
+		SubscriptionID:          subID,
+	}
+
+	msg := &pubsub.Message{
+		ID:   "msg-id-1",
+		Data: []byte("msg-data-1"),
+	}
+	if _, err := psconn.Publish(ctx, msg); err == nil {
+		t.Errorf("publish succeeded unexpectedly")
+	}
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err == nil && ok {
 		t.Errorf("topic id=%s got exists=%v want=false, err=%v", topicID, ok, err)
 	}
 }
 
+// Test that failures of racing topic opens are reported out
+func TestPublishParallelFailure(t *testing.T) {
+	// This test is racy since it relies on a delay on one goroutine to
+	// ensure a second hits a sync.Once while the other is still processing
+	// it.  Optimistically try with a short delay, but retry with longer
+	// ones so a failure is almost certainly a real failure, not a race.
+	var overallError error
+	for _, delay := range []time.Duration{time.Second / 4, 2 * time.Second, 10 * time.Second, 40 * time.Second} {
+		overallError = func() error {
+			failureMethod := "/google.pubsub.v1.Publisher/GetTopic"
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+			// Inject a failure, but also add a delay to the call sees the error
+			failureMap := make(map[string][]failPattern)
+			failureMap[failureMethod] = []failPattern{{
+				ErrReturn: fmt.Errorf("Injected error"),
+				Count:     1,
+				Delay:     delay}}
+			client, err := pc.New(ctx, projectID, failureMap)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: true,
+				AllowCreateTopic:        true,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			msg := &pubsub.Message{
+				ID:   "msg-id-1",
+				Data: []byte("msg-data-1"),
+			}
+			resChan := make(chan error)
+			// Try a publish.  We want this to be the first to try to create the channel
+			go func() {
+				_, err := psconn.Publish(ctx, msg)
+				resChan <- err
+			}()
+
+			// Try a second publish.  We hope the above has hit it's critical section before
+			// this starts so that this reports out the error returned above.
+			_, errPub1 := psconn.Publish(ctx, msg)
+			errPub2 := <-resChan
+			if errPub1 == nil || errPub2 == nil {
+				return fmt.Errorf("expected dual expected failure, saw (%v) (%v) last run", errPub1, errPub2)
+			} else if errPub1 == nil && errPub2 == nil {
+				t.Fatalf("Dual success when expecting at least one failure, delay %v", delay)
+			}
+			return nil
+		}()
+		// Saw a successfull run, no retry needed.
+		if overallError == nil {
+			break
+		}
+		// Failure.  The loop will bump the delay and try again(unless we've hit the max reasonable delay)
+	}
+	if overallError != nil {
+		t.Errorf(overallError.Error())
+	}
+}
+
+// Test that creating a subscription also creates the topic and subscription
 func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 	ctx := context.Background()
 	pc := &testPubsubClient{}
 	defer pc.Close()
 
 	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
-	client, err := pc.New(ctx, projectID)
+	client, err := pc.New(ctx, projectID, nil)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client: %v", err)
 	}
@@ -101,8 +427,15 @@ func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 	go psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
 		msg.Ack()
 	})
-	// Sleep one sec for the goroutine to create the topic and subscription.
-	time.Sleep(time.Second)
+	// Sleep waiting for the goroutine to create the topic and subscription
+	// If it takes over a minute, run the test anyway to get failure logging
+	for _, delay := range []time.Duration{time.Second / 4, time.Second, 20 * time.Second, 40 * time.Second} {
+		time.Sleep(delay)
+		ok, err := client.Subscription(subID).Exists(ctx)
+		if ok == true && err == nil {
+			break
+		}
+	}
 
 	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
 		t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
@@ -112,9 +445,13 @@ func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 		t.Errorf("subscription id=%s got exists=%v want=true, err=%v", subID, ok, err)
 	}
 
-	if psconn.subInfo.sub.ReceiveSettings.NumGoroutines != DefaultReceiveSettings.NumGoroutines {
+	si, err := psconn.getOrCreateSubscriptionInfo(context.Background(), true)
+	if err != nil {
+		t.Errorf("error getting subscription info %v", err)
+	}
+	if si.sub.ReceiveSettings.NumGoroutines != DefaultReceiveSettings.NumGoroutines {
 		t.Errorf("subscription receive settings have NumGoroutines=%d, want %d",
-			psconn.subInfo.sub.ReceiveSettings.NumGoroutines, DefaultReceiveSettings.NumGoroutines)
+			si.sub.ReceiveSettings.NumGoroutines, DefaultReceiveSettings.NumGoroutines)
 	}
 
 	cancel()
@@ -127,22 +464,223 @@ func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 		t.Errorf("subscription id=%s got exists=%v want=false, err=%v", subID, ok, err)
 	}
 
-	if err := psconn.DeleteTopic(ctx); err != nil {
-		t.Errorf("delete topic failed: %v", err)
-	}
+	verifyTopicDeleteWorks(t, client, psconn, topicID)
+}
 
-	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || ok {
-		t.Errorf("topic id=%s got exists=%v want=false, err=%v", topicID, ok, err)
+// Test receive on an existing topic and subscription also works.
+func TestReceiveExistingTopic(t *testing.T) {
+	for _, allow := range [](struct{ Sub, Topic bool }){{true, true}, {true, false}, {false, true}, {false, false}} {
+		t.Run(fmt.Sprintf("sub_%v__topic_%v", allow.Sub, allow.Topic), func(t *testing.T) {
+
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+			client, err := pc.New(ctx, projectID, nil)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: allow.Sub,
+				AllowCreateTopic:        allow.Topic,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			topic, err := client.CreateTopic(ctx, topicID)
+			if err != nil {
+				pc.Close()
+				t.Fatalf("failed to pre-create topic: %v", err)
+			}
+
+			_, err = client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
+				Topic:             topic,
+				AckDeadline:       DefaultAckDeadline,
+				RetentionDuration: DefaultRetentionDuration,
+			})
+			topic.Stop()
+			if err != nil {
+				pc.Close()
+				t.Fatalf("failed to pre-createsubscription: %v", err)
+			}
+
+			ctx2, cancel := context.WithCancel(ctx)
+			go psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
+				msg.Ack()
+			})
+			// Block waiting for receive to succeed
+			si, err := psconn.getOrCreateSubscriptionInfo(context.Background(), false)
+			if err != nil {
+				t.Errorf("error getting subscription info %v", err)
+			}
+			if si.sub.ReceiveSettings.NumGoroutines != DefaultReceiveSettings.NumGoroutines {
+				t.Errorf("subscription receive settings have NumGoroutines=%d, want %d",
+					si.sub.ReceiveSettings.NumGoroutines, DefaultReceiveSettings.NumGoroutines)
+			}
+
+			cancel()
+
+			if err := psconn.DeleteSubscription(ctx); err == nil {
+				t.Errorf("delete subscription unexpectedly succeeded")
+			}
+
+			if ok, err := client.Subscription(subID).Exists(ctx); err != nil || !ok {
+				t.Errorf("subscription id=%s got exists=%v want=true, err=%v", subID, ok, err)
+			}
+
+			verifyTopicDeleteFails(t, client, psconn, topicID)
+		})
 	}
 }
 
+// Test that creating a subscription after a failed attempt to create a subsciption works
+func TestReceiveCreateSubscriptionAfterFailure(t *testing.T) {
+	for _, failureMethod := range []string{
+		"/google.pubsub.v1.Publisher/GetTopic",
+		"/google.pubsub.v1.Publisher/CreateTopic",
+		"/google.pubsub.v1.Subscriber/GetSubscription",
+		"/google.pubsub.v1.Subscriber/CreateSubscription"} {
+		t.Run(fmt.Sprintf("%s", failureMethod), func(t *testing.T) {
+
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+			failureMap := make(map[string][]failPattern)
+			failureMap[failureMethod] = []failPattern{{
+				ErrReturn: fmt.Errorf("Injected error"),
+				Count:     1,
+				Delay:     0}}
+			client, err := pc.New(ctx, projectID, failureMap)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: true,
+				AllowCreateTopic:        true,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			// We expect this receive to fail due to the injected error
+			ctx2, cancel := context.WithCancel(ctx)
+			errRet := make(chan error)
+			go func() {
+				errRet <- psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
+					msg.Ack()
+				})
+			}()
+
+			select {
+			case err := <-errRet:
+				if err == nil {
+					t.Fatalf("unexpected nil error from Receive")
+				}
+			case <-time.After(time.Minute):
+				cancel()
+				t.Fatalf("timeout waiting for receive error")
+			}
+
+			// We expect this receive to succeed
+			errRet2 := make(chan error)
+			ctx2, cancel = context.WithCancel(context.Background())
+			go func() {
+				errRet2 <- psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
+					msg.Ack()
+				})
+			}()
+			// Sleep waiting for the goroutine to create the topic and subscription
+			// If it takes over a minute, run the test anyway to get failure logging
+			for _, delay := range []time.Duration{time.Second / 4, time.Second, 20 * time.Second, 40 * time.Second} {
+				time.Sleep(delay)
+				ok, err := client.Subscription(subID).Exists(ctx)
+				if ok == true && err == nil {
+					break
+				}
+			}
+			select {
+			case err := <-errRet2:
+				t.Errorf("unexpected error from Receive: %v", err)
+			default:
+			}
+			if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
+				t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
+			}
+
+			if ok, err := client.Subscription(subID).Exists(ctx); err != nil || !ok {
+				t.Errorf("subscription id=%s got exists=%v want=true, err=%v", subID, ok, err)
+			}
+
+			cancel()
+		})
+	}
+}
+
+// Test that lack of create privileges for topic or subscription causes a receive to fail for
+// a non-existing subscription and topic
+func TestReceiveCreateDisallowedFail(t *testing.T) {
+	ctx := context.Background()
+	pc := &testPubsubClient{}
+	defer pc.Close()
+
+	for _, allow := range [](struct{ Sub, Topic bool }){{false, true}, {true, false}, {false, false}} {
+		t.Run(fmt.Sprintf("sub_%v__topic_%v", allow.Sub, allow.Topic), func(t *testing.T) {
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+			client, err := pc.New(ctx, projectID, nil)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: allow.Sub,
+				AllowCreateTopic:        allow.Topic,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			ctx2, cancel := context.WithCancel(ctx)
+			errRet := make(chan error)
+			go func() {
+				errRet <- psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
+					msg.Ack()
+				})
+			}()
+
+			select {
+			case err := <-errRet:
+				if err == nil {
+					t.Fatalf("unexpected nil error from Receive")
+				}
+			case <-time.After(time.Minute):
+				cancel()
+				t.Fatalf("timeout waiting for receive error")
+			}
+		})
+	}
+}
+
+// Test a full round trip of a message
 func TestPublishReceiveRoundtrip(t *testing.T) {
 	ctx := context.Background()
 	pc := &testPubsubClient{}
 	defer pc.Close()
 
 	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
-	client, err := pc.New(ctx, projectID)
+	client, err := pc.New(ctx, projectID, nil)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client: %v", err)
 	}

--- a/v1/cloudevents/transport/pubsub/internal/connection_test.go
+++ b/v1/cloudevents/transport/pubsub/internal/connection_test.go
@@ -669,6 +669,7 @@ func TestReceiveCreateDisallowedFail(t *testing.T) {
 				cancel()
 				t.Fatalf("timeout waiting for receive error")
 			}
+			cancel()
 		})
 	}
 }

--- a/v1/cloudevents/transport/pubsub/internal/connection_test.go
+++ b/v1/cloudevents/transport/pubsub/internal/connection_test.go
@@ -291,7 +291,7 @@ func TestPublishCreateTopicAfterDelete(t *testing.T) {
 	verifyTopicDeleteWorks(t, client, psconn, topicID)
 }
 
-// Test that publishing fails if a toic doesn't exist and topic creation isn't allowed
+// Test that publishing fails if a topic doesn't exist and topic creation isn't allowed
 func TestPublishCreateTopicNotAllowedFails(t *testing.T) {
 	ctx := context.Background()
 	pc := &testPubsubClient{}

--- a/v1/cloudevents/transport/pubsub/internal/connection_test.go
+++ b/v1/cloudevents/transport/pubsub/internal/connection_test.go
@@ -19,10 +19,6 @@ type testPubsubClient struct {
 	conn *grpc.ClientConn
 }
 
-type pubSubClientFailureInject struct {
-	*pubsub.Client
-}
-
 type failPattern struct {
 	// Error to return.  nil for no injected error
 	ErrReturn error
@@ -211,7 +207,7 @@ func TestPublishAfterPublishFailure(t *testing.T) {
 		"/google.pubsub.v1.Publisher/GetTopic",
 		"/google.pubsub.v1.Publisher/CreateTopic",
 		"/google.pubsub.v1.Publisher/Publish"} {
-		t.Run(fmt.Sprintf("%s", failureMethod), func(t *testing.T) {
+		t.Run(failureMethod, func(t *testing.T) {
 			ctx := context.Background()
 			pc := &testPubsubClient{}
 			defer pc.Close()
@@ -545,7 +541,7 @@ func TestReceiveCreateSubscriptionAfterFailure(t *testing.T) {
 		"/google.pubsub.v1.Publisher/CreateTopic",
 		"/google.pubsub.v1.Subscriber/GetSubscription",
 		"/google.pubsub.v1.Subscriber/CreateSubscription"} {
-		t.Run(fmt.Sprintf("%s", failureMethod), func(t *testing.T) {
+		t.Run(failureMethod, func(t *testing.T) {
 
 			ctx := context.Background()
 			pc := &testPubsubClient{}

--- a/v2/protocol/pubsub/internal/connection.go
+++ b/v2/protocol/pubsub/internal/connection.go
@@ -13,6 +13,20 @@ import (
 	pscontext "github.com/cloudevents/sdk-go/v2/protocol/pubsub/context"
 )
 
+type topicInfo struct {
+	topic      *pubsub.Topic
+	wasCreated bool
+	once       sync.Once
+	err        error
+}
+
+type subInfo struct {
+	sub        *pubsub.Subscription
+	wasCreated bool
+	once       sync.Once
+	err        error
+}
+
 // Connection acts as either a pubsub topic or a pubsub subscription .
 type Connection struct {
 	// AllowCreateTopic controls if the protocol can create a topic if it does
@@ -27,24 +41,29 @@ type Connection struct {
 
 	Client *pubsub.Client
 
-	TopicID         string
-	topic           *pubsub.Topic
-	topicWasCreated bool
-	topicOnce       sync.Once
+	TopicID   string
+	topicInfo *topicInfo
 
 	SubscriptionID string
-	sub            *pubsub.Subscription
-	subWasCreated  bool
-	subOnce        sync.Once
+	subInfo        *subInfo
+
+	// Held when reading or writing topicInfo and subInfo. This is only
+	// held while reading the pointer, the structure internally manage
+	// their own internal concurrency.  This also controls
+	// the update of AckDeadline and RetentionDuration if those are
+	// nil on start.
+	initLock sync.Mutex
 
 	// ReceiveSettings is used to configure Pubsub pull subscription.
 	ReceiveSettings *pubsub.ReceiveSettings
 
 	// AckDeadline is Pub/Sub AckDeadline.
 	// Default is 30 seconds.
+	// This can only be set prior to first call of any function.
 	AckDeadline *time.Duration
 	// RetentionDuration is Pub/Sub RetentionDuration.
 	// Default is 25 hours.
+	// This can only be set prior to first call of any function.
 	RetentionDuration *time.Duration
 }
 
@@ -64,129 +83,210 @@ var DefaultReceiveSettings = pubsub.ReceiveSettings{
 	Synchronous:   false,
 }
 
-func (c *Connection) getOrCreateTopic(ctx context.Context) (*pubsub.Topic, error) {
-	var err error
-	c.topicOnce.Do(func() {
+func (c *Connection) getOrCreateTopicInfo(ctx context.Context, getAlreadyOpenOnly bool) (*topicInfo, error) {
+	// See if a topic has already been created or is in the process of being created.
+	// If not, start creating one.
+	c.initLock.Lock()
+	ti := c.topicInfo
+	if ti == nil && !getAlreadyOpenOnly {
+		c.topicInfo = &topicInfo{}
+		ti = c.topicInfo
+	}
+	c.initLock.Unlock()
+	if ti == nil {
+		return nil, fmt.Errorf("no already open topic")
+	}
+
+	// Make sure the topic structure is initialized at most once.
+	ti.once.Do(func() {
 		var ok bool
 		// Load the topic.
 		topic := c.Client.Topic(c.TopicID)
-		ok, err = topic.Exists(ctx)
-		if err != nil {
+		ok, ti.err = topic.Exists(ctx)
+		if ti.err != nil {
 			return
 		}
 		// If the topic does not exist, create a new topic with the given name.
 		if !ok {
 			if !c.AllowCreateTopic {
-				err = fmt.Errorf("protocol not allowed to create topic %q", c.TopicID)
+				ti.err = fmt.Errorf("protocol not allowed to create topic %q", c.TopicID)
 				return
 			}
-			topic, err = c.Client.CreateTopic(ctx, c.TopicID)
-			if err != nil {
+			topic, ti.err = c.Client.CreateTopic(ctx, c.TopicID)
+			if ti.err != nil {
 				return
 			}
-			c.topicWasCreated = true
+			ti.wasCreated = true
 		}
 		// Success.
-		c.topic = topic
+		ti.topic = topic
 	})
-	if c.topic == nil {
-		return nil, fmt.Errorf("unable to create topic %q, %v", c.TopicID, err)
+	if ti.topic == nil {
+		// Initialization failed, remove this attempt so that future callers
+		// will try to initialize again.
+		c.initLock.Lock()
+		if c.topicInfo == ti {
+			c.topicInfo = nil
+		}
+		c.initLock.Unlock()
+
+		return nil, fmt.Errorf("unable to get or create topic %q, %v", c.TopicID, ti.err)
 	}
-	return c.topic, err
+	return ti, nil
+}
+
+func (c *Connection) getOrCreateTopic(ctx context.Context, getAlreadyOpenOnly bool) (*pubsub.Topic, error) {
+	ti, err := c.getOrCreateTopicInfo(ctx, getAlreadyOpenOnly)
+	if ti != nil {
+		return ti.topic, nil
+	} else {
+		return nil, err
+	}
 }
 
 // DeleteTopic deletes the connection's topic
 func (c *Connection) DeleteTopic(ctx context.Context) error {
-	if !c.topicWasCreated {
+	ti, err := c.getOrCreateTopicInfo(ctx, true)
+
+	if err != nil {
+		return errors.New("topic not open")
+	}
+	if !ti.wasCreated {
 		return errors.New("topic was not created by pubsub protocol")
 	}
-	if err := c.topic.Delete(ctx); err != nil {
+	if err := ti.topic.Delete(ctx); err != nil {
 		return err
 	}
-	c.topic = nil
-	c.topicWasCreated = false
-	c.topicOnce = sync.Once{}
+
+	ti.topic.Stop()
+
+	c.initLock.Lock()
+	if ti == c.topicInfo {
+		c.topicInfo = nil
+	}
+	c.initLock.Unlock()
+
 	return nil
 }
 
-func (c *Connection) getOrCreateSubscription(ctx context.Context) (*pubsub.Subscription, error) {
-	var err error
-	c.subOnce.Do(func() {
+func (c *Connection) getOrCreateSubscriptionInfo(ctx context.Context, getAlreadyOpenOnly bool) (*subInfo, error) {
+	c.initLock.Lock()
+	// Default the ack deadline and retention duration config.
+	// We only do this once.
+	if c.AckDeadline == nil {
+		ackDeadline := DefaultAckDeadline
+		c.AckDeadline = &(ackDeadline)
+	}
+	if c.RetentionDuration == nil {
+		retentionDuration := DefaultRetentionDuration
+		c.RetentionDuration = &retentionDuration
+	}
+	// See if a subscription has already been created or is in the process of being created.
+	// If not, start creating one.
+	si := c.subInfo
+	if si == nil && !getAlreadyOpenOnly {
+		c.subInfo = &subInfo{}
+		si = c.subInfo
+	}
+	c.initLock.Unlock()
+	if si == nil {
+		return nil, fmt.Errorf("no already open subscription")
+	}
+
+	// Make sure the subscription structure is initialized at most once.
+	si.once.Do(func() {
 		// Load the subscription.
 		var ok bool
 		sub := c.Client.Subscription(c.SubscriptionID)
-		ok, err = sub.Exists(ctx)
-		if err != nil {
+		ok, si.err = sub.Exists(ctx)
+		if si.err != nil {
 			return
 		}
 		// If subscription doesn't exist, create it.
 		if !ok {
 			if !c.AllowCreateSubscription {
-				err = fmt.Errorf("protocol not allowed to create subscription %q", c.SubscriptionID)
+				si.err = fmt.Errorf("protocol not allowed to create subscription %q", c.SubscriptionID)
 				return
 			}
 
 			// Load the topic.
 			var topic *pubsub.Topic
-			topic, err = c.getOrCreateTopic(ctx)
-			if err != nil {
+			topic, si.err = c.getOrCreateTopic(ctx, false)
+			if si.err != nil {
 				return
-			}
-			// Default the ack deadline and retention duration config.
-			if c.AckDeadline == nil {
-				ackDeadline := DefaultAckDeadline
-				c.AckDeadline = &(ackDeadline)
-			}
-			if c.RetentionDuration == nil {
-				retentionDuration := DefaultRetentionDuration
-				c.RetentionDuration = &retentionDuration
 			}
 
 			// Create a new subscription to the previously created topic
 			// with the given name.
 			// TODO: allow to use push config + allow setting the SubscriptionConfig.
-			sub, err = c.Client.CreateSubscription(ctx, c.SubscriptionID, pubsub.SubscriptionConfig{
+			sub, si.err = c.Client.CreateSubscription(ctx, c.SubscriptionID, pubsub.SubscriptionConfig{
 				Topic:             topic,
 				AckDeadline:       *c.AckDeadline,
 				RetentionDuration: *c.RetentionDuration,
 			})
-			if err != nil {
-				_ = c.Client.Close()
+			if si.err != nil {
 				return
 			}
-			if c.ReceiveSettings == nil {
-				sub.ReceiveSettings = DefaultReceiveSettings
-			} else {
-				sub.ReceiveSettings = *c.ReceiveSettings
-			}
-			c.subWasCreated = true
+
+			si.wasCreated = true
+		}
+		if c.ReceiveSettings == nil {
+			sub.ReceiveSettings = DefaultReceiveSettings
+		} else {
+			sub.ReceiveSettings = *c.ReceiveSettings
 		}
 		// Success.
-		c.sub = sub
+		si.sub = sub
 	})
-	if c.sub == nil {
-		return nil, fmt.Errorf("unable to create subscription %q, %v", c.SubscriptionID, err)
+	if si.sub == nil {
+		// Initialization failed, remove this attempt so that future callers
+		// will try to initialize again.
+		c.initLock.Lock()
+		if c.subInfo == si {
+			c.subInfo = nil
+		}
+		c.initLock.Unlock()
+		return nil, fmt.Errorf("unable to create subscription %q, %v", c.SubscriptionID, si.err)
 	}
-	return c.sub, err
+	return si, nil
+}
+
+func (c *Connection) getOrCreateSubscription(ctx context.Context, getAlreadyOpenOnly bool) (*pubsub.Subscription, error) {
+	si, err := c.getOrCreateSubscriptionInfo(ctx, getAlreadyOpenOnly)
+	if si != nil {
+		return si.sub, nil
+	} else {
+		return nil, err
+	}
 }
 
 // DeleteSubscription delete's the connection's subscription
 func (c *Connection) DeleteSubscription(ctx context.Context) error {
-	if !c.subWasCreated {
+	si, err := c.getOrCreateSubscriptionInfo(ctx, true)
+
+	if err != nil {
+		return errors.New("subscription not open")
+	}
+
+	if !si.wasCreated {
 		return errors.New("subscription was not created by pubsub protocol")
 	}
-	if err := c.sub.Delete(ctx); err != nil {
+	if err := si.sub.Delete(ctx); err != nil {
 		return err
 	}
-	c.sub = nil
-	c.subWasCreated = false
-	c.subOnce = sync.Once{}
+
+	c.initLock.Lock()
+	if si == c.subInfo {
+		c.subInfo = nil
+	}
+	c.initLock.Unlock()
+
 	return nil
 }
 
 // Publish publishes a message to the connection's topic
 func (c *Connection) Publish(ctx context.Context, msg *pubsub.Message) (*binding.Message, error) {
-	topic, err := c.getOrCreateTopic(ctx)
+	topic, err := c.getOrCreateTopic(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +299,7 @@ func (c *Connection) Publish(ctx context.Context, msg *pubsub.Message) (*binding
 // Receive begins pulling messages.
 // NOTE: This is a blocking call.
 func (c *Connection) Receive(ctx context.Context, fn func(context.Context, *pubsub.Message)) error {
-	sub, err := c.getOrCreateSubscription(ctx)
+	sub, err := c.getOrCreateSubscription(ctx, false)
 	if err != nil {
 		return err
 	}

--- a/v2/protocol/pubsub/internal/connection_test.go
+++ b/v2/protocol/pubsub/internal/connection_test.go
@@ -19,9 +19,31 @@ type testPubsubClient struct {
 	conn *grpc.ClientConn
 }
 
-func (pc *testPubsubClient) New(ctx context.Context, projectID string) (*pubsub.Client, error) {
+type pubSubClientFailureInject struct {
+	*pubsub.Client
+}
+
+type failPattern struct {
+	// Error to return.  nil for no injected error
+	ErrReturn error
+	// Times to return this error (or non-error).  0 for infinite.
+	Count int
+	// Duration to block prior to making the call
+	Delay time.Duration
+}
+
+// Create a pubsub client.  If failureMap is provided, it gives a set of failures to induce in specific methods.
+// failureMap is modified by the event processor and should not be read or modified after calling New()
+func (pc *testPubsubClient) New(ctx context.Context, projectID string, failureMap map[string][]failPattern) (*pubsub.Client, error) {
 	pc.srv = pstest.NewServer()
-	conn, err := grpc.Dial(pc.srv.Addr, grpc.WithInsecure())
+	var err error
+	var conn *grpc.ClientConn
+	if len(failureMap) == 0 {
+		conn, err = grpc.Dial(pc.srv.Addr, grpc.WithInsecure())
+	} else {
+		conn, err = grpc.Dial(pc.srv.Addr, grpc.WithInsecure(), grpc.WithUnaryInterceptor(makeFailureIntercept(failureMap)))
+
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -34,13 +56,85 @@ func (pc *testPubsubClient) Close() {
 	pc.conn.Close()
 }
 
+// Make a grpc failure injector that failes the specified methods with the
+// specified rates.
+func makeFailureIntercept(failureMap map[string][]failPattern) grpc.UnaryClientInterceptor {
+	var lock sync.Mutex
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		var injectedErr error
+		var delay time.Duration
+
+		lock.Lock()
+		if failureMap != nil {
+			fpArr := failureMap[method]
+			if len(fpArr) != 0 {
+				injectedErr = fpArr[0].ErrReturn
+				delay = fpArr[0].Delay
+				if fpArr[0].Count != 0 {
+					fpArr[0].Count--
+					if fpArr[0].Count == 0 {
+						failureMap[method] = fpArr[1:]
+					}
+				}
+			}
+		}
+		lock.Unlock()
+		if delay != 0 {
+			time.Sleep(delay)
+		}
+		if injectedErr != nil {
+			return injectedErr
+		} else {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+	}
+
+}
+
+// Verify that the topic exists prior to the call, deleting it via psconn succeeds, and
+// the topic does not exist after the call.
+func verifyTopicDeleteWorks(t *testing.T, client *pubsub.Client, psconn *Connection, topicID string) {
+	ctx := context.Background()
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
+		t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
+	}
+
+	if err := psconn.DeleteTopic(ctx); err != nil {
+		t.Errorf("delete topic failed: %v", err)
+	}
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || ok {
+		t.Errorf("topic id=%s got exists=%v want=false, err=%v", topicID, ok, err)
+	}
+}
+
+// Verify that the topic exists before and after the call, and that deleting it via psconn fails
+func verifyTopicDeleteFails(t *testing.T, client *pubsub.Client, psconn *Connection, topicID string) {
+	ctx := context.Background()
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
+		t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
+	}
+
+	if err := psconn.DeleteTopic(ctx); err == nil {
+		t.Errorf("delete topic succeeded unexpectedly")
+	}
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
+		t.Errorf("topic id=%s after delete got exists=%v want=true, err=%v", topicID, ok, err)
+	}
+}
+
+// Test that publishing creates a topic
 func TestPublishCreateTopic(t *testing.T) {
 	ctx := context.Background()
 	pc := &testPubsubClient{}
 	defer pc.Close()
 
 	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
-	client, err := pc.New(ctx, projectID)
+
+	client, err := pc.New(ctx, projectID, nil)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client: %v", err)
 	}
@@ -63,26 +157,258 @@ func TestPublishCreateTopic(t *testing.T) {
 		t.Errorf("failed to publish message: %v", err)
 	}
 
-	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
-		t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
+	verifyTopicDeleteWorks(t, client, psconn, topicID)
+}
+
+// Test that publishing to an already created topic works and doesn't allow topic deletion
+func TestPublishExistingTopic(t *testing.T) {
+	for _, allowCreate := range []bool{true, false} {
+		t.Run(fmt.Sprintf("allowCreate_%v", allowCreate), func(t *testing.T) {
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+			client, err := pc.New(ctx, projectID, nil)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: true,
+				AllowCreateTopic:        allowCreate,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			topic, err := client.CreateTopic(ctx, topicID)
+			if err != nil {
+				t.Fatalf("failed to pre-create topic: %v", err)
+			}
+			topic.Stop()
+
+			msg := &pubsub.Message{
+				ID:   "msg-id-1",
+				Data: []byte("msg-data-1"),
+			}
+			if _, err := psconn.Publish(ctx, msg); err != nil {
+				t.Errorf("failed to publish message: %v", err)
+			}
+
+			verifyTopicDeleteFails(t, client, psconn, topicID)
+		})
+	}
+}
+
+// Make sure that Publishing works if the original publish failed due to an
+// error in one of the pubsub calls.
+func TestPublishAfterPublishFailure(t *testing.T) {
+	for _, failureMethod := range []string{
+		"/google.pubsub.v1.Publisher/GetTopic",
+		"/google.pubsub.v1.Publisher/CreateTopic",
+		"/google.pubsub.v1.Publisher/Publish"} {
+		t.Run(fmt.Sprintf("%s", failureMethod), func(t *testing.T) {
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+			failureMap := make(map[string][]failPattern)
+			failureMap[failureMethod] = []failPattern{{
+				ErrReturn: fmt.Errorf("Injected error"),
+				Count:     1,
+				Delay:     0}}
+			client, err := pc.New(ctx, projectID, failureMap)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: true,
+				AllowCreateTopic:        true,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			msg := &pubsub.Message{
+				ID:   "msg-id-1",
+				Data: []byte("msg-data-1"),
+			}
+			// Fails due to injected failure
+			if _, err := psconn.Publish(ctx, msg); err == nil {
+				t.Errorf("Expected publish failure, but didn't see it: %v", err)
+			}
+			// Succeeds
+			if _, err := psconn.Publish(ctx, msg); err != nil {
+				t.Errorf("failed to publish message: %v", err)
+			}
+			verifyTopicDeleteWorks(t, client, psconn, topicID)
+		})
+	}
+}
+
+// Test Publishing after Deleting a first version of a topic
+func TestPublishCreateTopicAfterDelete(t *testing.T) {
+	ctx := context.Background()
+	pc := &testPubsubClient{}
+	defer pc.Close()
+
+	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+	client, err := pc.New(ctx, projectID, nil)
+	if err != nil {
+		t.Fatalf("failed to create pubsub client: %v", err)
+	}
+	defer client.Close()
+
+	psconn := &Connection{
+		AllowCreateSubscription: true,
+		AllowCreateTopic:        true,
+		Client:                  client,
+		ProjectID:               projectID,
+		TopicID:                 topicID,
+		SubscriptionID:          subID,
 	}
 
-	if err := psconn.DeleteTopic(ctx); err != nil {
-		t.Errorf("delete topic failed: %v", err)
+	msg := &pubsub.Message{
+		ID:   "msg-id-1",
+		Data: []byte("msg-data-1"),
+	}
+	if _, err := psconn.Publish(ctx, msg); err != nil {
+		t.Errorf("failed to publish message: %v", err)
 	}
 
-	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || ok {
+	verifyTopicDeleteWorks(t, client, psconn, topicID)
+
+	if _, err := psconn.Publish(ctx, msg); err != nil {
+		t.Errorf("failed to publish message: %v", err)
+	}
+
+	verifyTopicDeleteWorks(t, client, psconn, topicID)
+}
+
+// Test that publishing fails if a toic doesn't exist and topic creation isn't allowed
+func TestPublishCreateTopicNotAllowedFails(t *testing.T) {
+	ctx := context.Background()
+	pc := &testPubsubClient{}
+	defer pc.Close()
+
+	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+	client, err := pc.New(ctx, projectID, nil)
+	if err != nil {
+		t.Fatalf("failed to create pubsub client: %v", err)
+	}
+	defer client.Close()
+
+	psconn := &Connection{
+		AllowCreateSubscription: true,
+		AllowCreateTopic:        false,
+		Client:                  client,
+		ProjectID:               projectID,
+		TopicID:                 topicID,
+		SubscriptionID:          subID,
+	}
+
+	msg := &pubsub.Message{
+		ID:   "msg-id-1",
+		Data: []byte("msg-data-1"),
+	}
+	if _, err := psconn.Publish(ctx, msg); err == nil {
+		t.Errorf("publish succeeded unexpectedly")
+	}
+
+	if ok, err := client.Topic(topicID).Exists(ctx); err == nil && ok {
 		t.Errorf("topic id=%s got exists=%v want=false, err=%v", topicID, ok, err)
 	}
 }
 
+// Test that failures of racing topic opens are reported out
+func TestPublishParallelFailure(t *testing.T) {
+	// This test is racy since it relies on a delay on one goroutine to
+	// ensure a second hits a sync.Once while the other is still processing
+	// it.  Optimistically try with a short delay, but retry with longer
+	// ones so a failure is almost certainly a real failure, not a race.
+	var overallError error
+	for _, delay := range []time.Duration{time.Second / 4, 2 * time.Second, 10 * time.Second, 40 * time.Second} {
+		overallError = func() error {
+			failureMethod := "/google.pubsub.v1.Publisher/GetTopic"
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+
+			// Inject a failure, but also add a delay to the call sees the error
+			failureMap := make(map[string][]failPattern)
+			failureMap[failureMethod] = []failPattern{{
+				ErrReturn: fmt.Errorf("Injected error"),
+				Count:     1,
+				Delay:     delay}}
+			client, err := pc.New(ctx, projectID, failureMap)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: true,
+				AllowCreateTopic:        true,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			msg := &pubsub.Message{
+				ID:   "msg-id-1",
+				Data: []byte("msg-data-1"),
+			}
+			resChan := make(chan error)
+			// Try a publish.  We want this to be the first to try to create the channel
+			go func() {
+				_, err := psconn.Publish(ctx, msg)
+				resChan <- err
+			}()
+
+			// Try a second publish.  We hope the above has hit it's critical section before
+			// this starts so that this reports out the error returned above.
+			_, errPub1 := psconn.Publish(ctx, msg)
+			errPub2 := <-resChan
+			if errPub1 == nil || errPub2 == nil {
+				return fmt.Errorf("expected dual expected failure, saw (%v) (%v) last run", errPub1, errPub2)
+			} else if errPub1 == nil && errPub2 == nil {
+				t.Fatalf("Dual success when expecting at least one failure, delay %v", delay)
+			}
+			return nil
+		}()
+		// Saw a successfull run, no retry needed.
+		if overallError == nil {
+			break
+		}
+		// Failure.  The loop will bump the delay and try again(unless we've hit the max reasonable delay)
+	}
+	if overallError != nil {
+		t.Errorf(overallError.Error())
+	}
+}
+
+// Test that creating a subscription also creates the topic and subscription
 func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 	ctx := context.Background()
 	pc := &testPubsubClient{}
 	defer pc.Close()
 
 	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
-	client, err := pc.New(ctx, projectID)
+	client, err := pc.New(ctx, projectID, nil)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client: %v", err)
 	}
@@ -101,8 +427,15 @@ func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 	go psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
 		msg.Ack()
 	})
-	// Sleep one sec for the goroutine to create the topic and subscription.
-	time.Sleep(time.Second)
+	// Sleep waiting for the goroutine to create the topic and subscription
+	// If it takes over a minute, run the test anyway to get failure logging
+	for _, delay := range []time.Duration{time.Second / 4, time.Second, 20 * time.Second, 40 * time.Second} {
+		time.Sleep(delay)
+		ok, err := client.Subscription(subID).Exists(ctx)
+		if ok == true && err == nil {
+			break
+		}
+	}
 
 	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
 		t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
@@ -112,9 +445,13 @@ func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 		t.Errorf("subscription id=%s got exists=%v want=true, err=%v", subID, ok, err)
 	}
 
-	if psconn.sub.ReceiveSettings.NumGoroutines != DefaultReceiveSettings.NumGoroutines {
+	si, err := psconn.getOrCreateSubscriptionInfo(context.Background(), true)
+	if err != nil {
+		t.Errorf("error getting subscription info %v", err)
+	}
+	if si.sub.ReceiveSettings.NumGoroutines != DefaultReceiveSettings.NumGoroutines {
 		t.Errorf("subscription receive settings have NumGoroutines=%d, want %d",
-			psconn.sub.ReceiveSettings.NumGoroutines, DefaultReceiveSettings.NumGoroutines)
+			si.sub.ReceiveSettings.NumGoroutines, DefaultReceiveSettings.NumGoroutines)
 	}
 
 	cancel()
@@ -127,22 +464,223 @@ func TestReceiveCreateTopicAndSubscription(t *testing.T) {
 		t.Errorf("subscription id=%s got exists=%v want=false, err=%v", subID, ok, err)
 	}
 
-	if err := psconn.DeleteTopic(ctx); err != nil {
-		t.Errorf("delete topic failed: %v", err)
-	}
+	verifyTopicDeleteWorks(t, client, psconn, topicID)
+}
 
-	if ok, err := client.Topic(topicID).Exists(ctx); err != nil || ok {
-		t.Errorf("topic id=%s got exists=%v want=false, err=%v", topicID, ok, err)
+// Test receive on an existing topic and subscription also works.
+func TestReceiveExistingTopic(t *testing.T) {
+	for _, allow := range [](struct{ Sub, Topic bool }){{true, true}, {true, false}, {false, true}, {false, false}} {
+		t.Run(fmt.Sprintf("sub_%v__topic_%v", allow.Sub, allow.Topic), func(t *testing.T) {
+
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+			client, err := pc.New(ctx, projectID, nil)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: allow.Sub,
+				AllowCreateTopic:        allow.Topic,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			topic, err := client.CreateTopic(ctx, topicID)
+			if err != nil {
+				pc.Close()
+				t.Fatalf("failed to pre-create topic: %v", err)
+			}
+
+			_, err = client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
+				Topic:             topic,
+				AckDeadline:       DefaultAckDeadline,
+				RetentionDuration: DefaultRetentionDuration,
+			})
+			topic.Stop()
+			if err != nil {
+				pc.Close()
+				t.Fatalf("failed to pre-createsubscription: %v", err)
+			}
+
+			ctx2, cancel := context.WithCancel(ctx)
+			go psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
+				msg.Ack()
+			})
+			// Block waiting for receive to succeed
+			si, err := psconn.getOrCreateSubscriptionInfo(context.Background(), false)
+			if err != nil {
+				t.Errorf("error getting subscription info %v", err)
+			}
+			if si.sub.ReceiveSettings.NumGoroutines != DefaultReceiveSettings.NumGoroutines {
+				t.Errorf("subscription receive settings have NumGoroutines=%d, want %d",
+					si.sub.ReceiveSettings.NumGoroutines, DefaultReceiveSettings.NumGoroutines)
+			}
+
+			cancel()
+
+			if err := psconn.DeleteSubscription(ctx); err == nil {
+				t.Errorf("delete subscription unexpectedly succeeded")
+			}
+
+			if ok, err := client.Subscription(subID).Exists(ctx); err != nil || !ok {
+				t.Errorf("subscription id=%s got exists=%v want=true, err=%v", subID, ok, err)
+			}
+
+			verifyTopicDeleteFails(t, client, psconn, topicID)
+		})
 	}
 }
 
+// Test that creating a subscription after a failed attempt to create a subsciption works
+func TestReceiveCreateSubscriptionAfterFailure(t *testing.T) {
+	for _, failureMethod := range []string{
+		"/google.pubsub.v1.Publisher/GetTopic",
+		"/google.pubsub.v1.Publisher/CreateTopic",
+		"/google.pubsub.v1.Subscriber/GetSubscription",
+		"/google.pubsub.v1.Subscriber/CreateSubscription"} {
+		t.Run(fmt.Sprintf("%s", failureMethod), func(t *testing.T) {
+
+			ctx := context.Background()
+			pc := &testPubsubClient{}
+			defer pc.Close()
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+			failureMap := make(map[string][]failPattern)
+			failureMap[failureMethod] = []failPattern{{
+				ErrReturn: fmt.Errorf("Injected error"),
+				Count:     1,
+				Delay:     0}}
+			client, err := pc.New(ctx, projectID, failureMap)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: true,
+				AllowCreateTopic:        true,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			// We expect this receive to fail due to the injected error
+			ctx2, cancel := context.WithCancel(ctx)
+			errRet := make(chan error)
+			go func() {
+				errRet <- psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
+					msg.Ack()
+				})
+			}()
+
+			select {
+			case err := <-errRet:
+				if err == nil {
+					t.Fatalf("unexpected nil error from Receive")
+				}
+			case <-time.After(time.Minute):
+				cancel()
+				t.Fatalf("timeout waiting for receive error")
+			}
+
+			// We expect this receive to succeed
+			errRet2 := make(chan error)
+			ctx2, cancel = context.WithCancel(context.Background())
+			go func() {
+				errRet2 <- psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
+					msg.Ack()
+				})
+			}()
+			// Sleep waiting for the goroutine to create the topic and subscription
+			// If it takes over a minute, run the test anyway to get failure logging
+			for _, delay := range []time.Duration{time.Second / 4, time.Second, 20 * time.Second, 40 * time.Second} {
+				time.Sleep(delay)
+				ok, err := client.Subscription(subID).Exists(ctx)
+				if ok == true && err == nil {
+					break
+				}
+			}
+			select {
+			case err := <-errRet2:
+				t.Errorf("unexpected error from Receive: %v", err)
+			default:
+			}
+			if ok, err := client.Topic(topicID).Exists(ctx); err != nil || !ok {
+				t.Errorf("topic id=%s got exists=%v want=true, err=%v", topicID, ok, err)
+			}
+
+			if ok, err := client.Subscription(subID).Exists(ctx); err != nil || !ok {
+				t.Errorf("subscription id=%s got exists=%v want=true, err=%v", subID, ok, err)
+			}
+
+			cancel()
+		})
+	}
+}
+
+// Test that lack of create privileges for topic or subscription causes a receive to fail for
+// a non-existing subscription and topic
+func TestReceiveCreateDisallowedFail(t *testing.T) {
+	ctx := context.Background()
+	pc := &testPubsubClient{}
+	defer pc.Close()
+
+	for _, allow := range [](struct{ Sub, Topic bool }){{false, true}, {true, false}, {false, false}} {
+		t.Run(fmt.Sprintf("sub_%v__topic_%v", allow.Sub, allow.Topic), func(t *testing.T) {
+
+			projectID, topicID, subID := "test-project", "test-topic", "test-sub"
+			client, err := pc.New(ctx, projectID, nil)
+			if err != nil {
+				t.Fatalf("failed to create pubsub client: %v", err)
+			}
+			defer client.Close()
+
+			psconn := &Connection{
+				AllowCreateSubscription: allow.Sub,
+				AllowCreateTopic:        allow.Topic,
+				Client:                  client,
+				ProjectID:               projectID,
+				TopicID:                 topicID,
+				SubscriptionID:          subID,
+			}
+
+			ctx2, cancel := context.WithCancel(ctx)
+			errRet := make(chan error)
+			go func() {
+				errRet <- psconn.Receive(ctx2, func(_ context.Context, msg *pubsub.Message) {
+					msg.Ack()
+				})
+			}()
+
+			select {
+			case err := <-errRet:
+				if err == nil {
+					t.Fatalf("unexpected nil error from Receive")
+				}
+			case <-time.After(time.Minute):
+				cancel()
+				t.Fatalf("timeout waiting for receive error")
+			}
+		})
+	}
+}
+
+// Test a full round trip of a message
 func TestPublishReceiveRoundtrip(t *testing.T) {
 	ctx := context.Background()
 	pc := &testPubsubClient{}
 	defer pc.Close()
 
 	projectID, topicID, subID := "test-project", "test-topic", "test-sub"
-	client, err := pc.New(ctx, projectID)
+	client, err := pc.New(ctx, projectID, nil)
 	if err != nil {
 		t.Fatalf("failed to create pubsub client: %v", err)
 	}

--- a/v2/protocol/pubsub/internal/connection_test.go
+++ b/v2/protocol/pubsub/internal/connection_test.go
@@ -669,6 +669,7 @@ func TestReceiveCreateDisallowedFail(t *testing.T) {
 				cancel()
 				t.Fatalf("timeout waiting for receive error")
 			}
+			cancel()
 		})
 	}
 }

--- a/v2/protocol/pubsub/internal/connection_test.go
+++ b/v2/protocol/pubsub/internal/connection_test.go
@@ -291,7 +291,7 @@ func TestPublishCreateTopicAfterDelete(t *testing.T) {
 	verifyTopicDeleteWorks(t, client, psconn, topicID)
 }
 
-// Test that publishing fails if a toic doesn't exist and topic creation isn't allowed
+// Test that publishing fails if a topic doesn't exist and topic creation isn't allowed
 func TestPublishCreateTopicNotAllowedFails(t *testing.T) {
 	ctx := context.Background()
 	pc := &testPubsubClient{}

--- a/v2/protocol/pubsub/internal/connection_test.go
+++ b/v2/protocol/pubsub/internal/connection_test.go
@@ -19,10 +19,6 @@ type testPubsubClient struct {
 	conn *grpc.ClientConn
 }
 
-type pubSubClientFailureInject struct {
-	*pubsub.Client
-}
-
 type failPattern struct {
 	// Error to return.  nil for no injected error
 	ErrReturn error
@@ -211,7 +207,7 @@ func TestPublishAfterPublishFailure(t *testing.T) {
 		"/google.pubsub.v1.Publisher/GetTopic",
 		"/google.pubsub.v1.Publisher/CreateTopic",
 		"/google.pubsub.v1.Publisher/Publish"} {
-		t.Run(fmt.Sprintf("%s", failureMethod), func(t *testing.T) {
+		t.Run(failureMethod, func(t *testing.T) {
 			ctx := context.Background()
 			pc := &testPubsubClient{}
 			defer pc.Close()
@@ -545,7 +541,7 @@ func TestReceiveCreateSubscriptionAfterFailure(t *testing.T) {
 		"/google.pubsub.v1.Publisher/CreateTopic",
 		"/google.pubsub.v1.Subscriber/GetSubscription",
 		"/google.pubsub.v1.Subscriber/CreateSubscription"} {
-		t.Run(fmt.Sprintf("%s", failureMethod), func(t *testing.T) {
+		t.Run(failureMethod, func(t *testing.T) {
 
 			ctx := context.Background()
 			pc := &testPubsubClient{}


### PR DESCRIPTION
Fix Issue #472 

The connection code used a sync.Once() code for Topics and Subscriptions to ensure exactly once initialization of connection state.  This had the side effect of causing future attempts to create the Topic or Subscription to fail without a retry.

This code still enforces topic/subscription initialization to be used at most once for a topic or subsciprtion, but unlinks the topic or subscription state from the underlying connection at the end of initialization if the initialization failed.

This also adds tests for these paths as well as some other paths.