### PR TITLE
527 invalid event sigsegv

### DIFF
--- a/protocol/stan/v2/message.go
+++ b/protocol/stan/v2/message.go
@@ -3,6 +3,7 @@ package stan
 import (
 	"bytes"
 	"context"
+	"github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/nats-io/stan.go"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -53,9 +54,13 @@ func (m *Message) ReadBinary(context.Context, binding.BinaryWriter) error {
 }
 
 func (m *Message) Finish(err error) error {
-	if m.manualAcks && err == nil {
+	if !m.manualAcks {
+		return err
+	}
+
+	if protocol.IsACK(err) {
 		return m.Msg.Ack()
 	}
 
-	return nil
+	return err
 }

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -221,6 +221,7 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 					msg, respFn, err = c.responder.Respond(ctx)
 				} else if c.receiver != nil {
 					msg, err = c.receiver.Receive(ctx)
+					respFn = noRespFn
 				}
 
 				if err == io.EOF { // Normal close
@@ -240,4 +241,9 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 	}
 	wg.Wait()
 	return nil
+}
+
+// noRespFn is used to simply forward the protocol.Result for receivers that aren't responders
+func noRespFn(_ context.Context, _ binding.Message, r protocol.Result, _ ...binding.Transformer) error {
+	return r
 }


### PR DESCRIPTION
Fixes #527, also added ACK logic in the STAN protocol to be based off the provided `err`, which is likely a `protocol.Result`