### PR TITLE
This will resolve issue mentioned in 656

### DIFF
--- a/test/integration/amqp/amqp_test.go
+++ b/test/integration/amqp/amqp_test.go
@@ -58,7 +58,6 @@ func receiverProtocolFactory(t *testing.T) *protocolamqp.Protocol {
 	return p
 }
 
-
 // Some test require an AMQP broker or router. If the connection fails
 // the tests are skipped. The env variable TEST_AMQP_URL can be set to the
 // test URL, otherwise the default is "/test"

--- a/test/integration/amqp/amqp_test.go
+++ b/test/integration/amqp/amqp_test.go
@@ -26,6 +26,39 @@ func TestSendEvent(t *testing.T) {
 	})
 }
 
+func TestSenderReceiverEvent(t *testing.T) {
+	test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+		eventIn = test.ConvertEventExtensionsToString(t, eventIn)
+		clienttest.SendReceive(t, func() interface{} {
+			s := senderProtocolFactory(t)
+			r := receiverProtocolFactory(t)
+			s.Receiver = r.Receiver
+			return s
+		}, eventIn, func(e event.Event) {
+			test.AssertEventEquals(t, eventIn, test.ConvertEventExtensionsToString(t, e))
+		})
+	})
+}
+
+func senderProtocolFactory(t *testing.T) *protocolamqp.Protocol {
+	c, ss, a := testClient(t)
+
+	p, err := protocolamqp.NewSenderProtocolFromClient(c, ss, a)
+	require.NoError(t, err)
+
+	return p
+}
+
+func receiverProtocolFactory(t *testing.T) *protocolamqp.Protocol {
+	c, ss, a := testClient(t)
+
+	p, err := protocolamqp.NewReceiverProtocolFromClient(c, ss, a)
+	require.NoError(t, err)
+
+	return p
+}
+
+
 // Some test require an AMQP broker or router. If the connection fails
 // the tests are skipped. The env variable TEST_AMQP_URL can be set to the
 // test URL, otherwise the default is "/test"


### PR DESCRIPTION
This will resolve issue mentioned  in [656](https://github.com/cloudevents/sdk-go/issues/656)
 Current  implements creates both receiver and sender amqp transport pointing to same address and causes issues as mentioned here.
The link source address of the receiver and the link target address of the transmitter are set to the same value. This means that transmitted msgs can loop back to the sender. The address uses balanced deliver so that the first msg goes to the proper destination, but the second msg loops back to sender.

This PR resolves that issue by creating separate implementation of NewProtocol as NewSenderProtocol and NewReceiver Protocol, while maintaining old implementation of NewProtocol.