### PR TITLE
Remove validation from the string representation

### DIFF
--- a/v2/event/event.go
+++ b/v2/event/event.go
@@ -66,18 +66,6 @@ func (e Event) ExtensionAs(name string, obj interface{}) error {
 func (e Event) String() string {
 	b := strings.Builder{}
 
-	b.WriteString("Validation: ")
-
-	valid := e.Validate()
-	if valid == nil {
-		b.WriteString("valid\n")
-	} else {
-		b.WriteString("invalid\n")
-	}
-	if valid != nil {
-		b.WriteString(fmt.Sprintf("Validation Error: \n%s\n", valid.Error()))
-	}
-
 	b.WriteString(e.Context.String())
 
 	if e.DataEncoded != nil {

--- a/v2/event/event.go
+++ b/v2/event/event.go
@@ -3,7 +3,6 @@ package event
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 

--- a/v2/event/event_test.go
+++ b/v2/event/event_test.go
@@ -224,8 +224,7 @@ func TestString(t *testing.T) {
 			event: event.Event{
 				Context: MinEventContextV03(),
 			},
-			want: `Validation: valid
-Context Attributes,
+			want: `Context Attributes,
   specversion: 0.3
   type: com.example.simple
   source: http://example.com/source
@@ -236,8 +235,7 @@ Context Attributes,
 			event: event.Event{
 				Context: MinEventContextV1(),
 			},
-			want: `Validation: valid
-Context Attributes,
+			want: `Context Attributes,
   specversion: 1.0
   type: com.example.simple
   source: http://example.com/source
@@ -249,8 +247,7 @@ Context Attributes,
 				Context:     FullEventContextV03(now),
 				DataEncoded: []byte(`{"a":"apple","b":"banana"}`),
 			},
-			want: fmt.Sprintf(`Validation: valid
-Context Attributes,
+			want: fmt.Sprintf(`Context Attributes,
   specversion: 0.3
   type: com.example.simple
   source: http://example.com/source
@@ -275,8 +272,7 @@ Data,
 				Context:     FullEventContextV1(now),
 				DataEncoded: []byte(`{"a":"apple","b":"banana"}`),
 			},
-			want: fmt.Sprintf(`Validation: valid
-Context Attributes,
+			want: fmt.Sprintf(`Context Attributes,
   specversion: 1.0
   type: com.example.simple
   source: http://example.com/source


### PR DESCRIPTION
The reasons for this change are:

* the validation it's not related to string representation at all.
* avoid the overhead of the validation when logging events. One that needs both just invokes both methods

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>