### PR TITLE
Fix error deleting attributes when writing to HTTP messages

### DIFF
--- a/v2/protocol/http/message_test.go
+++ b/v2/protocol/http/message_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/binding/spec"
+	bindingtest "github.com/cloudevents/sdk-go/v2/binding/test"
+	"github.com/cloudevents/sdk-go/v2/binding/transformer"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/test"
 )
@@ -118,6 +120,18 @@ func TestMessageMetadataReader(t *testing.T) {
 
 	got := binding.MessageMetadataReader(NewMessageFromHttpRequest(req))
 	require.Equal(t, eventIn.Extensions()["exstring"], got.GetExtension("exstring"))
+	_, id := got.GetAttribute(spec.ID)
+	require.Equal(t, eventIn.ID(), id)
+}
+
+func TestMessageTransformDeleteExtension(t *testing.T) {
+	eventIn := test.FullEvent()
+	req := httptest.NewRequest("POST", "http://localhost", nil)
+	msg := bindingtest.MustCreateMockBinaryMessage(eventIn)
+	require.NoError(t, WriteRequest(binding.WithForceBinary(context.TODO()), msg, req, transformer.DeleteExtension("exstring")))
+
+	got := binding.MessageMetadataReader(NewMessageFromHttpRequest(req))
+	require.Equal(t, nil, got.GetExtension("exstring"))
 	_, id := got.GetAttribute(spec.ID)
 	require.Equal(t, eventIn.ID(), id)
 }

--- a/v2/protocol/http/write_request.go
+++ b/v2/protocol/http/write_request.go
@@ -106,6 +106,7 @@ func (b *httpRequestWriter) SetAttribute(attribute spec.Attribute, value interfa
 	mapping := attributeHeadersMapping[attribute.Name()]
 	if value == nil {
 		delete(b.Header, mapping)
+		return nil
 	}
 
 	// Http headers, everything is a string!
@@ -120,6 +121,7 @@ func (b *httpRequestWriter) SetAttribute(attribute spec.Attribute, value interfa
 func (b *httpRequestWriter) SetExtension(name string, value interface{}) error {
 	if value == nil {
 		delete(b.Header, extNameToHeaderName(name))
+		return nil
 	}
 	// Http headers, everything is a string!
 	s, err := types.Format(value)


### PR DESCRIPTION
Transformers which delete attributes currently fail when writing a binary message to an HTTP request with the error "invalid CloudEvents value: <nil>".