### PR TITLE
Add required call to SetID when marshalling JSON CloudEvent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ To marshal a CloudEvent into JSON:
 
 ```go
 event := cloudevents.NewEvent()
+event.SetID("example-uuid-32943bac6fea")
 event.SetSource("example/uri")
 event.SetType("example.type")
 event.SetData(cloudevents.ApplicationJSON, map[string]string{"hello": "world"})


### PR DESCRIPTION
Fixes #640.  Simple addition of SetID so that this code can be used as-is.