### PR TITLE
Only use the token queue for fields we really can't parse immediately

### DIFF
--- a/v2/event/event_unmarshal.go
+++ b/v2/event/event_unmarshal.go
@@ -19,7 +19,7 @@ const specVersionV1Flag uint8 = 1 << 5
 const dataBase64Flag uint8 = 1 << 6
 const dataContentTypeFlag uint8 = 1 << 7
 
-const preallocQueueSize = 5 // at most the 5 overlapping fields
+const preallocQueueSize = 8 // at most the 5 overlapping fields, fitting cache lines.
 
 func checkFlag(state uint8, flag uint8) bool {
 	return state&flag != 0
@@ -216,9 +216,6 @@ func readJsonFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 				// ... except these, they need to be parsed after specversion is known.
 				tokenQueue = append(tokenQueue, entry{key: key, value: iterator.ReadAny()})
 			default:
-				if extensions == nil {
-					extensions = make(map[string]interface{}, 1)
-				}
 				extensions[key] = iterator.Read()
 			}
 			continue

--- a/v2/event/event_unmarshal.go
+++ b/v2/event/event_unmarshal.go
@@ -158,11 +158,7 @@ func readJsonFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 						cachedData = stream.Buffer()
 						err = stream.Error
 					default:
-						value := val.GetInterface()
-						if eventContext.Extensions == nil {
-							eventContext.Extensions = make(map[string]interface{}, 1)
-						}
-						err = eventContext.SetExtension(entry.key, value)
+						err = eventContext.SetExtension(entry.key, val.GetInterface())
 					}
 					if err != nil {
 						return err
@@ -189,11 +185,7 @@ func readJsonFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 						err = stream.Error
 						appendFlag(&state, dataBase64Flag)
 					default:
-						value := val.GetInterface()
-						if eventContext.Extensions == nil {
-							eventContext.Extensions = make(map[string]interface{}, 1)
-						}
-						err = eventContext.SetExtension(entry.key, value)
+						err = eventContext.SetExtension(entry.key, val.GetInterface())
 					}
 					if err != nil {
 						return err
@@ -205,6 +197,7 @@ func readJsonFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 
 		// If no specversion, enqueue unconditionally
 		if !checkFlag(state, specVersionV03Flag|specVersionV1Flag) {
+			// Most of these keys can be parsed regardless of the specversion ...
 			switch key {
 			case "id":
 				id = iterator.ReadString()
@@ -220,6 +213,7 @@ func readJsonFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 				datacontenttype = readStrPtr(iterator)
 				appendFlag(&state, dataContentTypeFlag)
 			case "data", "data_base64", "dataschema", "schemaurl", "datacontentencoding":
+				// ... except these, they need to be parsed after specversion is known.
 				tokenQueue = append(tokenQueue, entry{key: key, value: iterator.ReadAny()})
 			default:
 				if extensions == nil {


### PR DESCRIPTION
Most of the keys are parsed identically between the versions, so why bother deferring their parsing and allocating stuff unnecessarily? This also puts an upper bound on the tokenQueue in theory.

Signed-off-by: Markus Thömmes <markusthoemmes@me.com>

## Benchmark

```
name                                                                                old time/op    new time/op    delta
Unmarshal/struct_data_v0.3-16                                                         16.3µs ± 0%    16.4µs ± 1%   +0.75%  (p=0.032 n=5+5)
Unmarshal/nil_data_v0.3-16                                                            14.8µs ± 0%    14.9µs ± 1%   +0.73%  (p=0.016 n=5+5)
Unmarshal/struct_data_v1.0-16                                                         16.1µs ± 1%    16.3µs ± 1%     ~     (p=0.056 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16    18.0µs ± 1%    17.3µs ± 1%   -4.10%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                         15.8µs ± 1%    15.9µs ± 1%     ~     (p=0.310 n=5+5)
Unmarshal/base64_json_encoded_data_v1.0-16                                            11.3µs ± 1%    11.4µs ± 1%     ~     (p=0.310 n=5+5)
Unmarshal/base64_xml_encoded_data_v1.0-16                                             11.8µs ± 1%    11.8µs ± 1%     ~     (p=0.548 n=5+5)
Unmarshal/string_data_v0.3-16                                                         15.8µs ± 1%    16.0µs ± 1%   +1.35%  (p=0.016 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16    17.8µs ± 0%    17.0µs ± 1%   -4.51%  (p=0.008 n=5+5)
Unmarshal/nil_data_v1.0-16                                                            15.0µs ± 1%    15.2µs ± 1%     ~     (p=0.095 n=5+5)

name                                                                                old alloc/op   new alloc/op   delta
Unmarshal/struct_data_v0.3-16                                                         3.37kB ± 0%    3.37kB ± 0%     ~     (all equal)
Unmarshal/nil_data_v0.3-16                                                            3.14kB ± 0%    3.14kB ± 0%     ~     (all equal)
Unmarshal/struct_data_v1.0-16                                                         3.20kB ± 0%    3.20kB ± 0%     ~     (all equal)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16    3.69kB ± 0%    3.45kB ± 0%   -6.53%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                         3.18kB ± 0%    3.18kB ± 0%     ~     (all equal)
Unmarshal/base64_json_encoded_data_v1.0-16                                            2.66kB ± 0%    2.66kB ± 0%     ~     (all equal)
Unmarshal/base64_xml_encoded_data_v1.0-16                                             2.67kB ± 0%    2.67kB ± 0%     ~     (all equal)
Unmarshal/string_data_v0.3-16                                                         3.36kB ± 0%    3.36kB ± 0%     ~     (all equal)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16    3.69kB ± 0%    3.45kB ± 0%   -6.53%  (p=0.008 n=5+5)
Unmarshal/nil_data_v1.0-16                                                            3.14kB ± 0%    3.14kB ± 0%     ~     (all equal)

name                                                                                old allocs/op  new allocs/op  delta
Unmarshal/struct_data_v0.3-16                                                           68.0 ± 0%      68.0 ± 0%     ~     (all equal)
Unmarshal/nil_data_v0.3-16                                                              63.0 ± 0%      63.0 ± 0%     ~     (all equal)
Unmarshal/struct_data_v1.0-16                                                           66.0 ± 0%      66.0 ± 0%     ~     (all equal)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16      82.0 ± 0%      70.0 ± 0%  -14.63%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                           65.0 ± 0%      65.0 ± 0%     ~     (all equal)
Unmarshal/base64_json_encoded_data_v1.0-16                                              48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Unmarshal/base64_xml_encoded_data_v1.0-16                                               48.0 ± 0%      48.0 ± 0%     ~     (all equal)
Unmarshal/string_data_v0.3-16                                                           67.0 ± 0%      67.0 ± 0%     ~     (all equal)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16      82.0 ± 0%      70.0 ± 0%  -14.63%  (p=0.008 n=5+5)
Unmarshal/nil_data_v1.0-16                                                              63.0 ± 0%      63.0 ± 0%     ~     (all equal)
```