### PR TITLE
Adding IsUndelivered to help the readability of results from the protocol layers

### DIFF
--- a/samples/amqp/sender/main.go
+++ b/samples/amqp/sender/main.go
@@ -76,7 +76,7 @@ func main() {
 			log.Fatalf("Failed to set data: %v", err)
 		}
 
-		if result := c.Send(context.Background(), event); cloudevents.Undelivered(result) {
+		if result := c.Send(context.Background(), event); cloudevents.IsUndelivered(result) {
 			log.Fatalf("Failed to send: %v", result)
 		} else if cloudevents.IsNACK(result) {
 			log.Printf("Event not accepted: %v", result)

--- a/samples/amqp/sender/main.go
+++ b/samples/amqp/sender/main.go
@@ -76,8 +76,10 @@ func main() {
 			log.Fatalf("Failed to set data: %v", err)
 		}
 
-		if result := c.Send(context.Background(), event); !cloudevents.IsACK(result) {
+		if result := c.Send(context.Background(), event); cloudevents.Undelivered(result) {
 			log.Fatalf("Failed to send: %v", result)
+		} else if cloudevents.IsNACK(result) {
+			log.Printf("Event not accepted: %v", result)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/samples/gochan/main.go
+++ b/samples/gochan/main.go
@@ -36,7 +36,7 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		if res := c.Send(ctx, e); cloudevents.Undelivered(res) {
+		if res := c.Send(ctx, e); cloudevents.IsUndelivered(res) {
 			log.Printf("[sender] failed to send: %v", res)
 		} else {
 			log.Printf("[sender] sent: %d, accepted: %t", i, cloudevents.IsACK(res))

--- a/samples/gochan/main.go
+++ b/samples/gochan/main.go
@@ -36,11 +36,10 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		res := c.Send(ctx, e)
-		if !cloudevents.IsACK(res) {
+		if res := c.Send(ctx, e); cloudevents.Undelivered(res) {
 			log.Printf("[sender] failed to send: %v", res)
 		} else {
-			log.Printf("[sender] sent: %d", i)
+			log.Printf("[sender] sent: %d, accepted: %t", i, cloudevents.IsACK(res))
 		}
 	}
 	// Wait for the timeout.

--- a/samples/http/requester-with-custom-client/main.go
+++ b/samples/http/requester-with-custom-client/main.go
@@ -90,7 +90,7 @@ func main() {
 			Message:  "Hello world!",
 		})
 
-		if resp, res := c.Request(context.TODO(), event); !cloudevents.IsACK(res) {
+		if resp, res := c.Request(context.TODO(), event); cloudevents.Undelivered(res) {
 			log.Printf("Failed to request: %v", res)
 		} else if resp != nil {
 			fmt.Printf("Response:\n%s\n", resp)

--- a/samples/http/requester-with-custom-client/main.go
+++ b/samples/http/requester-with-custom-client/main.go
@@ -90,7 +90,7 @@ func main() {
 			Message:  "Hello world!",
 		})
 
-		if resp, res := c.Request(context.TODO(), event); cloudevents.Undelivered(res) {
+		if resp, res := c.Request(context.TODO(), event); cloudevents.IsUndelivered(res) {
 			log.Printf("Failed to request: %v", res)
 		} else if resp != nil {
 			fmt.Printf("Response:\n%s\n", resp)

--- a/samples/http/requester/main.go
+++ b/samples/http/requester/main.go
@@ -73,7 +73,7 @@ func main() {
 					ctx = cloudevents.WithEncodingStructured(ctx)
 				}
 
-				if resp, res := c.Request(ctx, event); cloudevents.Undelivered(res) {
+				if resp, res := c.Request(ctx, event); cloudevents.IsUndelivered(res) {
 					log.Printf("Failed to request: %v", res)
 				} else if resp != nil {
 					fmt.Printf("Response:\n%s\n", resp)

--- a/samples/http/requester/main.go
+++ b/samples/http/requester/main.go
@@ -73,7 +73,7 @@ func main() {
 					ctx = cloudevents.WithEncodingStructured(ctx)
 				}
 
-				if resp, res := c.Request(ctx, event); !cloudevents.IsACK(res) {
+				if resp, res := c.Request(ctx, event); cloudevents.Undelivered(res) {
 					log.Printf("Failed to request: %v", res)
 				} else if resp != nil {
 					fmt.Printf("Response:\n%s\n", resp)

--- a/samples/http/sender-retry/main.go
+++ b/samples/http/sender-retry/main.go
@@ -41,7 +41,7 @@ func send10(ctx context.Context, c cloudevents.Client) {
 			"message": "Hello, World!",
 		})
 
-		if result := c.Send(ctx, e); cloudevents.Undelivered(result) {
+		if result := c.Send(ctx, e); cloudevents.IsUndelivered(result) {
 			log.Printf("Failed to send: %s", result.Error())
 		} else if cloudevents.IsACK(result) {
 			log.Printf("Sent: %d", i)

--- a/samples/http/sender-retry/main.go
+++ b/samples/http/sender-retry/main.go
@@ -41,10 +41,12 @@ func send10(ctx context.Context, c cloudevents.Client) {
 			"message": "Hello, World!",
 		})
 
-		if result := c.Send(ctx, e); !cloudevents.IsACK(result) {
+		if result := c.Send(ctx, e); cloudevents.Undelivered(result) {
 			log.Printf("Failed to send: %s", result.Error())
-		} else {
+		} else if cloudevents.IsACK(result) {
 			log.Printf("Sent: %d", i)
+		} else if cloudevents.IsNACK(result) {
+			log.Printf("Sent but not accepted: %s", result.Error())
 		}
 		time.Sleep(50 * time.Millisecond)
 	}

--- a/samples/http/sender/main.go
+++ b/samples/http/sender/main.go
@@ -31,7 +31,7 @@ func main() {
 		})
 
 		res := c.Send(ctx, e)
-		if cloudevents.Undelivered(res) {
+		if cloudevents.IsUndelivered(res) {
 			log.Printf("Failed to send: %v", res)
 		} else {
 			var httpResult *cehttp.Result

--- a/samples/http/sender/main.go
+++ b/samples/http/sender/main.go
@@ -31,7 +31,7 @@ func main() {
 		})
 
 		res := c.Send(ctx, e)
-		if !cloudevents.IsACK(res) {
+		if cloudevents.Undelivered(res) {
 			log.Printf("Failed to send: %v", res)
 		} else {
 			var httpResult *cehttp.Result

--- a/samples/kafka/sender-receiver/main.go
+++ b/samples/kafka/sender-receiver/main.go
@@ -63,7 +63,7 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
+		if result := c.Send(context.Background(), e); cloudevents.IsUndelivered(result) {
 			log.Printf("failed to send: %v", err)
 		} else {
 			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))

--- a/samples/kafka/sender-receiver/main.go
+++ b/samples/kafka/sender-receiver/main.go
@@ -63,11 +63,10 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		err := c.Send(context.Background(), e)
-		if err != nil {
+		if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
 			log.Printf("failed to send: %v", err)
 		} else {
-			log.Printf("sent: %d", i)
+			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))
 		}
 	}
 

--- a/samples/kafka/sender/main.go
+++ b/samples/kafka/sender/main.go
@@ -39,7 +39,7 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
+		if result := c.Send(context.Background(), e); cloudevents.IsUndelivered(result) {
 			log.Printf("failed to send: %v", err)
 		} else {
 			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))

--- a/samples/kafka/sender/main.go
+++ b/samples/kafka/sender/main.go
@@ -39,11 +39,10 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		err := c.Send(context.Background(), e)
-		if err != nil {
+		if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
 			log.Printf("failed to send: %v", err)
 		} else {
-			log.Printf("sent: %d", i)
+			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))
 		}
 	}
 }

--- a/samples/nats/sender/main.go
+++ b/samples/nats/sender/main.go
@@ -60,8 +60,10 @@ func main() {
 				Message:  fmt.Sprintf("Hello, %s!", contentType),
 			})
 
-			if result := c.Send(context.Background(), e); !cloudevents.IsACK(result) {
-				log.Fatalf("failed to send: %v", result)
+			if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
+				log.Printf("failed to send: %v", err)
+			} else {
+				log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))
 			}
 			time.Sleep(100 * time.Millisecond)
 		}

--- a/samples/nats/sender/main.go
+++ b/samples/nats/sender/main.go
@@ -60,7 +60,7 @@ func main() {
 				Message:  fmt.Sprintf("Hello, %s!", contentType),
 			})
 
