### PR TITLE
Fix comparison to nil interface

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -216,7 +216,7 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 		}
 
 		if err != nil {
-			cecontext.LoggerFrom(ctx).Warn("Error while receiving a message: %s", err.Error())
+			cecontext.LoggerFrom(ctx).Warnf("Error while receiving a message: %s", err)
 			continue
 		}
 

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -201,7 +201,12 @@ func (p *Protocol) Respond(ctx context.Context) (binding.Message, protocol.Respo
 		if !ok {
 			return nil, nil, io.EOF
 		}
+
+		if in.msg == nil {
+			return nil, in.respFn, in.err
+		}
 		return in.msg, in.respFn, in.err
+
 	case <-ctx.Done():
 		return nil, nil, io.EOF
 	}


### PR DESCRIPTION
Fix an issue where comparing a nil Message interface to nil would always return `false`, causing the receiver to crash.

Also respond with an error instead of OK when the message encoding can't be determined.

```
HTTP/1.1 400 Bad Request
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Wed, 29 Apr 2020 10:18:26 GMT
Content-Length: 49

Cannot read CloudEvent: unknown Message encoding
```

Fixes #477