### PR TITLE
fix broken tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,14 +59,17 @@ jobs:
       - run:
           name: Run unit tests
           command: |
+            set -o pipefail
             ./hack/unit-test.sh | tee ${TEST_RESULTS}/go-unit-test.out
       - run:
           name: Run integrations tests
           command: |
+            set -o pipefail
             TEST_AMQP_URL=amqp://localhost/test ./hack/integration-test.sh | tee ${TEST_RESULTS}/go-integration-test.out
       - run:
           name: Run conformance tests
           command: |
+            set -o pipefail
             ./hack/conformance-test.sh | tee ${TEST_RESULTS}/go-conformance-test.out
 
       - run:

--- a/v2/context/context_test.go
+++ b/v2/context/context_test.go
@@ -17,7 +17,6 @@ func TestTargetContext(t *testing.T) {
 		ctx    context.Context
 		want   *url.URL
 	}{
-		"nil context": {},
 		"todo context, set url": {
 			ctx:    context.TODO(),
 			target: "http://example.com",
@@ -35,12 +34,6 @@ func TestTargetContext(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			defer func() {
-				err := recover()
-				if err == "" {
-					t.Error("should panic in nil context")
-				}
-			}()
 
 			ctx := cecontext.WithTarget(tc.ctx, tc.target)
 

--- a/v2/context/context_test.go
+++ b/v2/context/context_test.go
@@ -18,10 +18,6 @@ func TestTargetContext(t *testing.T) {
 		want   *url.URL
 	}{
 		"nil context": {},
-		"nil context, set url": {
-			target: "http://example.com",
-			want:   exampleDotCom,
-		},
 		"todo context, set url": {
 			ctx:    context.TODO(),
 			target: "http://example.com",
@@ -39,6 +35,12 @@ func TestTargetContext(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			defer func() {
+				err := recover()
+				if err == "" {
+					t.Error("should panic in nil context")
+				}
+			}()
 
 			ctx := cecontext.WithTarget(tc.ctx, tc.target)
 

--- a/v2/context/logger_test.go
+++ b/v2/context/logger_test.go
@@ -24,7 +24,6 @@ func TestLoggerContext(t *testing.T) {
 		ctx    context.Context
 		want   *zap.SugaredLogger
 	}{
-		"nil context, panic": {},
 		"todo context, set logger": {
 			ctx:    context.TODO(),
 			logger: namedLogger,
@@ -38,14 +37,6 @@ func TestLoggerContext(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			if tc.ctx == nil {
-				defer func() {
-					err := recover()
-					if err == "" {
-						t.Error("should panic in nil context")
-					}
-				}()
-			}
 
 			ctx := WithLogger(tc.ctx, tc.logger)
 			got := LoggerFrom(ctx)

--- a/v2/context/logger_test.go
+++ b/v2/context/logger_test.go
@@ -24,13 +24,7 @@ func TestLoggerContext(t *testing.T) {
 		ctx    context.Context
 		want   *zap.SugaredLogger
 	}{
-		"nil context": {
-			want: fallbackLogger,
-		},
-		"nil context, set nop logger": {
-			logger: nopLogger,
-			want:   nopLogger,
-		},
+		"nil context, panic": {},
 		"todo context, set logger": {
 			ctx:    context.TODO(),
 			logger: namedLogger,
@@ -44,6 +38,14 @@ func TestLoggerContext(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			if tc.ctx == nil {
+				defer func() {
+					err := recover()
+					if err == "" {
+						t.Error("should panic in nil context")
+					}
+				}()
+			}
 
 			ctx := WithLogger(tc.ctx, tc.logger)
 			got := LoggerFrom(ctx)


### PR DESCRIPTION
## Description
On the CI it looks like the test is passing, but actually not.
I think this is an issue that needs to be resolved early as soon as possible for the project to proceed well.

## Why
`tee` hides the original return code.
https://github.com/cloudevents/sdk-go/blob/b276f25392c52ea8c93ef7713c817f4e5d551eb1/.circleci/config.yml#L59-L70

```
$ git checkout master
$ ./hack/unit-test.sh
...
...
PASS
coverage: 11.2%
ok  	github.com/cloudevents/sdk-go/v2/types	0.061s	coverage: 11.2%
FAIL
$ echo $?
1
```

## Need attention
And I fixed the test because it is normal to panic if a nil context is passed.
Follows the behavior of the standard library.
https://github.com/golang/go/blob/9f33108dfa22946622a8a78b5cd3f64cd3e455dd/src/context/context.go#L521