### PR TITLE
Provide additional context in shutdown errors

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -223,7 +223,7 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 				}
 
 				if err != nil {
-					cecontext.LoggerFrom(ctx).Warnf("Error while receiving a message: %s", err)
+					cecontext.LoggerFrom(ctx).Warn("Error while receiving a message: ", err)
 					continue
 				}
 
@@ -231,7 +231,7 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 				wg.Add(1)
 				go func() {
 					if err := c.invoker.Invoke(ctx, msg, respFn); err != nil {
-						cecontext.LoggerFrom(ctx).Warnf("Error while handling a message: %s", err)
+						cecontext.LoggerFrom(ctx).Warn("Error while handling a message: ", err)
 					}
 					wg.Done()
 				}()
@@ -242,7 +242,7 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 	// Start the opener, if set.
 	if c.opener != nil {
 		if err = c.opener.OpenInbound(ctx); err != nil {
-			err = fmt.Errorf("error while opening the inbound connection: %s", err)
+			err = fmt.Errorf("error while opening the inbound connection: %w", err)
 			cancel()
 		}
 	}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,7 +3,6 @@ module github.com/cloudevents/sdk-go/v2
 go 1.14
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.1

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -62,7 +62,7 @@ type Protocol struct {
 	// To support Opener:
 
 	// ShutdownTimeout defines the timeout given to the http.Server when calling Shutdown.
-	// If nil, DefaultShutdownTimeout is used.
+	// If 0, DefaultShutdownTimeout is used.
 	ShutdownTimeout time.Duration
 
 	// Port is the port configured to bind the receiver to. Defaults to 8080.


### PR DESCRIPTION
I found out while investigating #636 that the error received from `errChan` was discarded during a server shutdown. I used the occasion to wrap those errors with some additional context to ease troubleshooting a little bit.

Example:

`2020/12/08 12:55:49 Failure during runtime of CloudEvents handler: error while opening the inbound connection: combined error during shutdown of HTTP server: shutting down HTTP server: context deadline exceeded, server failed during shutdown: http: some terrible error`