### PR TITLE
Reenable PubSub Connection Tests

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -26,6 +26,8 @@ require (
 	go.opencensus.io v0.22.0
 	go.uber.org/zap v1.10.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	google.golang.org/api v0.15.0
+	google.golang.org/grpc v1.26.0
 )
 
 go 1.13

--- a/v2/protocol/pubsub/internal/connection.go
+++ b/v2/protocol/pubsub/internal/connection.go
@@ -76,11 +76,7 @@ var DefaultReceiveSettings = pubsub.ReceiveSettings{
 	// Pubsub default receive settings will fill in other values.
 	// https://godoc.org/cloud.google.com/go/pubsub#Client.Subscription
 
-	// Override the default number of goroutines.
-	// This is a magical number now. This has shown throughput improvements empirically
-	// by at least 10x (compared to the default value).
-	NumGoroutines: 1000,
-	Synchronous:   false,
+	Synchronous: false,
 }
 
 func (c *Connection) getOrCreateTopicInfo(ctx context.Context, getAlreadyOpenOnly bool) (*topicInfo, error) {

--- a/v2/protocol/pubsub/internal/connection_test.go
+++ b/v2/protocol/pubsub/internal/connection_test.go
@@ -1,5 +1,3 @@
-// +build ignore
-
 package internal
 
 import (


### PR DESCRIPTION
Fixes #504. Fixes #509.

The test would previously timeout due to #509 so this modifies the default Receive settings to use the default number of GRPC streams defined by cloud.google.com/go/pubsub.