### PR TITLE
consumers of the SDK should be given power to throttle incoming messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,5 +31,5 @@ Code style for this module is maintained using [`go fmt`](https://golang.org/cmd
 
 ### Maintainers
 
-If you are a maintainer of this repository, [here](maintainers_guide.pr) is a brief
+If you are a maintainer of this repository, [here](maintainer_guidelines.md) is a brief
 guide with helpful tips.

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -246,13 +246,9 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 				}
 
 				// Do not block on the invoker.
-				wg.Add(1)
-				go func() {
-					if err := c.invoker.Invoke(ctx, msg, respFn); err != nil {
-						cecontext.LoggerFrom(ctx).Warn("Error while handling a message: ", err)
-					}
-					wg.Done()
-				}()
+				if err := c.invoker.Invoke(ctx, msg, respFn); err != nil {
+					cecontext.LoggerFrom(ctx).Warn("Error while handling a message: ", err)
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
- Invoker does not have to execute in goroutine.
- This way the users of the library can add in any kind of throttle that they want to put in place