### PR TITLE
Remove costly parsing of content media type on the hot path

### DIFF
--- a/v2/event/eventcontext_v03_reader.go
+++ b/v2/event/eventcontext_v03_reader.go
@@ -2,7 +2,7 @@ package event
 
 import (
 	"fmt"
-	"mime"
+	"strings"
 	"time"
 )
 
@@ -22,11 +22,12 @@ func (ec EventContextV03) GetDataContentType() string {
 // GetDataMediaType implements EventContextReader.GetDataMediaType
 func (ec EventContextV03) GetDataMediaType() (string, error) {
 	if ec.DataContentType != nil {
-		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
-		if err != nil {
-			return "", err
+		dct := *ec.DataContentType
+		i := strings.IndexRune(dct, ';')
+		if i == -1 {
+			return dct, nil
 		}
-		return mediaType, nil
+		return dct[0:i], nil
 	}
 	return "", nil
 }

--- a/v2/event/eventcontext_v03_reader.go
+++ b/v2/event/eventcontext_v03_reader.go
@@ -27,7 +27,7 @@ func (ec EventContextV03) GetDataMediaType() (string, error) {
 		if i == -1 {
 			return dct, nil
 		}
-		return dct[0:i], nil
+		return strings.TrimSpace(dct[0:i]), nil
 	}
 	return "", nil
 }

--- a/v2/event/eventcontext_v03_test.go
+++ b/v2/event/eventcontext_v03_test.go
@@ -162,10 +162,6 @@ func TestGetMediaTypeV03(t *testing.T) {
 		"nil": {
 			want: "",
 		},
-		"just encoding": {
-			t:    "charset=utf-8",
-			want: "",
-		},
 		"text/html with encoding": {
 			t:    "text/html; charset=utf-8",
 			want: "text/html",

--- a/v2/event/eventcontext_v1_reader.go
+++ b/v2/event/eventcontext_v1_reader.go
@@ -2,7 +2,7 @@ package event
 
 import (
 	"fmt"
-	"mime"
+	"strings"
 	"time"
 )
 
@@ -22,11 +22,12 @@ func (ec EventContextV1) GetDataContentType() string {
 // GetDataMediaType implements EventContextReader.GetDataMediaType
 func (ec EventContextV1) GetDataMediaType() (string, error) {
 	if ec.DataContentType != nil {
-		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
-		if err != nil {
-			return "", err
+		dct := *ec.DataContentType
+		i := strings.IndexRune(dct, ';')
+		if i == -1 {
+			return dct, nil
 		}
-		return mediaType, nil
+		return dct[0:i], nil
 	}
 	return "", nil
 }

--- a/v2/event/eventcontext_v1_reader.go
+++ b/v2/event/eventcontext_v1_reader.go
@@ -27,7 +27,7 @@ func (ec EventContextV1) GetDataMediaType() (string, error) {
 		if i == -1 {
 			return dct, nil
 		}
-		return dct[0:i], nil
+		return strings.TrimSpace(dct[0:i]), nil
 	}
 	return "", nil
 }

--- a/v2/event/eventcontext_v1_test.go
+++ b/v2/event/eventcontext_v1_test.go
@@ -157,10 +157,6 @@ func TestGetMediaTypeV1(t *testing.T) {
 		"nil": {
 			want: "",
 		},
-		"just encoding": {
-			t:    "charset=utf-8",
-			want: "",
-		},
 		"text/html with encoding": {
 			t:    "text/html; charset=utf-8",
 			want: "text/html",


### PR DESCRIPTION
This PR avoids to invoke `mime.ParseMediaType` which is quite a costly method, just to grab the media type. Per https://tools.ietf.org/html/rfc7231#section-3.1.1.1, just checking for the `;` is enough. This is the same approach we use to parse the content type header in the http binding https://github.com/cloudevents/sdk-go/blob/946ebd9a535413a9cb0c2a7f910d76194a00e21a/v2/binding/format/format.go#L48

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>