### PR TITLE
Implemented streaming writer

### DIFF
--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -1,13 +1,192 @@
 package event
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/cloudevents/sdk-go/v2/observability"
 )
+
+// WriteJson assumes the input event is valid
+func WriteJson(in *Event, writer io.Writer) error {
+	stream := jsoniter.NewStream(jsoniter.ConfigFastest, writer, 1024)
+	stream.WriteObjectStart()
+
+	var ext map[string]interface{}
+	var dct *string
+	var isBase64 bool
+
+	// Write the context (without the extensions)
+	switch eventContext := in.Context.(type) {
+	case *EventContextV03:
+		// Set a bunch of variables we need later
+		ext = eventContext.Extensions
+		dct = eventContext.DataContentType
+		isBase64 = eventContext.DataContentEncoding != nil
+
+		stream.WriteObjectField("specversion")
+		stream.WriteString(CloudEventsVersionV03)
+		stream.WriteMore()
+
+		stream.WriteObjectField("id")
+		stream.WriteString(eventContext.ID)
+		stream.WriteMore()
+
+		stream.WriteObjectField("source")
+		stream.WriteString(eventContext.Source.String())
+		stream.WriteMore()
+
+		stream.WriteObjectField("type")
+		stream.WriteString(eventContext.Type)
+
+		if eventContext.Subject != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("subject")
+			stream.WriteString(*eventContext.Subject)
+		}
+
+		if eventContext.DataContentEncoding != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("datacontentencoding")
+			stream.WriteString(*eventContext.DataContentEncoding)
+		}
+
+		if eventContext.DataContentType != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("datacontenttype")
+			stream.WriteString(*eventContext.DataContentType)
+		}
+
+		if eventContext.SchemaURL != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("schemaurl")
+			stream.WriteString(eventContext.SchemaURL.String())
+		}
+
+		if eventContext.Time != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("time")
+			stream.WriteString(eventContext.Time.String())
+		}
+	case *EventContextV1:
+		// Set a bunch of variables we need later
+		ext = eventContext.Extensions
+		dct = eventContext.DataContentType
+		isBase64 = in.DataBase64
+
+		stream.WriteObjectField("specversion")
+		stream.WriteString(CloudEventsVersionV1)
+		stream.WriteMore()
+
+		stream.WriteObjectField("id")
+		stream.WriteString(eventContext.ID)
+		stream.WriteMore()
+
+		stream.WriteObjectField("source")
+		stream.WriteString(eventContext.Source.String())
+		stream.WriteMore()
+
+		stream.WriteObjectField("type")
+		stream.WriteString(eventContext.Type)
+
+		if eventContext.Subject != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("subject")
+			stream.WriteString(*eventContext.Subject)
+		}
+
+		if eventContext.DataContentType != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("datacontenttype")
+			stream.WriteString(*eventContext.DataContentType)
+		}
+
+		if eventContext.DataSchema != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("dataschema")
+			stream.WriteString(eventContext.DataSchema.String())
+		}
+
+		if eventContext.Time != nil {
+			stream.WriteMore()
+			stream.WriteObjectField("time")
+			stream.WriteString(eventContext.Time.String())
+		}
+	}
+
+	// Let's do a check on the error
+	if stream.Error != nil {
+		return fmt.Errorf("error while writing the event attributes: %w", stream.Error)
+	}
+
+	// Let's write the body
+	if in.DataEncoded != nil {
+		stream.WriteMore()
+
+		// We need to figure out the media type first
+		var mediaType string
+		if dct == nil {
+			mediaType = ApplicationJSON
+		} else {
+			// This code is required to extract the media type from the full content type string (which might contain encoding and stuff)
+			contentType := *dct
+			i := strings.IndexRune(contentType, ';')
+			if i == -1 {
+				i = len(contentType)
+			}
+			mediaType = strings.TrimSpace(strings.ToLower(contentType[0:i]))
+		}
+
+		isJson := mediaType == "" || mediaType == ApplicationJSON || mediaType == TextJSON
+
+		// If isJson and no encoding to base64, we don't need to perform additional steps
+		if isJson && !isBase64 {
+			stream.WriteObjectField("data")
+			_, err := stream.Write(in.DataEncoded)
+			if err != nil {
+				return fmt.Errorf("error while writing data: %w", err)
+			}
+		} else {
+			if in.Context.GetSpecVersion() == CloudEventsVersionV1 && isBase64 {
+				stream.WriteObjectField("data_base64")
+			} else {
+				stream.WriteObjectField("data")
+			}
+			// At this point of we need to write to base 64 string, or we just need to write the plain string
+			if isBase64 {
+				stream.WriteString(base64.StdEncoding.EncodeToString(in.DataEncoded))
+			} else {
+				stream.WriteString(string(in.DataEncoded))
+			}
+		}
+
+	}
+
+	// Let's do a check on the error
+	if stream.Error != nil {
+		return fmt.Errorf("error while writing the event data: %w", stream.Error)
+	}
+
+	for k, v := range ext {
+		stream.WriteMore()
+		stream.WriteObjectField(k)
+		stream.WriteVal(v)
+	}
+
+	stream.WriteObjectEnd()
+
+	// Let's do a check on the error
+	if stream.Error != nil {
+		return fmt.Errorf("error while writing the event extensions: %w", stream.Error)
+	}
+	return stream.Flush()
+}
 
 // MarshalJSON implements a custom json marshal method used when this type is
 // marshaled using json.Marshal.
