### PR TITLE
Fix Kafka ConsumeClaim loop to Mark right offset

### DIFF
--- a/protocol/kafka_sarama/v2/receiver.go
+++ b/protocol/kafka_sarama/v2/receiver.go
@@ -49,12 +49,13 @@ func (r *Receiver) Close(context.Context) error {
 
 func (r *Receiver) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	for message := range claim.Messages() {
-		m := NewMessageFromConsumerMessage(message)
+		msg := message
+		m := NewMessageFromConsumerMessage(msg)
 
 		r.incoming <- msgErr{
 			msg: binding.WithFinish(m, func(err error) {
 				if protocol.IsACK(err) {
-					session.MarkMessage(message, "")
+					session.MarkMessage(msg, "")
 				}
 			}),
 		}


### PR DESCRIPTION
https://github.com/cloudevents/sdk-go/issues/643

message is a pointer varying in the for loop, when MarkMessage is called, the pointer points to something potentially different to the current iteration

Signed-off-by: Matthieu Bernardin <matt.bernardin@gmail.com>