### PR TITLE
Deprecate the stan protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go SDK for [CloudEvents](https://github.com/cloudevents/spec)
 
-[![go-doc](https://godoc.org/github.com/cloudevents/sdk-go?status.svg)](https://godoc.org/github.com/cloudevents/sdk-go)
+[![go-doc](https://godoc.org/github.com/cloudevents/sdk-go/v2?status.svg)](https://godoc.org/github.com/cloudevents/sdk-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cloudevents/sdk-go)](https://goreportcard.com/report/github.com/cloudevents/sdk-go)
 [![Releases](https://img.shields.io/github/release-pre/cloudevents/sdk-go.svg)](https://github.com/cloudevents/sdk-go/releases)
 [![LICENSE](https://img.shields.io/github/license/cloudevents/sdk-go.svg)](https://github.com/cloudevents/sdk-go/blob/main/LICENSE)

--- a/docs/protocol_implementations.md
+++ b/docs/protocol_implementations.md
@@ -4,58 +4,80 @@ nav_order: 4
 ---
 
 # Protocol Binding implementations
+
 {: .no_toc }
 
 1. TOC
+
 {:toc}
 
 ## Overview
 
 A Protocol binding in sdk-go is implemented defining:
 
-* How to read and write the event back/forth the protocol specific data structured (eg how to read an `Event` starting from `net/http.HttpRequest`)
-* How to let the protocol interact with the `Client`
+- How to read and write the event back/forth the protocol specific data
+  structured (eg how to read an `Event` starting from `net/http.HttpRequest`)
+- How to let the protocol interact with the `Client`
 
-The former is done implementing the [`Message` interface](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/message.go) and 
-the `Write<DataStructure>` functions, while the latter is done implementing specific `protocol` interfaces.
+The former is done implementing the
+[`Message` interface](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/message.go)
+and the `Write<DataStructure>` functions, while the latter is done implementing
+specific `protocol` interfaces.
 
 ## Protocol implementations
 
-* [AMQP Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/amqp) using [go-amqp](https://github.com/Azure/go-amqp)
-* [HTTP Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/http) using [net/http](https://golang.org/pkg/net/http/)
-* [Kafka Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/kafka_sarama) using [Sarama](https://github.com/Shopify/sarama)
-* [NATS Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/nats) using [nats.go](https://github.com/nats-io/nats.go)
-* [STAN Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/stan) using [stan.go](https://github.com/nats-io/stan.go)
-* [PubSub Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/pubsub)
-* [Go channels protocol binding](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/gochan) (useful for mocking purpose)
+- [AMQP Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/amqp)
+  using [go-amqp](https://github.com/Azure/go-amqp)
+- [HTTP Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/http)
+  using [net/http](https://golang.org/pkg/net/http/)
+- [Kafka Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/kafka_sarama)
+  using [Sarama](https://github.com/Shopify/sarama)
+- [NATS Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/nats)
+  using [nats.go](https://github.com/nats-io/nats.go)
+- [NATS JetStream Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/nats_jetstream)
+  using [nats.go](https://github.com/nats-io/nats.go)
+- [~~STAN Protocol Binding~~](https://github.com/cloudevents/sdk-go/tree/main/protocol/stan)
+  using [stan.go](https://github.com/nats-io/stan.go) Deprecated, Please use the
+  nats_jetstream package for
+  [nats streaming](https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2).
+- [PubSub Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/protocol/pubsub)
+- [Go channels protocol binding](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/gochan)
+  (useful for mocking purpose)
 
 ## `Message` interface
 
-`Message` is the interface to a binding-specific message containing an event. 
-This interface abstracts how to read a `CloudEvent` starting from a protocol specific data structure.
+`Message` is the interface to a binding-specific message containing an event.
+This interface abstracts how to read a `CloudEvent` starting from a protocol
+specific data structure.
 
 To convert a `Message` back and forth to `Event`, an `Event` can be wrapped into
-a `Message` using [`binding.ToMessage()`](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/event_message.go) and a `Message`
-can be converted to `Event` using [`binding.ToEvent()`](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/to_event.go).
+a `Message` using
+[`binding.ToMessage()`](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/event_message.go)
+and a `Message` can be converted to `Event` using
+[`binding.ToEvent()`](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/to_event.go).
 
 A `Message` has its own lifecycle:
 
-* Some implementations of `Message` can be successfully read only one time, 
-  because the encoding process drain the message itself. In order to consume a message several 
-  times, the [`buffering` module](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/buffering) provides several APIs to buffer the `Message`.
-* Every time the `Message` receiver/emitter can forget the message, `Message.Finish()` **must** be invoked.
+- Some implementations of `Message` can be successfully read only one time,
+  because the encoding process drain the message itself. In order to consume a
+  message several times, the
+  [`buffering` module](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/buffering)
+  provides several APIs to buffer the `Message`.
+- Every time the `Message` receiver/emitter can forget the message,
+  `Message.Finish()` **must** be invoked.
 
-You can use `Message`s alone or you can interact with them through the protocol implementations.
+You can use `Message`s alone or you can interact with them through the protocol
+implementations.
 
 ## `Message` implementation and `Write<DataStructure>` functions
 
-Depending on the protocol binding, the `Message` implementation could support both
-binary and structured messages.
+Depending on the protocol binding, the `Message` implementation could support
+both binary and structured messages.
 
-All protocol implementations provides a function, with a name like `NewMessage`, to wrap the
-[3pl][3pl] data structure into the `Message` implementation. For example, 
-`http.NewMessageFromHttpRequest` takes an `net/http.HttpRequest` and wraps it into `protocol/http.Message`, 
-which implements `Message`.
+All protocol implementations provides a function, with a name like `NewMessage`,
+to wrap the [3pl][3pl] data structure into the `Message` implementation. For
+example, `http.NewMessageFromHttpRequest` takes an `net/http.HttpRequest` and
+wraps it into `protocol/http.Message`, which implements `Message`.
 
 `Write<DataStructure>` functions read a `binding.Message` and write what is
 found into the [3pl][3pl] data structure. For example, `nats.WriteMsg` writes
@@ -64,22 +86,32 @@ the message into a `nats.Msg`, or `http.WriteRequest` writes message into a
 
 ## Transformations
 
-You can perform simple transformations on `Message` without going through the `Event` representation
-using the [`Transformer`s](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/transformer.go).
+You can perform simple transformations on `Message` without going through the
+`Event` representation using the
+[`Transformer`s](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/transformer.go).
 
-Some built-in `Transformer`s are provided in the [`transformer` module](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/transformer).
+Some built-in `Transformer`s are provided in the
+[`transformer` module](https://github.com/cloudevents/sdk-go/tree/main/v2/binding/transformer).
 
 ## `protocol` interfaces
 
-Every Protocol implementation provides a set of implemented interfaces to produce/consume messages and 
-implement request/response semantics. Six interfaces are defined:
+Every Protocol implementation provides a set of implemented interfaces to
+produce/consume messages and implement request/response semantics. Six
+interfaces are defined:
 
-* [`Receiver`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/inbound.go): Interface that produces message, receiving them from the wire.
-* [`Sender`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/outbound.go): Interface that consumes messages, sending them to the wire.
-* [`Responder`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/inbound.go): Server side request/response.
-* [`Requester`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/outbound.go): Client side request/response.
-* [`Opener`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/lifecycle.go): Interface that is optionally needed to bootstrap a `Receiver`/`Responder`
-* [`Closer`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/lifecycle.go): Interface that is optionally needed to close the connection with remote systems
+- [`Receiver`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/inbound.go):
+  Interface that produces message, receiving them from the wire.
+- [`Sender`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/outbound.go):
+  Interface that consumes messages, sending them to the wire.
+- [`Responder`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/inbound.go):
+  Server side request/response.
+- [`Requester`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/outbound.go):
+  Client side request/response.
+- [`Opener`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/lifecycle.go):
+  Interface that is optionally needed to bootstrap a `Receiver`/`Responder`
+- [`Closer`](https://github.com/cloudevents/sdk-go/tree/main/v2/protocol/lifecycle.go):
+  Interface that is optionally needed to close the connection with remote
+  systems
 
 Every protocol implements one or several of them, depending on its capabilities.
 

--- a/protocol/stan/v2/doc.go
+++ b/protocol/stan/v2/doc.go
@@ -5,5 +5,8 @@
 
 /*
 Package stan implements the CloudEvent transport implementation using NATS Streaming.
+
+Deprecated: Please use the nats_jetstream package for nats streaming.
+See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 */
 package stan

--- a/protocol/stan/v2/message.go
+++ b/protocol/stan/v2/message.go
@@ -8,6 +8,7 @@ package stan
 import (
 	"bytes"
 	"context"
+
 	"github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/nats-io/stan.go"
 
@@ -17,6 +18,8 @@ import (
 
 // Message implements binding.Message by wrapping an *stan.Msg.
 // This message *can* be read several times safely
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 type Message struct {
 	Msg        *stan.Msg
 	manualAcks bool
@@ -24,6 +27,8 @@ type Message struct {
 
 // NewMessage wraps a *nats.Msg in a binding.Message.
 // The returned message *can* be read several times safely
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 func NewMessage(msg *stan.Msg, opts ...MessageOption) (*Message, error) {
 	m := &Message{Msg: msg}
 

--- a/protocol/stan/v2/protocol.go
+++ b/protocol/stan/v2/protocol.go
@@ -17,6 +17,8 @@ import (
 
 // Protocol is a reference implementation for using the CloudEvents binding
 // integration. Protocol acts as both a STAN client and a STAN handler.
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 type Protocol struct {
 	Conn stan.Conn
 
@@ -30,6 +32,8 @@ type Protocol struct {
 }
 
 // NewProtocol creates a new STAN protocol including managing the lifecycle of the connection
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 func NewProtocol(clusterID, clientID, sendSubject, receiveSubject string, stanOpts []stan.Option, opts ...ProtocolOption) (*Protocol, error) {
 	conn, err := stan.Connect(clusterID, clientID, stanOpts...)
 	if err != nil {
@@ -50,6 +54,8 @@ func NewProtocol(clusterID, clientID, sendSubject, receiveSubject string, stanOp
 }
 
 // NewProtocolFromConn creates a new STAN protocol but leaves managing the lifecycle of the connection up to the caller
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 func NewProtocolFromConn(conn stan.Conn, sendSubject, receiveSubject string, opts ...ProtocolOption) (*Protocol, error) {
 	var err error
 	p := &Protocol{

--- a/protocol/stan/v2/receiver.go
+++ b/protocol/stan/v2/receiver.go
@@ -8,10 +8,11 @@ package stan
 import (
 	"context"
 	"fmt"
-	"github.com/cloudevents/sdk-go/v2/binding"
-	"github.com/nats-io/stan.go"
 	"io"
 	"sync"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/nats-io/stan.go"
 )
 
 type msgErr struct {
@@ -20,11 +21,15 @@ type msgErr struct {
 }
 
 // Receiver implements protocol.Receiver for STAN subscriptions
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 type Receiver struct {
 	incoming    chan msgErr
 	messageOpts []MessageOption
 }
 
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 func NewReceiver(opts ...ReceiverOption) (*Receiver, error) {
 	r := &Receiver{
 		incoming: make(chan msgErr),
@@ -76,6 +81,8 @@ func (r *Receiver) applyOptions(opts ...ReceiverOption) error {
 // - protocol.Opener
 // - protocol.Closer
 // - protocol.Receiver
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 type Consumer struct {
 	Receiver
 
@@ -92,6 +99,8 @@ type Consumer struct {
 	connOwned     bool // whether this consumer is responsible for closing the connection
 }
 
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 func NewConsumer(clusterID, clientID, subject string, stanOpts []stan.Option, opts ...ConsumerOption) (*Consumer, error) {
 	conn, err := stan.Connect(clusterID, clientID, stanOpts...)
 	if err != nil {
@@ -109,6 +118,8 @@ func NewConsumer(clusterID, clientID, subject string, stanOpts []stan.Option, op
 	return c, err
 }
 
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 func NewConsumerFromConn(conn stan.Conn, subject string, opts ...ConsumerOption) (*Consumer, error) {
 	c := &Consumer{
 		Conn:          conn,

--- a/protocol/stan/v2/sender.go
+++ b/protocol/stan/v2/sender.go
@@ -9,12 +9,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/protocol"
 
 	"github.com/nats-io/stan.go"
 )
 
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 type Sender struct {
 	Conn    stan.Conn
 	Subject string
@@ -23,6 +26,8 @@ type Sender struct {
 }
 
 // NewSender creates a new protocol.Sender responsible for opening and closing the STAN connection
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 func NewSender(clusterID, clientID, subject string, stanOpts []stan.Option, opts ...SenderOption) (*Sender, error) {
 	conn, err := stan.Connect(clusterID, clientID, stanOpts...)
 	if err != nil {
@@ -44,6 +49,8 @@ func NewSender(clusterID, clientID, subject string, stanOpts []stan.Option, opts
 
 // NewSenderFromConn creates a new protocol.Sender which leaves responsibility for opening and closing the STAN
 // connection to the caller
+// Deprecated: Please use the nats_jetstream package for nats streaming.
+// See https://pkg.go.dev/github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2.
 func NewSenderFromConn(conn stan.Conn, subject string, opts ...SenderOption) (*Sender, error) {
 	s := &Sender{
 		Conn:    conn,


### PR DESCRIPTION
fixes https://github.com/cloudevents/sdk-go/issues/697

`stan` has been replaced with `nats_jetstream`.