### PR TITLE
Add test for corner-case of having data_base64 as an extension in V03

### DIFF
--- a/v2/event/event_unmarshal_test.go
+++ b/v2/event/event_unmarshal_test.go
@@ -829,7 +829,7 @@ func TestUnmarshalWithOrdering(t *testing.T) {
 				DataBase64:  true,
 			},
 		},
-		"base64 json encoded data v0.3 with data/data_base64 -> datacontenttype -> specversion -> datacontentencoding": {
+		"base64 json encoded data v0.3 with data/data_base64": {
 			body: new(orderedJsonObjectBuilder).Start().
 				Add("data_base64", "foo").
 				Add("data", base64.StdEncoding.EncodeToString([]byte(`{"hello":"world"}`))).
@@ -855,6 +855,32 @@ func TestUnmarshalWithOrdering(t *testing.T) {
 				}.AsV03(),
 				DataEncoded: mustJsonMarshal(t, map[string]interface{}{"hello": "world"}),
 				DataBase64:  true,
+			},
+		},
+		"struct json data v0.3 with with data/data_base64": {
+			body: new(orderedJsonObjectBuilder).Start().
+				Add("data_base64", "foo").
+				Add("data", structData).
+				Add("id", "ABC-123").
+				Add("time", now.Format(time.RFC3339Nano)).
+				Add("type", "com.example.test").
+				Add("source", "http://example.com/source").
+				Add("datacontenttype", "application/json").
+				Add("specversion", "0.3").
+				End(),
+			want: &event.Event{
+				Context: event.EventContextV03{
+					Type:            "com.example.test",
+					Source:          *sourceV1,
+					ID:              "ABC-123",
+					Time:            &now,
+					DataContentType: event.StringOfApplicationJSON(),
+					Extensions: map[string]interface{}{
+						"data_base64": "foo",
+					},
+				}.AsV03(),
+				DataEncoded: mustJsonMarshal(t, structData),
+				DataBase64:  false,
 			},
 		},
 	}

--- a/v2/event/event_unmarshal_test.go
+++ b/v2/event/event_unmarshal_test.go
@@ -829,6 +829,34 @@ func TestUnmarshalWithOrdering(t *testing.T) {
 				DataBase64:  true,
 			},
 		},
+		"base64 json encoded data v0.3 with data/data_base64 -> datacontenttype -> specversion -> datacontentencoding": {
+			body: new(orderedJsonObjectBuilder).Start().
+				Add("data_base64", "foo").
+				Add("data", base64.StdEncoding.EncodeToString([]byte(`{"hello":"world"}`))).
+				Add("id", "ABC-123").
+				Add("time", now.Format(time.RFC3339Nano)).
+				Add("type", "com.example.test").
+				Add("source", "http://example.com/source").
+				Add("datacontenttype", "application/json").
+				Add("specversion", "0.3").
+				Add("datacontentencoding", "base64").
+				End(),
+			want: &event.Event{
+				Context: event.EventContextV03{
+					Type:                "com.example.test",
+					Source:              *sourceV1,
+					ID:                  "ABC-123",
+					Time:                &now,
+					DataContentEncoding: strptr(event.Base64),
+					DataContentType:     event.StringOfApplicationJSON(),
+					Extensions: map[string]interface{}{
+						"data_base64": "foo",
+					},
+				}.AsV03(),
+				DataEncoded: mustJsonMarshal(t, map[string]interface{}{"hello": "world"}),
+				DataBase64:  true,
+			},
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
Adds a test that catches the corner-case of having a `data_base64` as an extension in V03.

Signed-off-by: Markus Thömmes <markusthoemmes@me.com>