### PR TITLE
Data race fix in client

### DIFF
--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -16,7 +16,7 @@ fi
 COVERPKG=$(go list ./... | grep -v /vendor | tr "\n" ",")
 for gomodule in $(go list ./test/integration/... | grep -v /cmd | grep -v /vendor)
 do
-  go test -v -parallel 1 -timeout 60s -covermode=atomic -coverprofile=coverage.tmp -coverpkg "$COVERPKG" "$gomodule" 2>&1 | sed 's/ of statements in.*//; /warning: no packages being tested depend on matches for pattern /d'
+  go test -v -parallel 1 -timeout 60s -race -covermode=atomic -coverprofile=coverage.tmp -coverpkg "$COVERPKG" "$gomodule" 2>&1 | sed 's/ of statements in.*//; /warning: no packages being tested depend on matches for pattern /d'
   tail -n +2 coverage.tmp >> ./coverage.txt
 done
 rm coverage.tmp

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -11,7 +11,7 @@ echo 'mode: atomic' > ./coverage.txt
 COVERPKG=$(go list ./... | grep -v /vendor | grep -v /test | tr "\n" ",")
 for gomodule in $(go list ./... | grep -v /cmd | grep -v /vendor | grep -v /test)
 do
-  go test -v -timeout 15s -covermode=atomic -coverprofile=coverage.tmp -coverpkg "$COVERPKG" "$gomodule" 2>&1 | sed 's/ of statements in.*//; /warning: no packages being tested depend on matches for pattern /d'
+  go test -v -timeout 15s -race -covermode=atomic -coverprofile=coverage.tmp -coverpkg "$COVERPKG" "$gomodule" 2>&1 | sed 's/ of statements in.*//; /warning: no packages being tested depend on matches for pattern /d'
   tail -n +2 coverage.tmp >> ./coverage.txt
 done
 rm coverage.tmp

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -207,9 +207,6 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 		}()
 	}
 
