### PR TITLE
Fix typo and change package of Result return value in fn signature

### DIFF
--- a/v2/client/receiver.go
+++ b/v2/client/receiver.go
@@ -41,17 +41,17 @@ var (
 // validate and invoke the provided function.
 // Valid fn signatures are:
 // * func()
-// * func() error
+// * func() protocol.Result
 // * func(context.Context)
-// * func(context.Context) transport.Result
+// * func(context.Context) protocol.Result
 // * func(event.Event)
 // * func(event.Event) transport.Result
 // * func(context.Context, event.Event)
-// * func(context.Context, event.Event) transport.Result
+// * func(context.Context, event.Event) protocol.Result
 // * func(event.Event) *event.Event
-// * func(event.Event) (*event.Event, transport.Result)
-// * func(context.Context, event.Event, *event.Event
-// * func(context.Context, event.Event) (*event.Event, transport.Result)
+// * func(event.Event) (*event.Event, protocol.Result)
+// * func(context.Context, event.Event) *event.Event
+// * func(context.Context, event.Event) (*event.Event, protocol.Result)
 //
 func receiver(fn interface{}) (*receiverFn, error) {
 	fnType := reflect.TypeOf(fn)


### PR DESCRIPTION
- there was missing `)` in one example.
- `transport.Result` as a return type is imho quite confusing as the `Result` type is in `protocol` package
- for consistency changed `func() error` -> `func() protocol.Result`

Signed-off-by: Zbynek Roubalik zroubali@redhat.com