### PR TITLE
Fix Go lib version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _Note:_ Supported
 Add the module as dependency using go mod:
 
 ```
-% go get github.com/cloudevents/sdk-go/v2@V2.0.0-RC2
+% go get github.com/cloudevents/sdk-go/v2@v2.0.0-RC2
 ```
 
 And import the module in your code


### PR DESCRIPTION
The `go get` statement at the top of the README fails due to a wrongly capitalized `v`. This PR fixes that.