-	var msg binding.Message
-	var respFn protocol.ResponseFn
-
 	// Start Polling.
 	wg := sync.WaitGroup{}
 	for i := 0; i < c.pollGoroutines; i++ {
@@ -217,6 +214,10 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 		go func() {
 			defer wg.Done()
 			for {
+				var msg binding.Message
+				var respFn protocol.ResponseFn
+				var err error
+
 				if c.responder != nil {
 					msg, respFn, err = c.responder.Respond(ctx)
 				} else if c.receiver != nil {

--- a/v2/client/client_test.go
+++ b/v2/client/client_test.go
@@ -436,7 +436,7 @@ func TestClientReceive(t *testing.T) {
 					ContentLength: int64(len([]byte(tc.req.Body))),
 				}
 
-				_, err = http.DefaultClient.Do(req)
+				_, _ = http.DefaultClient.Do(req)
 
 				//// Make a copy of the request.
 				//body, err := ioutil.ReadAll(resp.Body)
@@ -465,7 +465,7 @@ func TestClientReceive(t *testing.T) {
 
 				// try the request again, expecting an error:
 
-				if _, err = http.DefaultClient.Do(req); err == nil {
+				if _, err := http.DefaultClient.Do(req); err == nil {
 					t.Fatalf("expected error to when sending request to stopped client")
 				}
 			})

--- a/v2/client/client_test.go
+++ b/v2/client/client_test.go
@@ -409,7 +409,7 @@ func TestClientReceive(t *testing.T) {
 				}()
 				time.Sleep(5 * time.Millisecond) // let the server start
 
-				target, _ := url.Parse(fmt.Sprintf("http://localhost:%d%s", p.GetPort(), p.GetPath()))
+				target, _ := url.Parse(fmt.Sprintf("http://localhost:%d%s", p.GetListeningPort(), p.GetPath()))
 
 				if tc.wantErr != "" {
 					if err == nil {
@@ -529,7 +529,7 @@ func TestTracedClientReceive(t *testing.T) {
 			}()
 			time.Sleep(5 * time.Millisecond) // let the server start
 
-			target := fmt.Sprintf("http://localhost:%d", p.GetPort())
+			target := fmt.Sprintf("http://localhost:%d", p.GetListeningPort())
 			sender := simpleTracingBinaryClient(target)
 
 			ctx, span := trace.StartSpan(context.TODO(), "test-span")

--- a/v2/client/client_test.go
+++ b/v2/client/client_test.go
@@ -397,7 +397,7 @@ func TestClientReceive(t *testing.T) {
 
 				ctx, cancel := context.WithCancel(context.TODO())
 				go func() {
-					err = c.StartReceiver(ctx, func(ctx context.Context, event event.Event) error {
+					err := c.StartReceiver(ctx, func(ctx context.Context, event event.Event) error {
 						go func() {
 							events <- event
 						}()

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -22,8 +22,6 @@ require (
 	go.opencensus.io v0.22.0
 	go.uber.org/zap v1.10.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	google.golang.org/api v0.15.0
-	google.golang.org/grpc v1.26.0
 )
 
 go 1.13

--- a/v2/protocol/http/options.go
+++ b/v2/protocol/http/options.go
@@ -80,9 +80,9 @@ func WithShutdownTimeout(timeout time.Duration) Option {
 
 func checkListen(t *Protocol, prefix string) error {
 	switch {
-	case t.Port != nil:
+	case t.Port != 0:
 		return fmt.Errorf("%v port already set", prefix)
-	case t.listener != nil:
+	case t.listener.Load() != nil:
 		return fmt.Errorf("%v listener already set", prefix)
 	}
 	return nil
@@ -101,7 +101,7 @@ func WithPort(port int) Option {
 		if err := checkListen(t, "http port option"); err != nil {
 			return err
 		}
-		t.setPort(port)
+		t.Port = port
 		return nil
 	}
 }
@@ -116,9 +116,8 @@ func WithListener(l net.Listener) Option {
 		if err := checkListen(t, "http port option"); err != nil {
 			return err
 		}
-		t.listener = l
-		_, err := t.listen()
-		return err
+		t.listener.Store(l)
+		return nil
 	}
 }
 

--- a/v2/protocol/http/options.go
+++ b/v2/protocol/http/options.go
@@ -80,16 +80,14 @@ func WithShutdownTimeout(timeout time.Duration) Option {
 
 func checkListen(t *Protocol, prefix string) error {
 	switch {
-	case t.Port != 0:
-		return fmt.Errorf("%v port already set", prefix)
 	case t.listener.Load() != nil:
-		return fmt.Errorf("%v listener already set", prefix)
+		return fmt.Errorf("error setting %v: listener already set", prefix)
 	}
 	return nil
 }
 
 // WithPort sets the listening port for StartReceiver.
-// Only one of WithListener  or WithPort is allowed.
+// Only one of WithListener or WithPort is allowed.
 func WithPort(port int) Option {
 	return func(t *Protocol) error {
 		if t == nil {
@@ -113,7 +111,7 @@ func WithListener(l net.Listener) Option {
 		if t == nil {
 			return fmt.Errorf("http listener option can not set nil protocol")
 		}
-		if err := checkListen(t, "http port option"); err != nil {
+		if err := checkListen(t, "http listener"); err != nil {
 			return err
 		}
 		t.listener.Store(l)

--- a/v2/protocol/http/options_test.go
+++ b/v2/protocol/http/options_test.go
@@ -402,7 +402,7 @@ func TestWithPort0(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer func() { forceClose(tr) }()
-			port := tr.GetPort()
+			port := tr.GetListeningPort()
 			if port <= 0 {
 				t.Error("no dynamic port")
 			}
@@ -423,7 +423,7 @@ func TestWithListener_forcecloser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	port := tr.GetPort()
+	port := tr.GetListeningPort()
 	if port <= 0 {
 		t.Error("no dynamic port")
 	}

--- a/v2/protocol/http/options_test.go
+++ b/v2/protocol/http/options_test.go
@@ -310,10 +310,6 @@ func TestWithShutdownTimeout(t *testing.T) {
 	}
 }
 
-func intptr(i int) *int {
-	return &i
-}
-
 func TestWithPort(t *testing.T) {
 	testCases := map[string]struct {
 		t       *Protocol

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -42,7 +42,7 @@ type Protocol struct {
 	ShutdownTimeout time.Duration
 
 	// Port is the port to bind the receiver to. Defaults to 8080.
-	Port *int
+	Port int
 	// Path is the path to bind the receiver to. Defaults to "/".
 	Path string
 
@@ -50,8 +50,9 @@ type Protocol struct {
 	reMu sync.Mutex
 	// Handler is the handler the http Server will use. Use this to reuse the
 	// http server. If nil, the Protocol will create a one.
-	Handler           *http.ServeMux
-	listener          net.Listener
+	Handler *http.ServeMux
+
+	listener          atomic.Value
 	roundTripper      http.RoundTripper
 	server            *http.Server
 	handlerRegistered bool

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -41,7 +41,8 @@ type Protocol struct {
 	// If nil, DefaultShutdownTimeout is used.
 	ShutdownTimeout time.Duration
 
-	// Port is the port to bind the receiver to. Defaults to 8080.
+	// Port is the port configured to bind the receiver to. Defaults to 8080.
+	// If you want to know the effective port you're listening to, use GetListeningPort()
 	Port int
 	// Path is the path to bind the receiver to. Defaults to "/".
 	Path string
@@ -62,6 +63,7 @@ type Protocol struct {
 func New(opts ...Option) (*Protocol, error) {
 	p := &Protocol{
 		incoming: make(chan msgErr),
+		Port:     -1,
 	}
 	if err := p.applyOptions(opts...); err != nil {
 		return nil, err

--- a/v2/protocol/http/protocol_lifecycle.go
+++ b/v2/protocol/http/protocol_lifecycle.go
@@ -87,7 +87,7 @@ func formatSpanName(r *http.Request) string {
 func (p *Protocol) listen() (net.Listener, error) {
 	if p.listener.Load() == nil {
 		port := 8080
-		if p.Port != 0 {
+		if p.Port != -1 {
 			port = p.Port
 			if port < 0 || port > 65535 {
 				return nil, fmt.Errorf("invalid port %d", port)

--- a/v2/protocol/http/protocol_lifecycle.go
+++ b/v2/protocol/http/protocol_lifecycle.go
@@ -28,13 +28,14 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 		p.handlerRegistered = true
 	}
 
-	addr, err := p.listen()
+	// After listener is invok
+	listener, err := p.listen()
 	if err != nil {
 		return err
 	}
 
 	p.server = &http.Server{
-		Addr: addr.String(),
+		Addr: listener.Addr().String(),
 		Handler: &ochttp.Handler{
 			Propagation:    &tracecontext.HTTPFormat{},
 			Handler:        attachMiddleware(p.Handler, p.middleware),
@@ -50,7 +51,7 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- p.server.Serve(p.listener)
+		errChan <- p.server.Serve(listener)
 	}()
 
 	// wait for the server to return or ctx.Done().
@@ -67,13 +68,13 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 	}
 }
 
-// GetPort returns the listening port.
-// Returns -1 if there is a listening error.
-// Note this will call net.Listen() if  the listener is not already started.
-func (p *Protocol) GetPort() int {
-	// Ensure we have a listener and therefore a port.
-	if _, err := p.listen(); err == nil || p.Port != nil {
-		return *p.Port
+// GetListeningPort returns the listening port.
+// Returns -1 if it's not listening.
+func (p *Protocol) GetListeningPort() int {
+	if listener := p.listener.Load(); listener != nil {
+		if tcpAddr, ok := listener.(net.Listener).Addr().(*net.TCPAddr); ok {
+			return tcpAddr.Port
+		}
 	}
 	return -1
 }
@@ -82,33 +83,25 @@ func formatSpanName(r *http.Request) string {
 	return "cloudevents.http." + r.URL.Path
 }
 
-func (p *Protocol) setPort(port int) {
-	if p.Port == nil {
-		p.Port = new(int)
-	}
-	*p.Port = port
-}
-
 // listen if not already listening, update t.Port
-func (p *Protocol) listen() (net.Addr, error) {
-	if p.listener == nil {
+func (p *Protocol) listen() (net.Listener, error) {
+	if p.listener.Load() == nil {
 		port := 8080
-		if p.Port != nil {
-			port = *p.Port
+		if p.Port != 0 {
+			port = p.Port
 			if port < 0 || port > 65535 {
 				return nil, fmt.Errorf("invalid port %d", port)
 			}
 		}
 		var err error
-		if p.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", port)); err != nil {
+		var listener net.Listener
+		if listener, err = net.Listen("tcp", fmt.Sprintf(":%d", port)); err != nil {
 			return nil, err
 		}
+		p.listener.Store(listener)
+		return listener, nil
 	}
-	addr := p.listener.Addr()
-	if tcpAddr, ok := addr.(*net.TCPAddr); ok {
-		p.setPort(tcpAddr.Port)
-	}
-	return addr, nil
+	return p.listener.Load().(net.Listener), nil
 }
 
 // GetPath returns the path the transport is hosted on. If the path is '/',

--- a/v2/protocol/http/protocol_test.go
+++ b/v2/protocol/http/protocol_test.go
@@ -28,6 +28,7 @@ func TestNew(t *testing.T) {
 			want: &Protocol{
 				Client:          http.DefaultClient,
 				ShutdownTimeout: dst,
+				Port:            -1,
 			},
 		},
 	}

--- a/v2/protocol/pubsub/internal/connection_test.go
+++ b/v2/protocol/pubsub/internal/connection_test.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package internal
 
 import (


### PR DESCRIPTION
There were two data races in client:

* Using `GetPort` for getting the actual port was racy because another goroutine is starting the listening. `GetPort` now is renamed with `GetListeningPort` for clarity and the internal `net.Listener` is behind an atomic.Value
* Trivial data race introduced by this PR https://github.com/cloudevents/sdk-go/pull/497

Enabled data race check in CI