-			if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
+			if result := c.Send(context.Background(), e); cloudevents.IsUndelivered(result) {
 				log.Printf("failed to send: %v", err)
 			} else {
 				log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))

--- a/samples/pubsub/multisender/main.go
+++ b/samples/pubsub/multisender/main.go
@@ -63,11 +63,11 @@ func main() {
 			Message:  "HELLO " + topic,
 		})
 
-		err = c.Send(ctx, event)
-
-		if err != nil {
+		if result := c.Send(ctx, event); cloudevents.Undelivered(result) {
 			log.Printf("failed to send: %v", err)
 			os.Exit(1)
+		} else {
+			log.Printf("sent, accepted: %t", cloudevents.IsACK(result))
 		}
 	}
 

--- a/samples/pubsub/multisender/main.go
+++ b/samples/pubsub/multisender/main.go
@@ -63,7 +63,7 @@ func main() {
 			Message:  "HELLO " + topic,
 		})
 
-		if result := c.Send(ctx, event); cloudevents.Undelivered(result) {
+		if result := c.Send(ctx, event); cloudevents.IsUndelivered(result) {
 			log.Printf("failed to send: %v", err)
 			os.Exit(1)
 		} else {

--- a/samples/pubsub/sender/main.go
+++ b/samples/pubsub/sender/main.go
@@ -50,11 +50,11 @@ func main() {
 		Message:  "HELLO",
 	})
 
-	err = c.Send(context.Background(), event)
-
-	if err != nil {
+	if result := c.Send(context.Background(), event); cloudevents.Undelivered(result) {
 		log.Printf("failed to send: %v", err)
 		os.Exit(1)
+	} else {
+		log.Printf("sent, accepted: %t", cloudevents.IsACK(result))
 	}
 
 	os.Exit(0)

--- a/samples/pubsub/sender/main.go
+++ b/samples/pubsub/sender/main.go
@@ -50,7 +50,7 @@ func main() {
 		Message:  "HELLO",
 	})
 
-	if result := c.Send(context.Background(), event); cloudevents.Undelivered(result) {
+	if result := c.Send(context.Background(), event); cloudevents.IsUndelivered(result) {
 		log.Printf("failed to send: %v", err)
 		os.Exit(1)
 	} else {

--- a/samples/stan/sender-receiver/main.go
+++ b/samples/stan/sender-receiver/main.go
@@ -44,7 +44,7 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
+		if result := c.Send(context.Background(), e); cloudevents.IsUndelivered(result) {
 			log.Printf("failed to send: %v", err)
 		} else {
 			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))

--- a/samples/stan/sender-receiver/main.go
+++ b/samples/stan/sender-receiver/main.go
@@ -44,11 +44,10 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		result := c.Send(context.Background(), e)
-		if !cloudevents.IsACK(result) {
-			log.Printf("failed to send: %v", result)
+		if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
+			log.Printf("failed to send: %v", err)
 		} else {
-			log.Printf("sent: %d", i)
+			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))
 		}
 	}
 }

