### PR TITLE
Drop unnecessary stream operation, reading handles escaping

### DIFF
--- a/v2/event/event_unmarshal.go
+++ b/v2/event/event_unmarshal.go
@@ -349,16 +349,11 @@ func consumeData(e *Event, isBase64 bool, iter *jsoniter.Iterator) error {
 	ct := e.DataContentType()
 	if ct != ApplicationJSON && ct != TextJSON {
 		// If not json, then data is encoded as string
-		src := iter.ReadString()
-
-		// Write through stream to unescape and copy.
-		stream := jsoniter.ConfigFastest.BorrowStream(nil)
-		defer jsoniter.ConfigFastest.ReturnStream(stream)
-		stream.WriteString(src)
-		b := stream.Buffer()
-		e.DataEncoded = b[1 : len(b)-1] // Remove the quotes.
+		src := iter.ReadString() // handles escaping
+		e.DataEncoded = []byte(src)
 		return nil
 	}
+
 	e.DataEncoded = iter.SkipAndReturnBytes()
 	return nil
 }


### PR DESCRIPTION
When cooking this up, I didn't realize that `ReadString` handles escaping of the string too, so the stream shenanigans are unnecessary on this path.

Signed-off-by: Markus Thömmes <markusthoemmes@me.com>

## Benchmark

```
name                                                                                old time/op    new time/op    delta
Unmarshal/string_data_v0.3-16                                                         16.1µs ± 1%    15.8µs ± 1%    ~     (p=0.056 n=5+5)
Unmarshal/nil_data_v0.3-16                                                            14.9µs ± 1%    14.7µs ± 1%    ~     (p=0.056 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16    16.9µs ± 0%    16.6µs ± 0%  -1.54%  (p=0.008 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16    17.2µs ± 1%    16.7µs ± 1%  -2.74%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                         15.9µs ± 1%    15.7µs ± 1%  -1.20%  (p=0.008 n=5+5)
Unmarshal/base64_json_encoded_data_v1.0-16                                            11.3µs ± 1%    11.2µs ± 1%  -0.69%  (p=0.016 n=5+5)
Unmarshal/base64_xml_encoded_data_v1.0-16                                             11.8µs ± 1%    11.7µs ± 1%    ~     (p=0.095 n=5+5)
Unmarshal/struct_data_v0.3-16                                                         16.6µs ± 1%    16.4µs ± 1%    ~     (p=0.095 n=5+5)
Unmarshal/nil_data_v1.0-16                                                            15.0µs ± 1%    15.0µs ± 0%    ~     (p=1.000 n=5+5)
Unmarshal/struct_data_v1.0-16                                                         16.2µs ± 0%    16.1µs ± 1%    ~     (p=0.151 n=5+5)

name                                                                                old alloc/op   new alloc/op   delta
Unmarshal/string_data_v0.3-16                                                         3.36kB ± 0%    3.36kB ± 0%    ~     (all equal)
Unmarshal/nil_data_v0.3-16                                                            3.14kB ± 0%    3.14kB ± 0%    ~     (all equal)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16    3.45kB ± 0%    3.40kB ± 0%  -1.48%  (p=0.008 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16    3.45kB ± 0%    3.40kB ± 0%  -1.48%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                         3.18kB ± 0%    3.18kB ± 0%    ~     (all equal)
Unmarshal/base64_json_encoded_data_v1.0-16                                            2.66kB ± 0%    2.66kB ± 0%    ~     (all equal)
Unmarshal/base64_xml_encoded_data_v1.0-16                                             2.67kB ± 0%    2.67kB ± 0%    ~     (all equal)
Unmarshal/struct_data_v0.3-16                                                         3.37kB ± 0%    3.37kB ± 0%    ~     (all equal)
Unmarshal/nil_data_v1.0-16                                                            3.14kB ± 0%    3.14kB ± 0%    ~     (all equal)
Unmarshal/struct_data_v1.0-16                                                         3.20kB ± 0%    3.20kB ± 0%    ~     (all equal)

name                                                                                old allocs/op  new allocs/op  delta
Unmarshal/string_data_v0.3-16                                                           67.0 ± 0%      67.0 ± 0%    ~     (all equal)
Unmarshal/nil_data_v0.3-16                                                              63.0 ± 0%      63.0 ± 0%    ~     (all equal)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v0.3-16      70.0 ± 0%      69.0 ± 0%  -1.43%  (p=0.008 n=5+5)
Unmarshal/data,_attributes_and_extensions_and_specversion_with_struct_data_v1.0-16      70.0 ± 0%      69.0 ± 0%  -1.43%  (p=0.008 n=5+5)
Unmarshal/string_data_v1.0-16                                                           65.0 ± 0%      65.0 ± 0%    ~     (all equal)
Unmarshal/base64_json_encoded_data_v1.0-16                                              48.0 ± 0%      48.0 ± 0%    ~     (all equal)
Unmarshal/base64_xml_encoded_data_v1.0-16                                               48.0 ± 0%      48.0 ± 0%    ~     (all equal)
Unmarshal/struct_data_v0.3-16                                                           68.0 ± 0%      68.0 ± 0%    ~     (all equal)
Unmarshal/nil_data_v1.0-16                                                              63.0 ± 0%      63.0 ± 0%    ~     (all equal)
Unmarshal/struct_data_v1.0-16                                                           66.0 ± 0%      66.0 ± 0%    ~     (all equal)
```