### PR TITLE
docs: add contributor, maintainer and pr guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to CloudEvents Go SDK
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+We welcome contributions from the community! Please take some time to become
+acquainted with the process before submitting a pull request. There are just
+a few things to keep in mind.
+
+## Pull Requests
+
+Typically a pull request should relate to an existing issue. If you have
+found a bug, want to add an improvement, or suggest an API change, please
+create an issue before proceeding with a pull request. For very minor changes
+such as typos in the documentation this isn't really necessary.
+
+For step by step help with managing your pull request, have a look at our
+[PR Guidelines](pr_guidelines.md) document.
+
+### Commit Messages
+
+Please follow the
+[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
+
+### Sign your work
+
+Each PR must be signed. Be sure your `git` `user.name` and `user.email` are configured
+then use the `--signoff` flag for your commits.
+
+```console
+git commit --signoff
+```
+
+### Style Guide
+
+Code style for this module is maintained using [`eslint`](https://www.npmjs.com/package/eslint).
+When you run tests with `npm test` linting is performed first. If you want to
+check your code style for linting errors without running tests, you can just
+run `npm run lint`. If there are errors, you can usually fix them automatically
+by running `npm run fix`.
+
+Linting rules are declared in [.eslintrc](https://github.com/cloudevents/sdk-javascript/blob/master/.eslintrc).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,8 @@ git commit --signoff
 ### Style Guide
 
 Code style for this module is maintained using [`go fmt`](https://golang.org/cmd/go/#hdr-Gofmt__reformat__package_sources).
+
+### Maintainers
+
+If you are a maintainer of this repository, [here](maintainers_guide.pr) is a brief
+guide with helpful tips.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,6 @@ such as typos in the documentation this isn't really necessary.
 For step by step help with managing your pull request, have a look at our
 [PR Guidelines](pr_guidelines.md) document.
 
-### Commit Messages
-
-Please follow the
-[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
-
 ### Sign your work
 
 Each PR must be signed. Be sure your `git` `user.name` and `user.email` are configured

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to CloudEvents Go SDK
+# Contributing to CloudEvents sdk-go
 
 :+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
@@ -27,10 +27,4 @@ git commit --signoff
 
 ### Style Guide
 
-Code style for this module is maintained using [`eslint`](https://www.npmjs.com/package/eslint).
-When you run tests with `npm test` linting is performed first. If you want to
-check your code style for linting errors without running tests, you can just
-run `npm run lint`. If there are errors, you can usually fix them automatically
-by running `npm run fix`.
-
-Linting rules are declared in [.eslintrc](https://github.com/cloudevents/sdk-javascript/blob/master/.eslintrc).
+Code style for this module is maintained using [`go fmt`](https://golang.org/cmd/go/#hdr-Gofmt__reformat__package_sources).

--- a/maintainer_guidelines.md
+++ b/maintainer_guidelines.md
@@ -1,0 +1,30 @@
+# Maintainer's Guide
+
+## Tips
+
+Here are a few tips for repository maintainers.
+
+* Stay on top of your pull requests. PRs that languish for too long can become difficult to merge.
+* Work from your own fork. As you are making contributions to the project, you should be working from your own fork just as outside contributors do. This keeps the branches in github to a minimum and reduces unnecessary CI runs.
+* Try to proactively label issues with backport labels if it's obvious that a change should be backported to previous releases.
+* When landing pull requests, if there is more than one commit, try to squash into a single commit. Usually this can just be done with the GitHub UI when merging the PR. Use "Squash and merge".
+* Triage issues once in a while in order to keep the repository alive. During the triage:
+  * If some issues are stale for too long because they are no longer valid/relevant or because the discussion reached no significant action items to perform, close them and invite the users to reopen if they need it.
+  * If some PRs are no longer valid but still needed, ask the user to rebase them
+  * If some issues and PRs are still relevant, use labels to help organize tasks
+  * If you find an issue that you want to create a fix for and submit a pull request, be sure to assign it to yourself so that others maintainers don't start working on it at the same time.
+
+## Branch Management
+
+The `master` branch is is the bleeding edge. New major versions of the module
+are cut from this branch and tagged. If you intend to submit a pull request
+you should use `master HEAD` as your starting point.
+
+Each major release will result in a new branch and tag. For example, the
+release of version 1.0.0 of the project results in a `v1.0.0` tag on the
+release commit, and a new branch `release-1.y.z` for subsequent minor and patch
+level releases of that major version if necessary. However, development will continue
+apace on `master` for the next major version - e.g. 2.0.0. Version branches
+are only created for each major version. Minor and patch level releases
+are simply tagged.
+

--- a/pr_guidelines.md
+++ b/pr_guidelines.md
@@ -1,0 +1,138 @@
+# Pull Request Guidelines
+
+Here you will find step by step guidance for creating, submitting and updating
+a pull request in this repository. We hope it will help you have an easy time
+managing your work and a positive, satisfying experience when contributing
+your code. Thanks for getting involved! :rocket:
+
+* [Getting Started](#getting-started)
+* [Branches](#branches)
+* [Commit Messages](#commit-messages)
+* [Staying current with master](#staying-current-with-master)
+* [Style Guide](#style-guide)
+* [Submitting and Updating a Pull Request](#submitting-and-updating-a-pull-request)
+* [Congratulations!](#congratulations)
+
+## Getting Started
+
+When creating a pull request, first fork this repository and clone it to your
+local development environment. Then add this repository as the upstream.
+
+```console
+git clone https://github.com/mygithuborg/sdk-go.git
+cd sdk-javascript
+git remote add upstream https://github.com/cloudevents/sdk-go.git
+```
+
+## Branches
+
+The first thing you'll need to do is create a branch for your work.
+If you are submitting a pull request that fixes or relates to an existing
+GitHub issue, you can use this in your branch name to keep things organized.
+For example, if you were to create a pull request to fix
+[this error with validation](https://github.com/cloudevents/sdk-go/issues/486)
+you might create a branch named `48-fix-http-agent-error`.
+
+```console
+git fetch upstream
+git reset --hard upstream/master
+git checkout -b 48-fix-if-present-validation
+```
+
+### Signing your commits
+
+Each commit must be signed. Use the `--signoff` flag for your commits.
+
+```console
+git commit --signoff
+```
+
+This will add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+The sign-off is a signature line at the end of your commit message. Your
+signature certifies that you wrote the patch or otherwise have the right to pass
+it on as open-source code. See [developercertificate.org](http://developercertificate.org/))
+for the full text of the certification.
+
+Be sure to have your `user.name` and `user.email` set in your git config.
+If your git config information is set properly then viewing the `git log`
+information for your commit will look something like this:
+
+```
+Author: Joe Smith <joe.smith@email.com>
+Date:   Thu Feb 2 11:41:15 2018 -0800
+
+    Update README
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+```
+
+Notice the `Author` and `Signed-off-by` lines match. If they don't your PR will
+be rejected by the automated DCO check.
+
+## Staying Current with `master`
+
+As you are working on your branch, changes may happen on `master`. Before
+submitting your pull request, be sure that your branch has been updated
+with the latest commits.
+
+```console
+git fetch upstream
+git rebase upstream/master
+```
+
+This may cause conflicts if the files you are changing on your branch are
+also changed on master. Error messages from `git` will indicate if conflicts
+exist and what files need attention. Resolve the conflicts in each file, then
+continue with the rebase with `git rebase --continue`.
+
+If you've already pushed some changes to your `origin` fork, you'll
+need to force push these changes.
+
+```console
+git push -f origin 48-fix-if-present-validation
+```
+
+## Submitting and Updating Your Pull Request
+
+Before submitting a pull request, you should make sure that all of the tests
+successfully pass by running `npm test`.
+
+Once you have sent your pull request, `master` may continue to evolve
+before your pull request has landed. If there are any commits on `master`
+that conflict with your changes, you may need to update your branch with
+these changes before the pull request can land. Resolve conflicts the same
+way as before.
+
+```console
+git fetch upstream
+git rebase upstream/master
+# fix any potential conflicts
+git push -f origin 48-fix-if-present-validation
+```
+
+This will cause the pull request to be updated with your changes, and
+CI will rerun.
+
+A maintainer may ask you to make changes to your pull request. Sometimes these
+changes are minor and shouldn't appear in the commit log. For example, you may
+have a typo in one of your code comments that should be fixed before merge.
+You can prevent this from adding noise to the commit log with an interactive
+rebase. See the [git documentation](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
+for details.
+
+```console
+git commit -m "fixup: fix typo"
+git rebase -i upstream/master # follow git instructions
+```
+
+Once you have rebased your commits, you can force push to your fork as before.
+
+## Congratulations!
+
+Congratulations! You've done it! We really appreciate the time and energy
+you've given to the project. Thank you.

--- a/pr_guidelines.md
+++ b/pr_guidelines.md
@@ -19,7 +19,7 @@ local development environment. Then add this repository as the upstream.
 
 ```console
 git clone https://github.com/mygithuborg/sdk-go.git
-cd sdk-javascript
+cd sdk-go
 git remote add upstream https://github.com/cloudevents/sdk-go.git
 ```
 
@@ -30,12 +30,12 @@ If you are submitting a pull request that fixes or relates to an existing
 GitHub issue, you can use this in your branch name to keep things organized.
 For example, if you were to create a pull request to fix
 [this error with validation](https://github.com/cloudevents/sdk-go/issues/486)
-you might create a branch named `48-fix-http-agent-error`.
+you might create a branch named `486-fix-if-present-validation`.
 
 ```console
 git fetch upstream
 git reset --hard upstream/master
-git checkout -b 48-fix-if-present-validation
+git checkout -b 486-fix-if-present-validation
 ```
 
 ### Signing your commits
@@ -93,13 +93,13 @@ If you've already pushed some changes to your `origin` fork, you'll
 need to force push these changes.
 
 ```console
-git push -f origin 48-fix-if-present-validation
+git push -f origin 486-fix-if-present-validation
 ```
 
 ## Submitting and Updating Your Pull Request
 
 Before submitting a pull request, you should make sure that all of the tests
-successfully pass by running `npm test`.
+successfully pass.
 
 Once you have sent your pull request, `master` may continue to evolve
 before your pull request has landed. If there are any commits on `master`
@@ -111,7 +111,7 @@ way as before.
 git fetch upstream
 git rebase upstream/master
 # fix any potential conflicts
-git push -f origin 48-fix-if-present-validation
+git push -f origin 486-fix-if-present-validation
 ```
 
 This will cause the pull request to be updated with your changes, and

--- a/pr_guidelines.md
+++ b/pr_guidelines.md
@@ -7,10 +7,9 @@ your code. Thanks for getting involved! :rocket:
 
 * [Getting Started](#getting-started)
 * [Branches](#branches)
-* [Commit Messages](#commit-messages)
 * [Staying current with master](#staying-current-with-master)
 * [Style Guide](#style-guide)
-* [Submitting and Updating a Pull Request](#submitting-and-updating-a-pull-request)
+* [Submitting and Updating a Pull Request](#submitting-and-updating-your-pull-request)
 * [Congratulations!](#congratulations)
 
 ## Getting Started


### PR DESCRIPTION
This commit adds a simple contributors guide, and an in depth set of guidelines
for creating, submitting and updating pull requests. There is also a short set
of suggestions for repository maintainers in a third document.

In an effort to better organize and manage the javascript SDK, I have done this for that repository [here](https://github.com/cloudevents/sdk-javascript/pull/105). There has been [some pushback](https://github.com/cloudevents/sdk-javascript/pull/105#issuecomment-626840358) however because this is not common across all of the SDKs in the organization. I have slightly modified my pull request on the javascript SDK and submitted it here for wider discussion (even though I am not a committer on this project).

The most notable difference between this and what I have suggested for the javascript SDK is that we use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) fspecification in order to [manage](https://github.com/conventional-changelog/standard-version) the CHANGELOG.md and I thought this might be too big of a change/suggestion for the Go SDK.

Looking forward to the discussion.

Signed-off-by: Lance Ball <lball@redhat.com>