--- a/samples/stan/sender/main.go
+++ b/samples/stan/sender/main.go
@@ -30,11 +30,10 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		result := c.Send(context.Background(), e)
-		if !cloudevents.IsACK(result) {
-			log.Printf("failed to send: %v", result)
+		if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
+			log.Printf("failed to send: %v", err)
 		} else {
-			log.Printf("sent: %d", i)
+			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))
 		}
 	}
 }

--- a/samples/stan/sender/main.go
+++ b/samples/stan/sender/main.go
@@ -30,7 +30,7 @@ func main() {
 			"message": "Hello, World!",
 		})
 
-		if result := c.Send(context.Background(), e); cloudevents.Undelivered(result) {
+		if result := c.Send(context.Background(), e); cloudevents.IsUndelivered(result) {
 			log.Printf("failed to send: %v", err)
 		} else {
 			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))

--- a/v2/alias.go
+++ b/v2/alias.go
@@ -113,8 +113,9 @@ var (
 	ResultACK  = protocol.ResultACK
 	ResultNACK = protocol.ResultNACK
 
-	IsACK  = protocol.IsACK
-	IsNACK = protocol.IsNACK
+	IsACK       = protocol.IsACK
+	IsNACK      = protocol.IsNACK
+	Undelivered = protocol.Undelivered
 
 	// HTTP Results
 

--- a/v2/alias.go
+++ b/v2/alias.go
@@ -113,9 +113,9 @@ var (
 	ResultACK  = protocol.ResultACK
 	ResultNACK = protocol.ResultNACK
 
-	IsACK       = protocol.IsACK
-	IsNACK      = protocol.IsNACK
-	Undelivered = protocol.Undelivered
+	IsACK         = protocol.IsACK
+	IsNACK        = protocol.IsNACK
+	IsUndelivered = protocol.IsUndelivered
 
 	// HTTP Results
 

--- a/v2/protocol/result.go
+++ b/v2/protocol/result.go
@@ -53,11 +53,11 @@ func IsNACK(target Result) bool {
 	return ResultIs(target, ResultNACK)
 }
 
-// Undelivered true means the target result is not an ACK/NACK, but some other
+// IsUndelivered true means the target result is not an ACK/NACK, but some other
 // error unrelated to delivery not from the intended recipient. Likely target
 // is an error that represents some part of the protocol is misconfigured or
 // the event that was attempting to be sent was invalid.
-func Undelivered(target Result) bool {
+func IsUndelivered(target Result) bool {
 	return !ResultIs(target, ResultACK) && !ResultIs(target, ResultNACK)
 }
 

--- a/v2/protocol/result.go
+++ b/v2/protocol/result.go
@@ -38,6 +38,7 @@ func NewResult(messageFmt string, args ...interface{}) Result {
 	return fmt.Errorf(messageFmt, args...) // TODO: look at adding ACK/Nak support.
 }
 
+// IsACK true means the recipient acknowledged the event.
 func IsACK(target Result) bool {
 	// special case, nil target also means ACK.
 	if target == nil {
@@ -47,8 +48,17 @@ func IsACK(target Result) bool {
 	return ResultIs(target, ResultACK)
 }
 
+// IsNACK true means the recipient did not acknowledge the event.
 func IsNACK(target Result) bool {
 	return ResultIs(target, ResultNACK)
+}
+
+// Undelivered true means the target result is not an ACK/NACK, but some other
+// error unrelated to delivery not from the intended recipient. Likely target
+// is an error that represents some part of the protocol is misconfigured or
+// the event that was attempting to be sent was invalid.
+func Undelivered(target Result) bool {
+	return !ResultIs(target, ResultACK) && !ResultIs(target, ResultNACK)
 }
 
 var (


### PR DESCRIPTION
Fixes https://github.com/cloudevents/sdk-go/issues/526


No API change, just a new helper method to understand result a little better.

Old:

```go
		if res := c.Send(ctx, e); !cloudevents.IsACK(res) {
			log.Printf("[sender] failed to send: %v", res)
		} else {
			log.Printf("[sender] sent: %d", i)
		}
```

Turns out, this is not true always, `!IsACK` can mean it was send and not accepted on the target side.

New:

```go
		if res := c.Send(ctx, e); cloudevents.IsUndelivered(res) {
			log.Printf("[sender] failed to send: %v", res)
		} else {
			log.Printf("[sender] sent: %d, accepted: %t", i, cloudevents.IsACK(res))
		}
```

Now we can quickly understand if the event was seen by the target or not, and then test if it was accepted or not.

Signed-off-by: Scott Nichols <snichols@vmware.com>