### PR TITLE
Correct sample in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ func main() {
 
 	// Send that Event.
 	if result := c.Send(ctx, event); !cloudevents.IsACK(result) {
-		log.Fatalf("failed to send, %v", err)}
+		log.Fatalf("failed to send, %v", result)
 	}
 }
 ```


### PR DESCRIPTION
1. One extra brace, will cause syntax error
2. `result` not `err`