### PR TITLE
fix sync issues when using standalone http receivers

### DIFF
--- a/v2/client/http_receiver.go
+++ b/v2/client/http_receiver.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"net/http"
+	"sync"
 
 	thttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
@@ -25,8 +26,11 @@ type EventReceiver struct {
 }
 
 func (r *EventReceiver) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
 		r.p.ServeHTTP(rw, req)
+		wg.Done()
 	}()
 
 	ctx := context.Background()
@@ -36,4 +40,6 @@ func (r *EventReceiver) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	} else if err := r.invoker.Invoke(ctx, msg, respFn); err != nil {
 		// TODO
 	}
+	// Block until ServeHTTP has returned
+	wg.Wait()
 }


### PR DESCRIPTION
fixes https://github.com/cloudevents/sdk-go/issues/537

Thanks for the repo-repo @maschmid it helped a lot to track this down. 

The root cause was the function that delegated to the ServeHTTP was exiting too soon and closing the http connection, so the bindings message to event function was attempting to read the large body out of a closed http connection, throwing an error, attempting to return a 500, but unable to do that because the ... connection was already closed. 

Adding a sync group to the standalone ServeHTTP method and also using sync.WaitGroup in the normal ServeHTTP to be consistent (I know, a little overkill, but I think it might be better than just a done channel. It gives options for batch mode in the near future.)
