### PR TITLE
656 make separate receiver sender protocol

### DIFF
--- a/protocol/amqp/v2/protocol.go
+++ b/protocol/amqp/v2/protocol.go
@@ -100,7 +100,6 @@ func NewSenderProtocolFromClient(client *amqp.Client, session *amqp.Session, add
 	if err := t.applyOptions(opts...); err != nil {
 		return nil, err
 	}
-
 	t.senderLinkOpts = append(t.senderLinkOpts, amqp.LinkTargetAddress(address))
 	// Create a sender
 	amqpSender, err := session.NewSender(t.senderLinkOpts...)
@@ -108,7 +107,7 @@ func NewSenderProtocolFromClient(client *amqp.Client, session *amqp.Session, add
 		_ = client.Close()
 		_ = session.Close(context.Background())
 		return nil, err
-	}
+	}:q
 	t.Sender = NewSender(amqpSender).(*sender)
 	t.SenderContextDecorators = []func(context.Context) context.Context{}
 
@@ -135,7 +134,6 @@ func NewReceiverProtocolFromClient(client *amqp.Client, session *amqp.Session, a
 		return nil, err
 	}
 	t.Receiver = NewReceiver(amqpReceiver).(*receiver)
-
 	return t, nil
 }
 
@@ -164,7 +162,6 @@ func NewSenderProtocol(server, address string, connOption []amqp.ConnOption, ses
 
 // NewReceiverProtocol creates a new receiver amqp transport.
 func NewReceiverProtocol(server, address string, connOption []amqp.ConnOption, sessionOption []amqp.SessionOption, opts ...Option) (*Protocol, error) {
-
 	client, err := amqp.Dial(server, connOption...)
 	if err != nil {
 		return nil, err
@@ -178,6 +175,7 @@ func NewReceiverProtocol(server, address string, connOption []amqp.ConnOption, s
 	}
 
 	p, err := NewReceiverProtocolFromClient(client, session, address, opts...)
+
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/amqp/v2/protocol.go
+++ b/protocol/amqp/v2/protocol.go
@@ -2,8 +2,6 @@ package amqp
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/Azure/go-amqp"
 
@@ -107,7 +105,7 @@ func NewSenderProtocolFromClient(client *amqp.Client, session *amqp.Session, add
 		_ = client.Close()
 		_ = session.Close(context.Background())
 		return nil, err
-	}:q
+	}
 	t.Sender = NewSender(amqpSender).(*sender)
 	t.SenderContextDecorators = []func(context.Context) context.Context{}
 

--- a/protocol/amqp/v2/protocol.go
+++ b/protocol/amqp/v2/protocol.go
@@ -2,6 +2,8 @@ package amqp
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/Azure/go-amqp"
 
@@ -78,6 +80,104 @@ func NewProtocol(server, queue string, connOption []amqp.ConnOption, sessionOpti
 	}
 
 	p, err := NewProtocolFromClient(client, session, queue, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	p.ownedClient = true
+	return p, nil
+}
+
+// NewSenderProtocolFromClient creates a new amqp sender transport.
+func NewSenderProtocolFromClient(client *amqp.Client, session *amqp.Session, address string, opts ...Option) (*Protocol, error) {
+	t := &Protocol{
+		Node:             address,
+		senderLinkOpts:   []amqp.LinkOption(nil),
+		receiverLinkOpts: []amqp.LinkOption(nil),
+		Client:           client,
+		Session:          session,
+	}
+	if err := t.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+
+	t.senderLinkOpts = append(t.senderLinkOpts, amqp.LinkTargetAddress(address))
+	// Create a sender
+	amqpSender, err := session.NewSender(t.senderLinkOpts...)
+	if err != nil {
+		_ = client.Close()
+		_ = session.Close(context.Background())
+		return nil, err
+	}
+	t.Sender = NewSender(amqpSender).(*sender)
+	t.SenderContextDecorators = []func(context.Context) context.Context{}
+
+	return t, nil
+}
+
+// NewReceiverProtocolFromClient creates a new receiver amqp transport.
+func NewReceiverProtocolFromClient(client *amqp.Client, session *amqp.Session, address string, opts ...Option) (*Protocol, error) {
+	t := &Protocol{
+		Node:             address,
+		senderLinkOpts:   []amqp.LinkOption(nil),
+		receiverLinkOpts: []amqp.LinkOption(nil),
+		Client:           client,
+		Session:          session,
+	}
+	if err := t.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+
+	t.Node = address
+	t.receiverLinkOpts = append(t.receiverLinkOpts, amqp.LinkSourceAddress(address))
+	amqpReceiver, err := t.Session.NewReceiver(t.receiverLinkOpts...)
+	if err != nil {
+		return nil, err
+	}
+	t.Receiver = NewReceiver(amqpReceiver).(*receiver)
+
+	return t, nil
+}
+
+// NewSenderProtocol creates a new sender amqp transport.
+func NewSenderProtocol(server, address string, connOption []amqp.ConnOption, sessionOption []amqp.SessionOption, opts ...Option) (*Protocol, error) {
+	client, err := amqp.Dial(server, connOption...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Open a session
+	session, err := client.NewSession(sessionOption...)
+	if err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
+	p, err := NewSenderProtocolFromClient(client, session, address, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	p.ownedClient = true
+	return p, nil
+}
+
+// NewReceiverProtocol creates a new receiver amqp transport.
+func NewReceiverProtocol(server, address string, connOption []amqp.ConnOption, sessionOption []amqp.SessionOption, opts ...Option) (*Protocol, error) {
+
+	client, err := amqp.Dial(server, connOption...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Open a session
+	session, err := client.NewSession(sessionOption...)
+	if err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
+	p, err := NewReceiverProtocolFromClient(client, session, address, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/stan/v2/context.go
+++ b/protocol/stan/v2/context.go
@@ -1,0 +1,44 @@
+package stan
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/v2/binding"
+)
+
+// MsgMetadata holds metadata of a received *stan.Msg. This information is kept in a separate struct so that users
+// cannot interact with the underlying message outside of the SDK.
+type MsgMetadata struct {
+	Sequence        uint64
+	Redelivered     bool
+	RedeliveryCount uint32
+}
+
+type msgKeyType struct{}
+
+var msgKey msgKeyType
+
+// MetadataContextDecorator returns an inbound context decorator which adds STAN message metadata to
+// the current context. If the inbound message is not a *stan.Message then this decorator is a no-op.
+func MetadataContextDecorator() func(context.Context, binding.Message) context.Context {
+	return func(ctx context.Context, m binding.Message) context.Context {
+		if msg, ok := m.(*Message); ok {
+			return context.WithValue(ctx, msgKey, MsgMetadata{
+				Sequence:        msg.Msg.Sequence,
+				Redelivered:     msg.Msg.Redelivered,
+				RedeliveryCount: msg.Msg.RedeliveryCount,
+			})
+		}
+
+		return ctx
+	}
+}
+
+// MessageMetadataFrom extracts the STAN message metadata from the provided ctx. The bool return parameter is true if
+// the metadata was set on the context, or false otherwise.
+func MessageMetadataFrom(ctx context.Context) (MsgMetadata, bool) {
+	if v, ok := ctx.Value(msgKey).(MsgMetadata); ok {
+		return v, true
+	}
+
+	return MsgMetadata{}, false
+}

--- a/protocol/stan/v2/context_test.go
+++ b/protocol/stan/v2/context_test.go
@@ -1,0 +1,89 @@
+package stan
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/nats-io/stan.go"
+	"github.com/nats-io/stan.go/pb"
+	"reflect"
+	"testing"
+)
+
+func TestMetadataContextDecorator(t *testing.T) {
+	type args struct {
+		msg binding.Message
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  MsgMetadata
+		want1 bool
+	}{
+		{
+			name: "STAN message contains metadata on context",
+			args: args{
+				msg: newSTANMessage(&stan.Msg{
+					MsgProto: pb.MsgProto{
+						Sequence:        13,
+						Redelivered:     true,
+						RedeliveryCount: 42,
+					},
+				}),
+			},
+			want: MsgMetadata{
+				Sequence:        13,
+				Redelivered:     true,
+				RedeliveryCount: 42,
+			},
+			want1: true,
+		},
+		{
+			name: "non-STAN message does not contain metadata on context",
+			args: args{
+				msg: fakeMessage{},
+			},
+			want:  MsgMetadata{},
+			want1: false,
+		},
+	}
+
+	decorator := MetadataContextDecorator()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := decorator(context.Background(), tt.args.msg)
+			got, got1 := MessageMetadataFrom(ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MessageMetadataFrom() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("MessageMetadataFrom() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+// newMessage wraps NewMessage and ignores any errors
+func newSTANMessage(msg *stan.Msg) binding.Message {
+	m, _ := NewMessage(msg)
+	return m
+}
+
+// fakeMessage implements binding.Message for tests
+type fakeMessage struct {
+}
+
+func (f fakeMessage) ReadEncoding() binding.Encoding {
+	panic("implement me")
+}
+
+func (f fakeMessage) ReadStructured(context.Context, binding.StructuredWriter) error {
+	panic("implement me")
+}
+
+func (f fakeMessage) ReadBinary(context.Context, binding.BinaryWriter) error {
+	panic("implement me")
+}
+
+func (f fakeMessage) Finish(error) error {
+	panic("implement me")
+}

--- a/test/integration/amqp/amqp_test.go
+++ b/test/integration/amqp/amqp_test.go
@@ -26,6 +26,20 @@ func TestSendEvent(t *testing.T) {
 	})
 }
 
+func TestSenderReceiverEvent(t *testing.T) {
+	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+		eventIn = test.ConvertEventExtensionsToString(t, eventIn)
+		clienttest.SendReceive(t, func() interface{} {
+			s:= senderProtocolFactory(t)
+			r:= receiverProtocolFactory(t)
+			s.Receiver=r.Receiver
+			return s
+		}, eventIn, func(e event.Event) {
+			test.AssertEventEquals(t, eventIn, test.ConvertEventExtensionsToString(t, e))
+		})
+	})
+}
+
 // Some test require an AMQP broker or router. If the connection fails
 // the tests are skipped. The env variable TEST_AMQP_URL can be set to the
 // test URL, otherwise the default is "/test"
@@ -53,6 +67,24 @@ func protocolFactory(t *testing.T) *protocolamqp.Protocol {
 	c, ss, a := testClient(t)
 
 	p, err := protocolamqp.NewProtocolFromClient(c, ss, a)
+	require.NoError(t, err)
+
+	return p
+}
+
+func senderProtocolFactory(t *testing.T) *protocolamqp.Protocol {
+	c, ss, a := testClient(t)
+
+	p, err := protocolamqp.NewSenderProtocolFromClient(c, ss, a)
+	require.NoError(t, err)
+
+	return p
+}
+
+func receiverProtocolFactory(t *testing.T) *protocolamqp.Protocol {
+	c, ss, a := testClient(t)
+
+	p, err := protocolamqp.NewReceiverProtocolFromClient(c, ss, a)
 	require.NoError(t, err)
 
 	return p

--- a/test/integration/amqp/amqp_test.go
+++ b/test/integration/amqp/amqp_test.go
@@ -30,9 +30,9 @@ func TestSenderReceiverEvent(t *testing.T) {
 	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 		eventIn = test.ConvertEventExtensionsToString(t, eventIn)
 		clienttest.SendReceive(t, func() interface{} {
-			s:= senderProtocolFactory(t)
-			r:= receiverProtocolFactory(t)
-			s.Receiver=r.Receiver
+			s := senderProtocolFactory(t)
+			r := receiverProtocolFactory(t)
+			s.Receiver = r.Receiver
 			return s
 		}, eventIn, func(e event.Event) {
 			test.AssertEventEquals(t, eventIn, test.ConvertEventExtensionsToString(t, e))
@@ -89,4 +89,3 @@ func receiverProtocolFactory(t *testing.T) *protocolamqp.Protocol {
 
 	return p
 }
-

--- a/test/integration/amqp/amqp_test.go
+++ b/test/integration/amqp/amqp_test.go
@@ -89,3 +89,4 @@ func receiverProtocolFactory(t *testing.T) *protocolamqp.Protocol {
 
 	return p
 }
+


### PR DESCRIPTION
This will resolve issue mentioned  in [656](https://github.com/cloudevents/sdk-go/issues/656)
 Current  implements creates both receiver and sender amqp transport pointing to same address and causes issues as mentioned here.
The link source address of the receiver and the link target address of the transmitter are set to the same value. This means that transmitted msgs can loop back to the sender. The address uses balanced deliver so that the first msg goes to the proper destination, but the second msg loops back to sender.

This PR resolves that issue by creating separate implementation of NewProtocol as NewSenderProtocol and NewReceiver Protocol, while maintaining old implementation of NewProtocol.