### PR TITLE
pass http.Option through

### DIFF
--- a/v2/client/client_default.go
+++ b/v2/client/client_default.go
@@ -11,8 +11,8 @@ import (
 // The WithTimeNow, and WithUUIDs client options are also applied to the
 // client, all outbound events will have a time and id set if not already
 // present.
-func NewDefault() (Client, error) {
-	p, err := http.NewObserved()
+func NewDefault(opts ...http.Option) (Client, error) {
+	p, err := http.NewObserved(opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In order to pass HTTP.Option into the client, I basically had to duplicate the NewDefault as seen here:
https://github.com/knative-sandbox/eventing-rabbitmq/pull/113/files#diff-e45c0bc45ea5877a2e315d983df2d17eR77

If we just allow the protocol Option optionally here (so doesn't change the signature), I could use this method as is.

WDYT?