### PR TITLE
Removed perf regression on format.Lookup

### DIFF
--- a/v2/binding/format/format.go
+++ b/v2/binding/format/format.go
@@ -3,7 +3,6 @@ package format
 import (
 	"encoding/json"
 	"fmt"
-	"mime"
 	"strings"
 
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -47,8 +46,10 @@ func init() {
 
 // Lookup returns the format for contentType, or nil if not found.
 func Lookup(contentType string) Format {
-	mediaType, _, _ := mime.ParseMediaType(contentType)
-	return formats[mediaType]
+	if i := strings.IndexRune(contentType, ';'); i != -1 {
+		return formats[contentType[0:i]]
+	}
+	return formats[contentType]
 }
 
 func unknown(mediaType string) error {

--- a/v2/binding/format/format.go
+++ b/v2/binding/format/format.go
@@ -46,9 +46,11 @@ func init() {
 
 // Lookup returns the format for contentType, or nil if not found.
 func Lookup(contentType string) Format {
-	if i := strings.IndexRune(contentType, ';'); i != -1 {
-		return formats[contentType[0:i]]
+	i := strings.IndexRune(contentType, ';')
+	if i == -1 {
+		i = len(contentType)
 	}
+	contentType = strings.TrimSpace(strings.ToLower(contentType[0:i]))
 	return formats[contentType]
 }
 

--- a/v2/binding/format/format_test.go
+++ b/v2/binding/format/format_test.go
@@ -45,6 +45,12 @@ func TestLookup(t *testing.T) {
 		require.Equal(f.MediaType(), event.ApplicationCloudEventsJSON)
 		require.Equal(format.JSON, f)
 	}
+
+	{
+		f := format.Lookup("application/CLOUDEVENTS+json ; charset=utf-8")
+		require.Equal(f.MediaType(), event.ApplicationCloudEventsJSON)
+		require.Equal(format.JSON, f)
+	}
 }
 
 func TestMarshalUnmarshal(t *testing.T) {


### PR DESCRIPTION
Fixes #494 

Removed usage of `mime.ParseMediaType(contentType)` since it's quite expensive and we discard all the results except the first part. Part of the code is took from ParseMediaType directly

Now results are back to the previous values:

```
(c875624)⚡ % go test -benchmem -bench  . ./...
goos: linux
goarch: amd64
pkg: github.com/cloudevents/sdk-go/v2/protocol/kafka_sarama
BenchmarkNewStructuredMessage-8          	 3852535	       324 ns/op	     528 B/op	       5 allocs/op
BenchmarkNewBinaryMessage-8              	 1000000	      1033 ns/op	     953 B/op	      12 allocs/op
BenchmarkNewStructuredMessageToEvent-8   	   36049	     30915 ns/op	   11007 B/op	     171 allocs/op
BenchmarkNewBinaryMessageToEvent-8       	  279211	      4595 ns/op	    2701 B/op	      44 allocs/op
BenchmarkEncodeStructuredMessage-8       	 2668867	       485 ns/op	     768 B/op	       8 allocs/op
BenchmarkEncodeBinaryMessage-8           	  293518	      3889 ns/op	    2608 B/op	      47 allocs/op
PASS
ok  	github.com/cloudevents/sdk-go/v2/protocol/kafka_sarama	8.327s
(c875624)⚡ % go test -benchmem -bench  . ./...                                                                                                                                ~/go/src/github.com/cloudevents/sdk-go/v2/protocol/kafka_sarama
(c875624)⚡ [130] % git checkout remove_parse_media_type
(remove_parse_media_type) % go test -benchmem -bench  . ./...
goos: linux
goarch: amd64
pkg: github.com/cloudevents/sdk-go/v2/protocol/kafka_sarama
BenchmarkNewStructuredMessage-8          	 3656006	       340 ns/op	     528 B/op	       5 allocs/op
BenchmarkNewBinaryMessage-8              	 1000000	      1069 ns/op	     953 B/op	      12 allocs/op
BenchmarkNewStructuredMessageToEvent-8   	   38396	     31017 ns/op	   11007 B/op	     171 allocs/op
BenchmarkNewBinaryMessageToEvent-8       	  251192	      4607 ns/op	    2705 B/op	      44 allocs/op
BenchmarkEncodeStructuredMessage-8       	   32894	     37538 ns/op	   13511 B/op	     226 allocs/op
BenchmarkEncodeBinaryMessage-8           	  280929	      4264 ns/op	    2656 B/op	      50 allocs/op
PASS
ok  	github.com/cloudevents/sdk-go/v2/protocol/kafka_sarama	8.232s

```

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>