### PR TITLE
client: return result from receiver invoke

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -220,8 +220,8 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 			continue
 		}
 
-		if err := c.invoker.Invoke(ctx, msg, respFn); err != nil {
-			return err
-		}
+		err := c.invoker.Invoke(ctx, msg, respFn)
+		fmt.Println("this, however, is still nil", err)
+		return err
 	}
 }

--- a/v2/client/invoker.go
+++ b/v2/client/invoker.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
@@ -78,6 +79,7 @@ func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn p
 
 	if respFn == nil {
 		// let the protocol ACK based on the result
+		fmt.Println("this has the error returned by the func", result)
 		return result
 	}
 


### PR DESCRIPTION
Return result from function receiver invoke, this way functions
returning an err such as:

func(event.Event) (*event.Event, protocol.Result)

Will return its err instead of masking it with an empty result

CC/ @n3wscott 