### PR TITLE
Do not copy bytes.Buffer when writing a pubsub message

### DIFF
--- a/protocol/pubsub/v2/write_pubsub_message.go
+++ b/protocol/pubsub/v2/write_pubsub_message.go
@@ -50,10 +50,13 @@ func (b *pubsubMessagePublisher) End(ctx context.Context) error {
 }
 
 func (b *pubsubMessagePublisher) SetData(reader io.Reader) error {
-	var buf bytes.Buffer
-	_, err := io.Copy(&buf, reader)
-	if err != nil {
-		return err
+	buf, ok := reader.(*bytes.Buffer)
+	if !ok {
+		buf = new(bytes.Buffer)
+		_, err := io.Copy(buf, reader)
+		if err != nil {
+			return err
+		}
 	}
 	b.Data = buf.Bytes()
 	return nil


### PR DESCRIPTION
Applies the optimization from #561 to pubsub messages, allowing them to avoid copying data when given a bytes.Buffer.