### PR TITLE
Finish() no longer used binding-message in Send()

### DIFF
--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -141,6 +141,9 @@ func (p *Protocol) Send(ctx context.Context, m binding.Message, transformers ...
 	}
 
 	msg, err := p.Request(ctx, m, transformers...)
+	if msg != nil {
+		defer func() { _ = msg.Finish(err) }()
+	}
 	if err != nil && !protocol.IsACK(err) {
 		var res *Result
 		if protocol.ResultAs(err, &res) {


### PR DESCRIPTION
Finish() no longer used binding-message in Send().  and I found that some trace mechanisms must rely on Finish() to complete.

Signed-off-by: XinYang <xinydev@gmail.com>