@@ -19,116 +198,14 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	var b []byte
-	var err error
-
-	switch e.SpecVersion() {
-	case CloudEventsVersionV03:
-		b, err = JsonEncodeLegacy(e)
-	case CloudEventsVersionV1:
-		b, err = JsonEncode(e)
-	default:
-		return nil, ValidationError{"specversion": fmt.Errorf("unknown : %q", e.SpecVersion())}
-	}
+	var buf bytes.Buffer
+	err := WriteJson(&e, &buf)
 
 	// Report the observable
 	if err != nil {
 		r.Error()
 		return nil, err
-	} else {
-		r.OK()
 	}
-
-	return b, nil
-}
-
-// JsonEncode encodes an event to JSON
-func JsonEncode(e Event) ([]byte, error) {
-	return jsonEncode(e.Context, e.DataEncoded, e.DataBase64)
-}
-
-// JsonEncodeLegacy performs legacy JSON encoding
-func JsonEncodeLegacy(e Event) ([]byte, error) {
-	isBase64 := e.Context.DeprecatedGetDataContentEncoding() == Base64
-	return jsonEncode(e.Context, e.DataEncoded, isBase64)
-}
-
-func jsonEncode(ctx EventContextReader, data []byte, shouldEncodeToBase64 bool) ([]byte, error) {
-	var b map[string]json.RawMessage
-	var err error
-
-	b, err = marshalEvent(ctx, ctx.GetExtensions())
-	if err != nil {
-		return nil, err
-	}
-
-	if data != nil {
-		// data here is a serialized version of whatever payload.
-		// If we need to write the payload as base64, shouldEncodeToBase64 is true.
-		mediaType, err := ctx.GetDataMediaType()
-		if err != nil {
-			return nil, err
-		}
-		isJson := mediaType == "" || mediaType == ApplicationJSON || mediaType == TextJSON
-		// If isJson and no encoding to base64, we don't need to perform additional steps
-		if isJson && !shouldEncodeToBase64 {
-			b["data"] = data
-		} else {
-			var dataKey = "data"
-			if ctx.GetSpecVersion() == CloudEventsVersionV1 && shouldEncodeToBase64 {
-				dataKey = "data_base64"
-			}
-			var dataPointer []byte
-			if shouldEncodeToBase64 {
-				dataPointer, err = json.Marshal(data)
-			} else {
-				dataPointer, err = json.Marshal(string(data))
-			}
-			if err != nil {
-				return nil, err
-			}
-
-			b[dataKey] = dataPointer
-		}
-	}
-
-	body, err := json.Marshal(b)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
-}
-
-func marshalEvent(eventCtx EventContextReader, extensions map[string]interface{}) (map[string]json.RawMessage, error) {
-	b, err := json.Marshal(eventCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	brm := map[string]json.RawMessage{}
-	if err := json.Unmarshal(b, &brm); err != nil {
-		return nil, err
-	}
-
-	sv, err := json.Marshal(eventCtx.GetSpecVersion())
-	if err != nil {
-		return nil, err
-	}
-
-	brm["specversion"] = sv
-
-	for k, v := range extensions {
-		k = strings.ToLower(k)
-		vb, err := json.Marshal(v)
-		if err != nil {
-			return nil, err
-		}
-		// Don't overwrite spec keys.
-		if _, ok := brm[k]; !ok {
-			brm[k] = vb
-		}
-	}
-
-	return brm, nil
+	r.OK()
+	return buf.Bytes(), nil
 }

--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -29,7 +29,6 @@ func WriteJson(in *Event, writer io.Writer) error {
 		// Set a bunch of variables we need later
 		ext = eventContext.Extensions
 		dct = eventContext.DataContentType
-		isBase64 = eventContext.DataContentEncoding != nil
 
 		stream.WriteObjectField("specversion")
 		stream.WriteString(CloudEventsVersionV03)
@@ -53,6 +52,7 @@ func WriteJson(in *Event, writer io.Writer) error {
 		}
 
 		if eventContext.DataContentEncoding != nil {
+			isBase64 = true
 			stream.WriteMore()
 			stream.WriteObjectField("datacontentencoding")
 			stream.WriteString(*eventContext.DataContentEncoding)

--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -13,7 +13,8 @@ import (
 	"github.com/cloudevents/sdk-go/v2/observability"
 )
 
-// WriteJson assumes the input event is valid
+// WriteJson writes the in event in the provided writer.
+// Note: this function assumes the input event is valid.
 func WriteJson(in *Event, writer io.Writer) error {
 	stream := jsoniter.NewStream(jsoniter.ConfigFastest, writer, 1024)
 	stream.WriteObjectStart()

--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -16,7 +16,8 @@ import (
 // WriteJson writes the in event in the provided writer.
 // Note: this function assumes the input event is valid.
 func WriteJson(in *Event, writer io.Writer) error {
-	stream := jsoniter.NewStream(jsoniter.ConfigFastest, writer, 1024)
+	stream := jsoniter.ConfigFastest.BorrowStream(writer)
+	defer jsoniter.ConfigFastest.ReturnStream(stream)
 	stream.WriteObjectStart()
 
 	var ext map[string]interface{}

--- a/v2/event/event_marshal_test.go
+++ b/v2/event/event_marshal_test.go
@@ -1,12 +1,12 @@
 package event_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/url"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -31,7 +31,7 @@ func TestMarshal(t *testing.T) {
 	testCases := map[string]struct {
 		event           event.Event
 		eventExtensions map[string]interface{}
-		want            []byte
+		want            map[string]interface{}
 		wantErr         *string
 	}{
 		"empty struct": {
@@ -63,25 +63,25 @@ func TestMarshal(t *testing.T) {
 				"exurl":    source,
 				"extime":   &now,
 			},
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "0.3",
 				"datacontenttype": "application/json",
 				"data": map[string]interface{}{
-					"a": 42,
+					"a": float64(42),
 					"b": "testing",
 				},
 				"id":        "ABC-123",
 				"time":      now.Format(time.RFC3339Nano),
 				"type":      "com.example.test",
 				"exbool":    true,
-				"exint":     42,
+				"exint":     float64(42),
 				"exstring":  "exstring",
 				"exbinary":  "AAECAw==",
 				"exurl":     "http://example.com/source",
 				"extime":    now.Format(time.RFC3339Nano),
 				"schemaurl": "http://example.com/schema",
 				"source":    "http://example.com/source",
-			}),
+			},
 		},
 		"nil data v0.3": {
 			event: event.Event{
@@ -102,21 +102,21 @@ func TestMarshal(t *testing.T) {
 				"exurl":    source,
 				"extime":   &now,
 			},
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "0.3",
 				"datacontenttype": "application/json",
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"exbool":          true,
-				"exint":           42,
+				"exint":           float64(42),
 				"exstring":        "exstring",
 				"exbinary":        "AAECAw==",
 				"exurl":           "http://example.com/source",
 				"extime":          now.Format(time.RFC3339Nano),
 				"schemaurl":       "http://example.com/schema",
 				"source":          "http://example.com/source",
-			}),
+			},
 		},
 		"string data v0.3": {
 			event: func() event.Event {
@@ -140,7 +140,7 @@ func TestMarshal(t *testing.T) {
 				"exurl":    source,
 				"extime":   &now,
 			},
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "0.3",
 				"datacontenttype": "application/json",
 				"data":            "This is a string.",
@@ -148,14 +148,14 @@ func TestMarshal(t *testing.T) {
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"exbool":          true,
-				"exint":           42,
+				"exint":           float64(42),
 				"exstring":        "exstring",
 				"exbinary":        "AAECAw==",
 				"exurl":           "http://example.com/source",
 				"extime":          now.Format(time.RFC3339Nano),
 				"schemaurl":       "http://example.com/schema",
 				"source":          "http://example.com/source",
-			}),
+			},
 		},
 		"struct data v1.0": {
 			event: func() event.Event {
@@ -182,25 +182,25 @@ func TestMarshal(t *testing.T) {
 				"exurl":    sourceV1,
 				"extime":   &now,
 			},
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "1.0",
 				"datacontenttype": "application/json",
 				"data": map[string]interface{}{
-					"a": 42,
+					"a": float64(42),
 					"b": "testing",
 				},
 				"id":         "ABC-123",
 				"time":       now.Format(time.RFC3339Nano),
 				"type":       "com.example.test",
 				"exbool":     true,
-				"exint":      42,
+				"exint":      float64(42),
 				"exstring":   "exstring",
 				"exbinary":   "AAECAw==",
 				"exurl":      "http://example.com/source",
 				"extime":     now.Format(time.RFC3339Nano),
 				"dataschema": "http://example.com/schema",
 				"source":     "http://example.com/source",
-			}),
+			},
 		},
 		"nil data v1.0": {
 			event: event.Event{
@@ -221,21 +221,21 @@ func TestMarshal(t *testing.T) {
 				"exurl":    sourceV1,
 				"extime":   &now,
 			},
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "1.0",
 				"datacontenttype": "application/json",
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"exbool":          true,
-				"exint":           42,
+				"exint":           float64(42),
 				"exstring":        "exstring",
 				"exbinary":        "AAECAw==",
 				"exurl":           "http://example.com/source",
 				"extime":          now.Format(time.RFC3339Nano),
 				"dataschema":      "http://example.com/schema",
 				"source":          "http://example.com/source",
-			}),
+			},
 		},
 		"string data v1.0": {
 			event: func() event.Event {
@@ -259,7 +259,7 @@ func TestMarshal(t *testing.T) {
 				"exurl":    sourceV1,
 				"extime":   &now,
 			},
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "1.0",
 				"datacontenttype": "application/json",
 				"data":            "This is a string.",
@@ -267,14 +267,14 @@ func TestMarshal(t *testing.T) {
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"exbool":          true,
-				"exint":           42,
+				"exint":           float64(42),
 				"exstring":        "exstring",
 				"exbinary":        "AAECAw==",
 				"exurl":           "http://example.com/source",
 				"extime":          now.Format(time.RFC3339Nano),
 				"dataschema":      "http://example.com/schema",
 				"source":          "http://example.com/source",
-			}),
+			},
 		},
 		"base64 json encoded data v1.0": {
 			event: func() event.Event {
@@ -290,16 +290,16 @@ func TestMarshal(t *testing.T) {
 				_ = e.SetData(event.ApplicationJSON, []byte(`{"hello": "world"}`))
 				return e
 			}(),
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "1.0",
 				"datacontenttype": "application/json",
-				"data_base64":     []byte(`{"hello": "world"}`),
+				"data_base64":     base64.StdEncoding.EncodeToString([]byte(`{"hello": "world"}`)),
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"dataschema":      "http://example.com/schema",
 				"source":          "http://example.com/source",
-			}),
+			},
 		},
 		"base64 xml encoded data v1.0": {
 			event: func() event.Event {
@@ -315,16 +315,16 @@ func TestMarshal(t *testing.T) {
 				_ = e.SetData(event.ApplicationXML, mustEncodeWithDataCodec(t, event.ApplicationXML, XMLDataExample{AnInt: 5, AString: "aaa"}))
 				return e
 			}(),
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "1.0",
 				"datacontenttype": event.ApplicationXML,
-				"data_base64":     mustEncodeWithDataCodec(t, event.ApplicationXML, XMLDataExample{AnInt: 5, AString: "aaa"}),
+				"data_base64":     base64.StdEncoding.EncodeToString(mustEncodeWithDataCodec(t, event.ApplicationXML, XMLDataExample{AnInt: 5, AString: "aaa"})),
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"dataschema":      "http://example.com/schema",
 				"source":          "http://example.com/source",
-			}),
+			},
 		},
 		"xml data v1.0": {
 			event: func() event.Event {
@@ -340,7 +340,7 @@ func TestMarshal(t *testing.T) {
 				_ = e.SetData(event.ApplicationXML, XMLDataExample{AnInt: 5, AString: "aaa"})
 				return e
 			}(),
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "1.0",
 				"datacontenttype": event.ApplicationXML,
 				"data":            string(mustEncodeWithDataCodec(t, event.ApplicationXML, XMLDataExample{AnInt: 5, AString: "aaa"})),
@@ -349,7 +349,7 @@ func TestMarshal(t *testing.T) {
 				"type":            "com.example.test",
 				"dataschema":      "http://example.com/schema",
 				"source":          "http://example.com/source",
-			}),
+			},
 		},
 		"number data v1.0": {
 			event: func() event.Event {
@@ -365,21 +365,20 @@ func TestMarshal(t *testing.T) {
 				_ = e.SetData(event.ApplicationJSON, 101)
 				return e
 			}(),
-			want: mustJsonMarshal(t, map[string]interface{}{
+			want: map[string]interface{}{
 				"specversion":     "1.0",
 				"datacontenttype": "application/json",
-				"data":            101,
+				"data":            float64(101),
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"dataschema":      "http://example.com/schema",
 				"source":          "http://example.com/source",
-			}),
+			},
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-
 			event := tc.event
 
 			for k, v := range tc.eventExtensions {
@@ -388,20 +387,16 @@ func TestMarshal(t *testing.T) {
 
 			gotBytes, err := json.Marshal(event)
 
-			if tc.wantErr != nil || err != nil {
-				if diff := cmp.Diff(*tc.wantErr, err.Error()); diff != "" {
-					t.Errorf("unexpected error (-want, +got) = %v", diff)
-				}
+			if tc.wantErr != nil {
+				require.Error(t, err, *tc.wantErr)
 				return
 			}
 
-			// so we can understand the diff, turn bytes to strings
-			want := string(tc.want)
-			got := string(gotBytes)
+			// so we can understand the diff, turn bytes to map
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal(gotBytes, &got))
 
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("unexpected event (-want, +got) = %v", diff)
-			}
+			require.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/v2/event/event_marshal_test.go
+++ b/v2/event/event_marshal_test.go
@@ -67,14 +67,14 @@ func TestMarshal(t *testing.T) {
 				"specversion":     "0.3",
 				"datacontenttype": "application/json",
 				"data": map[string]interface{}{
-					"a": float64(42),
+					"a": 42,
 					"b": "testing",
 				},
 				"id":        "ABC-123",
 				"time":      now.Format(time.RFC3339Nano),
 				"type":      "com.example.test",
 				"exbool":    true,
-				"exint":     float64(42),
+				"exint":     42,
 				"exstring":  "exstring",
 				"exbinary":  "AAECAw==",
 				"exurl":     "http://example.com/source",
@@ -109,7 +109,7 @@ func TestMarshal(t *testing.T) {
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"exbool":          true,
-				"exint":           float64(42),
+				"exint":           42,
 				"exstring":        "exstring",
 				"exbinary":        "AAECAw==",
 				"exurl":           "http://example.com/source",
@@ -148,7 +148,7 @@ func TestMarshal(t *testing.T) {
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"exbool":          true,
-				"exint":           float64(42),
+				"exint":           42,
 				"exstring":        "exstring",
 				"exbinary":        "AAECAw==",
 				"exurl":           "http://example.com/source",
@@ -186,14 +186,14 @@ func TestMarshal(t *testing.T) {
 				"specversion":     "1.0",
 				"datacontenttype": "application/json",
 				"data": map[string]interface{}{
-					"a": float64(42),
+					"a": 42,
 					"b": "testing",
 				},
 				"id":         "ABC-123",
 				"time":       now.Format(time.RFC3339Nano),
 				"type":       "com.example.test",
 				"exbool":     true,
-				"exint":      float64(42),
+				"exint":      42,
 				"exstring":   "exstring",
 				"exbinary":   "AAECAw==",
 				"exurl":      "http://example.com/source",
@@ -228,7 +228,7 @@ func TestMarshal(t *testing.T) {
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"exbool":          true,
-				"exint":           float64(42),
+				"exint":           42,
 				"exstring":        "exstring",
 				"exbinary":        "AAECAw==",
 				"exurl":           "http://example.com/source",
@@ -267,7 +267,7 @@ func TestMarshal(t *testing.T) {
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
 				"exbool":          true,
-				"exint":           float64(42),
+				"exint":           42,
 				"exstring":        "exstring",
 				"exbinary":        "AAECAw==",
 				"exurl":           "http://example.com/source",
@@ -368,7 +368,7 @@ func TestMarshal(t *testing.T) {
 			want: map[string]interface{}{
 				"specversion":     "1.0",
 				"datacontenttype": "application/json",
-				"data":            float64(101),
+				"data":            101,
 				"id":              "ABC-123",
 				"time":            now.Format(time.RFC3339Nano),
 				"type":            "com.example.test",
@@ -392,11 +392,7 @@ func TestMarshal(t *testing.T) {
 				return
 			}
 
-			// so we can understand the diff, turn bytes to map
-			var got map[string]interface{}
-			require.NoError(t, json.Unmarshal(gotBytes, &got))
-
-			require.Equal(t, tc.want, got)
+			assertJsonEquals(t, tc.want, gotBytes)
 		})
 	}
 }
@@ -405,4 +401,17 @@ func mustJsonMarshal(tb testing.TB, body interface{}) []byte {
 	b, err := json.Marshal(body)
 	require.NoError(tb, err)
 	return b
+}
+
+func assertJsonEquals(t *testing.T, want map[string]interface{}, got []byte) {
+	var gotToCompare map[string]interface{}
+	require.NoError(t, json.Unmarshal(got, &gotToCompare))
+
+	// Marshal and unmarshal want to make sure the types are correct
+	wantBytes, err := json.Marshal(want)
+	require.NoError(t, err)
+	var wantToCompare map[string]interface{}
+	require.NoError(t, json.Unmarshal(wantBytes, &wantToCompare))
+
+	require.Equal(t, wantToCompare, gotToCompare)
 }


### PR DESCRIPTION
Like #618, but from event to bytes.

A thing to notice of this streaming writer is that it writes the event fields in an order such that the parser of #618 can efficiently parse it, without buffering some fields.

Note that the marshal tests and others had to be changed because they were doing a string comparison, but the new marshaller writes the elements in a different order. Also, the unmarshalling to map uses always floats even for integers. But, semantically speaking, **there is no diff with the previous code**. 

Results:

```
name                                                                               old time/op    new time/op    delta
Marshal/number_data_v1.0-8                                                           17.1µs ± 5%     5.9µs ± 4%  -65.44%  (p=0.008 n=5+5)
Marshal/struct_data_v0.3-8                                                           27.5µs ± 3%     9.2µs ± 2%  -66.52%  (p=0.008 n=5+5)
Marshal/nil_data_v0.3-8                                                              26.0µs ± 0%     9.0µs ± 1%  -65.39%  (p=0.008 n=5+5)
Marshal/string_data_v0.3-8                                                           28.2µs ± 0%     9.2µs ± 2%  -67.30%  (p=0.008 n=5+5)
Marshal/struct_data_v1.0-8                                                           29.0µs ± 0%     8.3µs ± 0%  -71.26%  (p=0.016 n=5+4)
Marshal/nil_data_v1.0-8                                                              26.5µs ± 0%     8.6µs ± 4%  -67.48%  (p=0.008 n=5+5)
Marshal/string_data_v1.0-8                                                           28.9µs ± 1%     8.8µs ± 1%  -69.55%  (p=0.008 n=5+5)
Marshal/base64_json_encoded_data_v1.0-8                                              19.2µs ± 0%     5.9µs ± 1%  -68.99%  (p=0.008 n=5+5)

name                                                                               old alloc/op   new alloc/op   delta
Marshal/number_data_v1.0-8                                                           5.16kB ± 0%    3.88kB ± 0%  -24.70%  (p=0.008 n=5+5)
Marshal/struct_data_v0.3-8                                                           8.76kB ± 0%    4.48kB ± 0%     ~     (p=0.079 n=4+5)
Marshal/nil_data_v0.3-8                                                              7.15kB ± 0%    4.55kB ± 0%  -36.34%  (p=0.029 n=4+4)
Marshal/string_data_v0.3-8                                                           8.76kB ± 0%    4.45kB ± 0%  -49.16%  (p=0.008 n=5+5)
Marshal/struct_data_v1.0-8                                                           9.04kB ± 0%    4.44kB ± 0%     ~     (p=0.079 n=4+5)
Marshal/nil_data_v1.0-8                                                              7.44kB ± 0%    4.52kB ± 0%  -39.30%  (p=0.008 n=5+5)
Marshal/string_data_v1.0-8                                                           9.04kB ± 0%    4.44kB ± 0%     ~     (p=0.079 n=4+5)
Marshal/base64_json_encoded_data_v1.0-8                                              5.32kB ± 0%    3.56kB ± 0%  -33.00%  (p=0.008 n=5+5)

name                                                                               old allocs/op  new allocs/op  delta
Marshal/number_data_v1.0-8                                                              106 ± 0%        41 ± 0%  -61.32%  (p=0.008 n=5+5)
Marshal/struct_data_v0.3-8                                                              134 ± 0%        52 ± 0%  -61.19%  (p=0.008 n=5+5)
Marshal/nil_data_v0.3-8                                                                 130 ± 0%        52 ± 0%  -60.00%  (p=0.008 n=5+5)
Marshal/string_data_v0.3-8                                                              134 ± 0%        52 ± 0%  -61.19%  (p=0.008 n=5+5)
Marshal/struct_data_v1.0-8                                                              134 ± 0%        50 ± 0%  -62.69%  (p=0.008 n=5+5)
Marshal/nil_data_v1.0-8                                                                 130 ± 0%        50 ± 0%  -61.54%  (p=0.008 n=5+5)
Marshal/string_data_v1.0-8                                                              134 ± 0%        50 ± 0%  -62.69%  (p=0.008 n=5+5)
Marshal/base64_json_encoded_data_v1.0-8                                                 108 ± 0%        42 ± 0%  -61.11%  (p=0.008 n=5+5)
```