### PR TITLE
Fix the link to the examples folder in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ err := json.Marshal(bytes, &event)
 
 * Look at the complete documentation: https://cloudevents.github.io/sdk-go/
 * Dig into the godoc: https://godoc.org/github.com/cloudevents/sdk-go/v2
-* Check out the [samples directory](./v2/samples) for an extended list of examples showing the different SDK features
+* Check out the [samples directory](./samples) for an extended list of examples showing the different SDK features
 
 ## Community
 


### PR DESCRIPTION
Examples are not available under ./v2/examples (anymore?), they
are in the ./examples directory, so fixing the link in the root
REAME.md.