### PR TITLE
Add ochttp middleware for W3C tracecontext headers in default client

### DIFF
--- a/v2/client/client_default.go
+++ b/v2/client/client_default.go
@@ -12,7 +12,7 @@ import (
 // client, all outbound events will have a time and id set if not already
 // present.
 func NewDefault() (Client, error) {
-	p, err := http.New()
+	p, err := http.NewObserved()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #572 