### PR TITLE
[WIP] Format now supports streaming

### DIFF
--- a/v2/binding/to_event.go
+++ b/v2/binding/to_event.go
@@ -61,13 +61,8 @@ type messageToEventBuilder event.Event
 var _ StructuredWriter = (*messageToEventBuilder)(nil)
 var _ BinaryWriter = (*messageToEventBuilder)(nil)
 
-func (b *messageToEventBuilder) SetStructuredEvent(ctx context.Context, format format.Format, ev io.Reader) error {
-	var buf bytes.Buffer
-	_, err := io.Copy(&buf, ev)
-	if err != nil {
-		return err
-	}
-	return format.Unmarshal(buf.Bytes(), (*event.Event)(b))
+func (b *messageToEventBuilder) SetStructuredEvent(ctx context.Context, format format.Format, reader io.Reader) error {
+	return format.Unmarshal(reader, (*event.Event)(b))
 }
 
 func (b *messageToEventBuilder) Start(ctx context.Context) error {


### PR DESCRIPTION
Depends on #621

Format now uses io.Reader/Writer, allowing binding.ToEvent and binding.ToMessage to use the new json streaming reader/writer

**Note:** this is breaking, although it's modifying an "internal" API (yeah it's public, but it's not really documented for users to use it)

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>