### PR TITLE
Skip intermediary Any when needing an interface anyway

### DIFF
--- a/v2/event/event_unmarshal.go
+++ b/v2/event/event_unmarshal.go
@@ -275,7 +275,7 @@ func ReadJson(out *Event, reader io.Reader) error {
 				if eventContext.Extensions == nil {
 					eventContext.Extensions = make(map[string]interface{}, 1)
 				}
-				iterator.Error = eventContext.SetExtension(key, iterator.ReadAny().GetInterface())
+				iterator.Error = eventContext.SetExtension(key, iterator.Read())
 			}
 		case *EventContextV1:
 			switch key {
@@ -299,7 +299,7 @@ func ReadJson(out *Event, reader io.Reader) error {
 				if eventContext.Extensions == nil {
 					eventContext.Extensions = make(map[string]interface{}, 1)
 				}
-				iterator.Error = eventContext.SetExtension(key, iterator.ReadAny().GetInterface())
+				iterator.Error = eventContext.SetExtension(key, iterator.Read())
 			}
 		}
 	}


### PR DESCRIPTION
As per title.

## Benchmark

```
benchmark                                                                                       old ns/op     new ns/op     delta
BenchmarkUnmarshal/struct_data_v0.3-16                                                          17204         16024         -6.86%
BenchmarkUnmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16     17956         18008         +0.29%
BenchmarkUnmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16     18128         18475         +1.91%
BenchmarkUnmarshal/string_data_v1.0-16                                                          16832         15551         -7.61%
BenchmarkUnmarshal/nil_data_v1.0-16                                                             16021         15380         -4.00%
BenchmarkUnmarshal/string_data_v0.3-16                                                          16729         16228         -2.99%
BenchmarkUnmarshal/nil_data_v0.3-16                                                             15394         14699         -4.51%
BenchmarkUnmarshal/struct_data_v1.0-16                                                          17052         16251         -4.70%
BenchmarkUnmarshal/base64_json_encoded_data_v1.0-16                                             11311         11383         +0.64%
BenchmarkUnmarshal/base64_xml_encoded_data_v1.0-16                                              12085         12065         -0.17%

benchmark                                                                                       old allocs     new allocs     delta
BenchmarkUnmarshal/struct_data_v0.3-16                                                          76             69             -9.21%
BenchmarkUnmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16     83             83             +0.00%
BenchmarkUnmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16     83             83             +0.00%
BenchmarkUnmarshal/string_data_v1.0-16                                                          73             66             -9.59%
BenchmarkUnmarshal/nil_data_v1.0-16                                                             71             64             -9.86%
BenchmarkUnmarshal/string_data_v0.3-16                                                          75             68             -9.33%
BenchmarkUnmarshal/nil_data_v0.3-16                                                             71             64             -9.86%
BenchmarkUnmarshal/struct_data_v1.0-16                                                          74             67             -9.46%
BenchmarkUnmarshal/base64_json_encoded_data_v1.0-16                                             49             49             +0.00%
BenchmarkUnmarshal/base64_xml_encoded_data_v1.0-16                                              49             49             +0.00%

benchmark                                                                                       old bytes     new bytes     delta
BenchmarkUnmarshal/struct_data_v0.3-16                                                          3584          3421          -4.55%
BenchmarkUnmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16     3739          3739          +0.00%
BenchmarkUnmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16     3739          3740          +0.03%
BenchmarkUnmarshal/string_data_v1.0-16                                                          3392          3229          -4.81%
BenchmarkUnmarshal/nil_data_v1.0-16                                                             3351          3189          -4.83%
BenchmarkUnmarshal/string_data_v0.3-16                                                          3568          3405          -4.57%
BenchmarkUnmarshal/nil_data_v0.3-16                                                             3352          3189          -4.86%
BenchmarkUnmarshal/struct_data_v1.0-16                                                          3407          3245          -4.75%
BenchmarkUnmarshal/base64_json_encoded_data_v1.0-16                                             2708          2708          +0.00%
BenchmarkUnmarshal/base64_xml_encoded_data_v1.0-16                                              2724          2724          +0.00%
```