### PR TITLE
Adding error to protocol result if not 200 status code

### DIFF
--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -141,7 +141,7 @@ func (p *Protocol) Send(ctx context.Context, m binding.Message, transformers ...
 	}
 
 	msg, err := p.Request(ctx, m, transformers...)
-	if err != nil {
+	if err != nil && !protocol.IsACK(err) {
 		var res *Result
 		if protocol.ResultAs(err, &res) {
 			if message, ok := msg.(*Message); ok {

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -6,6 +6,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -139,7 +140,18 @@ func (p *Protocol) Send(ctx context.Context, m binding.Message, transformers ...
 		return fmt.Errorf("nil Message")
 	}
 
-	_, err := p.Request(ctx, m, transformers...)
+	msg, err := p.Request(ctx, m, transformers...)
+	if err != nil {
+		var res *Result
+		if protocol.ResultAs(err, &res) {
+			if message, ok := msg.(*Message); ok {
+				buf := new(bytes.Buffer)
+				buf.ReadFrom(message.BodyReader)
+				errorStr := buf.String()
+				err = NewResult(res.StatusCode, "%s", errorStr)
+			}
+		}
+	}
 	return err
 }
 

--- a/v2/protocol/http/protocol_retry.go
+++ b/v2/protocol/http/protocol_retry.go
@@ -8,6 +8,7 @@ package http
 import (
 	"context"
 	"errors"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -42,7 +43,12 @@ func (p *Protocol) doOnce(req *http.Request) (binding.Message, protocol.Result) 
 	if resp.StatusCode/100 == 2 {
 		result = protocol.ResultACK
 	} else {
-		result = protocol.ResultNACK
+		respbody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			result = protocol.ResultNACK
+		} else {
+			result = protocol.NewReceipt(false, "%s", string(respbody))
+		}
 	}
 
 	return NewMessage(resp.Header, resp.Body), NewResult(resp.StatusCode, "%w", result)

--- a/v2/protocol/http/protocol_retry.go
+++ b/v2/protocol/http/protocol_retry.go
@@ -8,7 +8,6 @@ package http
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -43,12 +42,7 @@ func (p *Protocol) doOnce(req *http.Request) (binding.Message, protocol.Result) 
 	if resp.StatusCode/100 == 2 {
 		result = protocol.ResultACK
 	} else {
-		respbody, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			result = protocol.ResultNACK
-		} else {
-			result = protocol.NewReceipt(false, "%s", string(respbody))
-		}
+		result = protocol.ResultNACK
 	}
 
 	return NewMessage(resp.Header, resp.Body), NewResult(resp.StatusCode, "%w", result)


### PR DESCRIPTION
Adding the error message to the protocol result so it can be retrieved when there are non 200 status codes.

Signed-off-by: Daniel Grist <dgrist@ibm.com>