### PR TITLE
By default, do not restrict the length of extension attribute names

### DIFF
--- a/v2/event/eventcontext_v1.go
+++ b/v2/event/eventcontext_v1.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"errors"
 	"fmt"
 	"mime"
 	"sort"
@@ -72,8 +71,8 @@ func (ec EventContextV1) ExtensionAs(name string, obj interface{}) error {
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
 // This function fails if the name doesn't respect the regex ^[a-zA-Z0-9]+$
 func (ec *EventContextV1) SetExtension(name string, value interface{}) error {
-	if !IsExtensionNameValid(name) {
-		return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set")
+	if err := validateExtensionName(name); err != nil {
+		return err
 	}
 
 	name = strings.ToLower(name)

--- a/v2/event/extensions.go
+++ b/v2/event/extensions.go
@@ -1,6 +1,8 @@
 package event
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -8,6 +10,12 @@ const (
 	// DataContentEncodingKey is the key to DeprecatedDataContentEncoding for versions that do not support data content encoding
 	// directly.
 	DataContentEncodingKey = "datacontentencoding"
+)
+
+var (
+	// This determines the behavior of validateExtensionName(). For MaxExtensionNameLength > 0, an error will be returned,
+	// if len(key) > MaxExtensionNameLength
+	MaxExtensionNameLength = 0
 )
 
 func caseInsensitiveSearch(key string, space map[string]interface{}) (interface{}, bool) {
@@ -21,13 +29,24 @@ func caseInsensitiveSearch(key string, space map[string]interface{}) (interface{
 }
 
 func IsExtensionNameValid(key string) bool {
-	if len(key) < 1 || len(key) > 20 {
+	if err := validateExtensionName(key); err != nil {
 		return false
 	}
+	return true
+}
+
+func validateExtensionName(key string) error {
+	if len(key) < 1 {
+		return errors.New("bad key, CloudEvents attribute names MUST NOT be empty")
+	}
+	if MaxExtensionNameLength > 0 && len(key) > MaxExtensionNameLength {
+		return fmt.Errorf("bad key, CloudEvents attribute name '%s' is longer than %d characters", key, MaxExtensionNameLength)
+	}
+
 	for _, c := range key {
 		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
-			return false
+			return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set")
 		}
 	}
-	return true
+	return nil
 }


### PR DESCRIPTION
I introduced a global variable `MaxExtensionNameLength` in package event, which by default is 0. If you prefer other mechanisms to globally set this value, please let me know.

As I wanted to focus on #670, I kept the changes minimal. I think that some of the functions would belong into different files now. E.g. `SetExtension()` could now go into `eventcontext_v1_writer.go`, and `extension.go` is not really needed as a separate file. 

Signed-off-by: Klaus Deissner <klaus.deissner@sap.com>