### PR TITLE
Allow stan protocol to set native *stan.Msg as a context value

### DIFF
--- a/protocol/stan/v2/context.go
+++ b/protocol/stan/v2/context.go
@@ -1,0 +1,44 @@
+package stan
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/v2/binding"
+)
+
+// MsgMetadata holds metadata of a received *stan.Msg. This information is kept in a separate struct so that users
+// cannot interact with the underlying message outside of the SDK.
+type MsgMetadata struct {
+	Sequence        uint64
+	Redelivered     bool
+	RedeliveryCount uint32
+}
+
+type msgKeyType struct{}
+
+var msgKey msgKeyType
+
+// MetadataContextDecorator returns an inbound context decorator which adds STAN message metadata to
+// the current context. If the inbound message is not a *stan.Message then this decorator is a no-op.
+func MetadataContextDecorator() func(context.Context, binding.Message) context.Context {
+	return func(ctx context.Context, m binding.Message) context.Context {
+		if msg, ok := m.(*Message); ok {
+			return context.WithValue(ctx, msgKey, MsgMetadata{
+				Sequence:        msg.Msg.Sequence,
+				Redelivered:     msg.Msg.Redelivered,
+				RedeliveryCount: msg.Msg.RedeliveryCount,
+			})
+		}
+
+		return ctx
+	}
+}
+
+// MessageMetadataFrom extracts the STAN message metadata from the provided ctx. The bool return parameter is true if
+// the metadata was set on the context, or false otherwise.
+func MessageMetadataFrom(ctx context.Context) (MsgMetadata, bool) {
+	if v, ok := ctx.Value(msgKey).(MsgMetadata); ok {
+		return v, true
+	}
+
+	return MsgMetadata{}, false
+}

--- a/protocol/stan/v2/context_test.go
+++ b/protocol/stan/v2/context_test.go
@@ -1,0 +1,89 @@
+package stan
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/nats-io/stan.go"
+	"github.com/nats-io/stan.go/pb"
+	"reflect"
+	"testing"
+)
+
+func TestMetadataContextDecorator(t *testing.T) {
+	type args struct {
+		msg binding.Message
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  MsgMetadata
+		want1 bool
+	}{
+		{
+			name: "STAN message contains metadata on context",
+			args: args{
+				msg: newSTANMessage(&stan.Msg{
+					MsgProto: pb.MsgProto{
+						Sequence:        13,
+						Redelivered:     true,
+						RedeliveryCount: 42,
+					},
+				}),
+			},
+			want: MsgMetadata{
+				Sequence:        13,
+				Redelivered:     true,
+				RedeliveryCount: 42,
+			},
+			want1: true,
+		},
+		{
+			name: "non-STAN message does not contain metadata on context",
+			args: args{
+				msg: fakeMessage{},
+			},
+			want:  MsgMetadata{},
+			want1: false,
+		},
+	}
+
+	decorator := MetadataContextDecorator()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := decorator(context.Background(), tt.args.msg)
+			got, got1 := MessageMetadataFrom(ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MessageMetadataFrom() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("MessageMetadataFrom() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+// newMessage wraps NewMessage and ignores any errors
+func newSTANMessage(msg *stan.Msg) binding.Message {
+	m, _ := NewMessage(msg)
+	return m
+}
+
+// fakeMessage implements binding.Message for tests
+type fakeMessage struct {
+}
+
+func (f fakeMessage) ReadEncoding() binding.Encoding {
+	panic("implement me")
+}
+
+func (f fakeMessage) ReadStructured(context.Context, binding.StructuredWriter) error {
+	panic("implement me")
+}
+
+func (f fakeMessage) ReadBinary(context.Context, binding.BinaryWriter) error {
+	panic("implement me")
+}
+
+func (f fakeMessage) Finish(error) error {
+	panic("implement me")
+}


### PR DESCRIPTION
See #657 

This is an approach which doesn't introduce any breaking changes, if users do nothing their `.Receive()` functions will receive the same `ctx` object they always have, however using the new `PropogateContext()` option will override it.

I'm going to add some comments to other parts of the codebase in this MR because I think I have an alternative approach, but needs discussion

Signed-off-by: dan-j <5727701+dan-j@users.noreply.github.com>