### PR TITLE
Remove writing through stream when caching data

### DIFF
--- a/v2/event/event_unmarshal_test.go
+++ b/v2/event/event_unmarshal_test.go
@@ -883,6 +883,30 @@ func TestUnmarshalWithOrdering(t *testing.T) {
 				DataBase64:  false,
 			},
 		},
+		"xml data v1.0": {
+			body: new(orderedJsonObjectBuilder).Start().
+				Add("specversion", "1.0").
+				Add("datacontenttype", event.ApplicationXML).
+				Add("data", string(mustEncodeWithDataCodec(t, event.ApplicationXML, XMLDataExample{AnInt: 5, AString: "aaa"}))).
+				Add("id", "ABC-123").
+				Add("time", now.Format(time.RFC3339Nano)).
+				Add("type", "com.example.test").
+				Add("dataschema", "http://example.com/schema").
+				Add("source", "http://example.com/source").
+				End(),
+			want: &event.Event{
+				Context: event.EventContextV1{
+					Type:            "com.example.test",
+					Source:          *sourceV1,
+					DataSchema:      schemaV1,
+					ID:              "ABC-123",
+					Time:            &now,
+					DataContentType: event.StringOfApplicationXML(),
+				}.AsV1(),
+				DataBase64:  false,
+				DataEncoded: mustEncodeWithDataCodec(t, event.ApplicationXML, &XMLDataExample{AnInt: 5, AString: "aaa"}),
+			},
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
Having the streams in the deferred path hid a bug we had with XML handling, since they unescape when writing through them.

This moves the stream down to where it is actually needed: String based data handling. The data needs to be copied anyway, so this should also save a copy step.

Signed-off-by: Markus Thömmes <markusthoemmes@me.com>

## Benchmark

```
name                                                                                old time/op    new time/op    delta
Unmarshal/string_data_v0.3-16                                                         16.1µs ± 1%    15.7µs ± 1%  -2.01%  (p=0.008 n=5+5)
Unmarshal/nil_data_v0.3-16                                                            14.9µs ± 1%    14.7µs ± 0%  -1.48%  (p=0.008 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16    16.9µs ± 0%    16.6µs ± 0%  -2.04%  (p=0.008 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16    17.2µs ± 1%    16.7µs ± 0%  -2.95%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                         15.9µs ± 1%    15.6µs ± 0%  -1.66%  (p=0.016 n=5+4)
Unmarshal/base64_json_encoded_data_v1.0-16                                            11.3µs ± 1%    11.2µs ± 1%  -1.14%  (p=0.008 n=5+5)
Unmarshal/base64_xml_encoded_data_v1.0-16                                             11.8µs ± 1%    11.6µs ± 1%  -1.71%  (p=0.008 n=5+5)
Unmarshal/struct_data_v0.3-16                                                         16.6µs ± 1%    16.2µs ± 1%  -2.00%  (p=0.008 n=5+5)
Unmarshal/nil_data_v1.0-16                                                            15.0µs ± 1%    14.9µs ± 1%  -1.05%  (p=0.032 n=5+5)
Unmarshal/struct_data_v1.0-16                                                         16.2µs ± 0%    16.0µs ± 1%    ~     (p=0.056 n=5+5)

name                                                                                old alloc/op   new alloc/op   delta
Unmarshal/string_data_v0.3-16                                                         3.36kB ± 0%    3.36kB ± 0%    ~     (all equal)
Unmarshal/nil_data_v0.3-16                                                            3.14kB ± 0%    3.14kB ± 0%    ~     (all equal)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16    3.45kB ± 0%    3.40kB ± 0%  -1.48%  (p=0.008 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16    3.45kB ± 0%    3.40kB ± 0%  -1.48%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                         3.18kB ± 0%    3.18kB ± 0%    ~     (all equal)
Unmarshal/base64_json_encoded_data_v1.0-16                                            2.66kB ± 0%    2.66kB ± 0%    ~     (all equal)
Unmarshal/base64_xml_encoded_data_v1.0-16                                             2.67kB ± 0%    2.67kB ± 0%    ~     (all equal)
Unmarshal/struct_data_v0.3-16                                                         3.37kB ± 0%    3.37kB ± 0%    ~     (all equal)
Unmarshal/nil_data_v1.0-16                                                            3.14kB ± 0%    3.14kB ± 0%    ~     (all equal)
Unmarshal/struct_data_v1.0-16                                                         3.20kB ± 0%    3.20kB ± 0%    ~     (all equal)

name                                                                                old allocs/op  new allocs/op  delta
Unmarshal/string_data_v0.3-16                                                           67.0 ± 0%      67.0 ± 0%    ~     (all equal)
Unmarshal/nil_data_v0.3-16                                                              63.0 ± 0%      63.0 ± 0%    ~     (all equal)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16      70.0 ± 0%      69.0 ± 0%  -1.43%  (p=0.008 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16      70.0 ± 0%      69.0 ± 0%  -1.43%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                           65.0 ± 0%      65.0 ± 0%    ~     (all equal)
Unmarshal/base64_json_encoded_data_v1.0-16                                              48.0 ± 0%      48.0 ± 0%    ~     (all equal)
Unmarshal/base64_xml_encoded_data_v1.0-16                                               48.0 ± 0%      48.0 ± 0%    ~     (all equal)
Unmarshal/struct_data_v0.3-16                                                           68.0 ± 0%      68.0 ± 0%    ~     (all equal)
Unmarshal/nil_data_v1.0-16                                                              63.0 ± 0%      63.0 ± 0%    ~     (all equal)
Unmarshal/struct_data_v1.0-16                                                           66.0 ± 0%      66.0 ± 0%    ~     (all equal)
```