### PR TITLE
Avoid Copying Event Data When Possible in binding.ToEvent

### DIFF
--- a/protocol/amqp/v2/message.go
+++ b/protocol/amqp/v2/message.go
@@ -100,7 +100,7 @@ func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) 
 
 	data := m.AMQP.GetData()
 	if len(data) != 0 { // Some data
-		err = encoder.SetData(bytes.NewReader(data))
+		err = encoder.SetData(bytes.NewBuffer(data))
 		if err != nil {
 			return err
 		}

--- a/protocol/kafka_sarama/v2/message.go
+++ b/protocol/kafka_sarama/v2/message.go
@@ -115,7 +115,7 @@ func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) 
 	}
 
 	if m.Value != nil {
-		err = encoder.SetData(bytes.NewReader(m.Value))
+		err = encoder.SetData(bytes.NewBuffer(m.Value))
 	}
 
 	return

--- a/protocol/pubsub/v2/message.go
+++ b/protocol/pubsub/v2/message.go
@@ -96,7 +96,7 @@ func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) 
 	}
 
 	if m.internal.Data != nil {
-		return encoder.SetData(bytes.NewReader(m.internal.Data))
+		return encoder.SetData(bytes.NewBuffer(m.internal.Data))
 	}
 
 	return

--- a/v2/binding/event_message.go
+++ b/v2/binding/event_message.go
@@ -48,7 +48,7 @@ func (m *EventMessage) ReadBinary(ctx context.Context, b BinaryWriter) (err erro
 	// Pass the body
 	body := (*event.Event)(m).Data()
 	if len(body) > 0 {
-		err = b.SetData(bytes.NewReader(body))
+		err = b.SetData(bytes.NewBuffer(body))
 		if err != nil {
 			return err
 		}

--- a/v2/binding/to_event.go
+++ b/v2/binding/to_event.go
@@ -79,12 +79,15 @@ func (b *messageToEventBuilder) End(ctx context.Context) error {
 }
 
 func (b *messageToEventBuilder) SetData(data io.Reader) error {
-	var buf bytes.Buffer
-	w, err := io.Copy(&buf, data)
-	if err != nil {
-		return err
+	buf, ok := data.(*bytes.Buffer)
+	if !ok {
+		buf = new(bytes.Buffer)
+		_, err := io.Copy(buf, data)
+		if err != nil {
+			return err
+		}
 	}
-	if w != 0 {
+	if buf.Len() > 0 {
 		b.DataEncoded = buf.Bytes()
 	}
 	return nil


### PR DESCRIPTION
Protocols which already buffer the event data can directly pass that buffer to the event created by binding.ToEvent. This change uses coercion from bytes.Buffer to skip copying the event data. Messages which do not wish to allow sharing of buffered event data, e.g. buffered messages which use a byte pool, should use bytes.Reader instead.