### PR TITLE
Fix kafka samples

### DIFF
--- a/v2/cmd/samples/kafka/receiver/main.go
+++ b/v2/cmd/samples/kafka/receiver/main.go
@@ -13,6 +13,7 @@ import (
 
 func main() {
 	saramaConfig := sarama.NewConfig()
+	saramaConfig.Version = sarama.V2_0_0_0
 
 	receiver, err := kafka_sarama.NewConsumer([]string{"127.0.0.1:9092"}, saramaConfig, "test-group-id", "test-topic")
 	if err != nil {

--- a/v2/cmd/samples/kafka/sender-receiver/main.go
+++ b/v2/cmd/samples/kafka/sender-receiver/main.go
@@ -18,7 +18,6 @@ const (
 
 func main() {
 	saramaConfig := sarama.NewConfig()
-	saramaConfig.Producer.Return.Successes = true
 	saramaConfig.Version = sarama.V2_0_0_0
 
 	// With NewProtocol you can use the same client both to send and receive.

--- a/v2/cmd/samples/kafka/sender-receiver/main.go
+++ b/v2/cmd/samples/kafka/sender-receiver/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sync/atomic"
 
 	"github.com/Shopify/sarama"
 
@@ -11,11 +12,17 @@ import (
 	"github.com/cloudevents/sdk-go/v2/protocol/kafka_sarama"
 )
 
+const (
+	count = 10
+)
+
 func main() {
 	saramaConfig := sarama.NewConfig()
+	saramaConfig.Producer.Return.Successes = true
+	saramaConfig.Version = sarama.V2_0_0_0
 
 	// With NewProtocol you can use the same client both to send and receive.
-	protocol, err := kafka_sarama.NewProtocol([]string{"127.0.0.1:9092"}, saramaConfig, "send-test-topic", "receive-test-topic")
+	protocol, err := kafka_sarama.NewProtocol([]string{"127.0.0.1:9092"}, saramaConfig, "test-topic", "test-topic")
 	if err != nil {
 		log.Fatalf("failed to create protocol: %s", err.Error())
 	}
@@ -27,10 +34,19 @@ func main() {
 		log.Fatalf("failed to create client, %v", err)
 	}
 
+	// Create a done channel to block until we've received (count) messages
+	done := make(chan struct{})
+
 	// Start the receiver
 	go func() {
 		log.Printf("will listen consuming topic test-topic\n")
-		err = c.StartReceiver(context.TODO(), receive)
+		var recvCount int32
+		err = c.StartReceiver(context.TODO(), func(ctx context.Context, event cloudevents.Event) {
+			receive(ctx, event)
+			if atomic.AddInt32(&recvCount, 1) == count {
+				done <- struct{}{}
+			}
+		})
 		if err != nil {
 			log.Fatalf("failed to start receiver: %s", err)
 		} else {
@@ -39,7 +55,7 @@ func main() {
 	}()
 
 	// Start sending the events
-	for i := 0; i < 10; i++ {
+	for i := 0; i < count; i++ {
 		e := cloudevents.NewEvent()
 		e.SetType("com.cloudevents.sample.sent")
 		e.SetSource("https://github.com/cloudevents/sdk-go/v2/cmd/samples/httpb/requester")
@@ -55,6 +71,8 @@ func main() {
 			log.Printf("sent: %d", i)
 		}
 	}
+
+	<-done
 }
 
 func receive(ctx context.Context, event cloudevents.Event) {

--- a/v2/cmd/samples/kafka/sender/main.go
+++ b/v2/cmd/samples/kafka/sender/main.go
@@ -16,6 +16,8 @@ const (
 
 func main() {
 	saramaConfig := sarama.NewConfig()
+	saramaConfig.Producer.Return.Successes = true
+	saramaConfig.Version = sarama.V2_0_0_0
 
 	sender, err := kafka_sarama.NewSender([]string{"127.0.0.1:9092"}, saramaConfig, "test-topic")
 	if err != nil {

--- a/v2/cmd/samples/kafka/sender/main.go
+++ b/v2/cmd/samples/kafka/sender/main.go
@@ -16,7 +16,6 @@ const (
 
 func main() {
 	saramaConfig := sarama.NewConfig()
-	saramaConfig.Producer.Return.Successes = true
 	saramaConfig.Version = sarama.V2_0_0_0
 
 	sender, err := kafka_sarama.NewSender([]string{"127.0.0.1:9092"}, saramaConfig, "test-topic")

--- a/v2/protocol/kafka_sarama/protocol.go
+++ b/v2/protocol/kafka_sarama/protocol.go
@@ -98,7 +98,7 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 	defer p.consumerMux.Unlock()
 
 	logger := cecontext.LoggerFrom(ctx)
-	logger.Infof("Starting consumer group to topic {} and group id {}", p.receiverTopic, p.receiverGroupId)
+	logger.Infof("Starting consumer group to topic %s and group id %s", p.receiverTopic, p.receiverGroupId)
 
 	return p.Consumer.OpenInbound(ctx)
 }

--- a/v2/protocol/kafka_sarama/protocol.go
+++ b/v2/protocol/kafka_sarama/protocol.go
@@ -39,6 +39,8 @@ type Protocol struct {
 
 // NewProtocol creates a new kafka transport.
 func NewProtocol(brokers []string, saramaConfig *sarama.Config, sendToTopic string, receiveFromTopic string, opts ...ProtocolOptionFunc) (*Protocol, error) {
+	// Force this setting because it's required by sarama SyncProducer
+	saramaConfig.Producer.Return.Successes = true
 	client, err := sarama.NewClient(brokers, saramaConfig)
 	if err != nil {
 		return nil, err

--- a/v2/protocol/kafka_sarama/sender.go
+++ b/v2/protocol/kafka_sarama/sender.go
@@ -16,6 +16,8 @@ type Sender struct {
 
 // NewSender returns a binding.Sender that sends messages to a specific receiverTopic using sarama.SyncProducer
 func NewSender(brokers []string, saramaConfig *sarama.Config, topic string, options ...SenderOptionFunc) (*Sender, error) {
+	// Force this setting because it's required by sarama SyncProducer
+	saramaConfig.Producer.Return.Successes = true
 	producer, err := sarama.NewSyncProducer(brokers, saramaConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes the kafka sample applications so that you can run them. Mostly this involves setting a config version and required settings by sarama's synchronous producer.

For the sender and receiver example, I've changed it to use the same topic for receiver and sender and added a barrier to make sure the receiver has seen `count` messages before allowing the main function to exit.