### PR TITLE
Remove regex to check the extension name

### DIFF
--- a/v2/event/eventcontext_v1.go
+++ b/v2/event/eventcontext_v1.go
@@ -72,7 +72,7 @@ func (ec EventContextV1) ExtensionAs(name string, obj interface{}) error {
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
 // This function fails if the name doesn't respect the regex ^[a-zA-Z0-9]+$
 func (ec *EventContextV1) SetExtension(name string, value interface{}) error {
-	if !IsAlphaNumeric(name) {
+	if !IsExtensionNameValid(name) {
 		return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set")
 	}
 

--- a/v2/event/extensions.go
+++ b/v2/event/extensions.go
@@ -25,7 +25,7 @@ func IsExtensionNameValid(key string) bool {
 		return false
 	}
 	for _, c := range key {
-		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
 			return false
 		}
 	}

--- a/v2/event/extensions.go
+++ b/v2/event/extensions.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"regexp"
 	"strings"
 )
 
@@ -21,4 +20,14 @@ func caseInsensitiveSearch(key string, space map[string]interface{}) (interface{
 	return nil, false
 }
 
-var IsAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString
+func IsExtensionNameValid(key string) bool {
+	if len(key) < 1 || len(key) > 20 {
+		return false
+	}
+	for _, c := range key {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
There's no need to use a regex for this simple check, this PR removes the regex and replaces it with a simple logic, which is a bit more efficient and allocates less

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>