### PR TITLE
[Braindump] Proposal for redesigning the client interface

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -17,32 +17,52 @@ import (
 )
 
 // Client interface defines the runtime contract the CloudEvents client supports.
-type Client interface {
+type Sender interface {
 	// Send will transmit the given event over the client's configured transport.
 	Send(ctx context.Context, event event.Event) protocol.Result
 
 	// Request will transmit the given event over the client's configured
 	// transport and return any response event.
 	Request(ctx context.Context, event event.Event) (*event.Event, protocol.Result)
+}
 
-	// StartReceiver will register the provided function for callback on receipt
-	// of a cloudevent. It will also start the underlying protocol as it has
-	// been configured.
-	// This call is blocking.
-	// Valid fn signatures are:
-	// * func()
-	// * func() error
-	// * func(context.Context)
-	// * func(context.Context) protocol.Result
-	// * func(event.Event)
-	// * func(event.Event) protocol.Result
-	// * func(context.Context, event.Event)
-	// * func(context.Context, event.Event) protocol.Result
-	// * func(event.Event) *event.Event
-	// * func(event.Event) (*event.Event, protocol.Result)
-	// * func(context.Context, event.Event) *event.Event
-	// * func(context.Context, event.Event) (*event.Event, protocol.Result)
-	StartReceiver(ctx context.Context, fn interface{}) error
+type ReceiverEvent interface {
+	Event() event.Event
+	Ack()
+	Reply(event *event.Event)
+	ReplyWithResult(*event.Event, protocol.Result)
+}
+
+// Client interface defines the runtime contract the CloudEvents client supports.
+type Receiver interface {
+	Channel() <-chan ReceiverEvent
+}
+
+type Client interface {
+	protocol.Closer
+	Sender
+	Receiver
+}
+
+// StartHandler will register the provided function for callback on receipt
+// of a cloudevent. It will also start the underlying protocol as it has
+// been configured.
+// This call is blocking.
+// Valid fn signatures are:
+// * func()
+// * func() error
+// * func(context.Context)
+// * func(context.Context) protocol.Result
+// * func(event.Event)
+// * func(event.Event) protocol.Result
+// * func(context.Context, event.Event)
+// * func(context.Context, event.Event) protocol.Result
+// * func(event.Event) *event.Event
+// * func(event.Event) (*event.Event, protocol.Result)
+// * func(context.Context, event.Event) *event.Event
+// * func(context.Context, event.Event) (*event.Event, protocol.Result)
+func StartHandler(ctx context.Context, fn interface{}) error {
+
 }
 
 // New produces a new client with the provided transport object and applied

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -17,34 +17,22 @@ import (
 )
 
 // Client interface defines the runtime contract the CloudEvents client supports.
-type Sender interface {
+type Client interface {
 	// Send will transmit the given event over the client's configured transport.
 	Send(ctx context.Context, event event.Event) protocol.Result
 
 	// Request will transmit the given event over the client's configured
 	// transport and return any response event.
 	Request(ctx context.Context, event event.Event) (*event.Event, protocol.Result)
+
+	Receive(ctx context.Context) (event.Event, error)
+
+	Respond(ctx context.Context) (event.Event, ResponseFn, error)
 }
 
-type ReceiverEvent interface {
-	Event() event.Event
-	Ack()
-	Reply(event *event.Event)
-	ReplyWithResult(*event.Event, protocol.Result)
-}
+type ResponseFn func(ctx context.Context, e *event.Event, r protocol.Result) error
 
-// Client interface defines the runtime contract the CloudEvents client supports.
-type Receiver interface {
-	Channel() <-chan ReceiverEvent
-}
-
-type Client interface {
-	protocol.Closer
-	Sender
-	Receiver
-}
-
-// StartHandler will register the provided function for callback on receipt
+// StartEventHandler will register the provided function for callback on receipt
 // of a cloudevent. It will also start the underlying protocol as it has
 // been configured.
 // This call is blocking.
@@ -61,7 +49,7 @@ type Client interface {
 // * func(event.Event) (*event.Event, protocol.Result)
 // * func(context.Context, event.Event) *event.Event
 // * func(context.Context, event.Event) (*event.Event, protocol.Result)
-func StartHandler(ctx context.Context, fn interface{}) error {
+func StartEventHandler(ctx context.Context, fn interface{}) error {
 
 }
 


### PR DESCRIPTION
I came out with this proposal after working on #606.

My problem with the `Client` interface is that, while `Send` and `Request` maps the interfaces in protocol, `StartReceiver` doesn't map the semantics of `Receiver` and `Responder`. This is particularly weird with `websocket` for example, when you have a bi-directional client per stream, so you can do something like:

```golang
c.Send()
[...]
c.Receive()
```

In particular, I find that `StartReceiver` is opinionated, maps to the concepts of http more than the concepts of messaging and it's less golang idiomatic than a channel or a method like `Receive`. Another point to consider is that going from the method invocation to the handler mode is relatively straightforward (and we could easily provide the method to do it, like showed in this PR), while going from the handler mode to the method invocation is harder and, generally, more error prone. 

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>