### PR TITLE
Cherry-pick: Add protobuf datacodec (#688)

### DIFF
--- a/binding/format/protobuf/v2/datacodec.go
+++ b/binding/format/protobuf/v2/datacodec.go
@@ -1,0 +1,50 @@
+package format
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/cloudevents/sdk-go/v2/event/datacodec"
+)
+
+const (
+	// ContentTypeProtobuf indicates that the data attribute is a protobuf
+	// message.
+	ContentTypeProtobuf = "application/protobuf"
+)
+
+func init() {
+	datacodec.AddDecoder(ContentTypeProtobuf, DecodeData)
+	datacodec.AddEncoder(ContentTypeProtobuf, EncodeData)
+}
+
+// DecodeData converts an encoded protobuf message back into the message (out).
+// The message must be a type compatible with whatever was given to EncodeData.
+func DecodeData(ctx context.Context, in []byte, out interface{}) error {
+	outmsg, ok := out.(proto.Message)
+	if !ok {
+		return fmt.Errorf("can only decode protobuf into proto.Message. got %T", out)
+	}
+	if err := proto.Unmarshal(in, outmsg); err != nil {
+		return fmt.Errorf("failed to unmarshal message: %s", err)
+	}
+	return nil
+}
+
+// EncodeData a protobuf message to bytes.
+//
+// Like the official datacodec implementations, this one returns the given value
+// as-is if it is already a byte slice.
+func EncodeData(ctx context.Context, in interface{}) ([]byte, error) {
+	if b, ok := in.([]byte); ok {
+		return b, nil
+	}
+	var pbmsg proto.Message
+	var ok bool
+	if pbmsg, ok = in.(proto.Message); !ok {
+		return nil, fmt.Errorf("protobuf encoding only works with protobuf messages. got %T", in)
+	}
+	return proto.Marshal(pbmsg)
+}

--- a/binding/format/protobuf/v2/protobuf_test.go
+++ b/binding/format/protobuf/v2/protobuf_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/types"
 
 	format "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
+	pb "github.com/cloudevents/sdk-go/binding/format/protobuf/v2/internal/pb"
 )
 
 func TestProtobufFormatWithoutProtobufCodec(t *testing.T) {
@@ -41,4 +42,47 @@ func TestProtobufFormatWithoutProtobufCodec(t *testing.T) {
 	var e2 event.Event
 	require.NoError(format.Protobuf.Unmarshal(b, &e2))
 	require.Equal(e, e2)
+}
+
+func TestProtobufFormatWithProtobufCodec(t *testing.T) {
+	require := require.New(t)
+	const test = "test"
+	e := event.New()
+	e.SetID(test)
+	e.SetTime(stdtime.Date(2021, 1, 1, 1, 1, 1, 1, stdtime.UTC))
+	e.SetExtension(test, test)
+	e.SetExtension("int", 1)
+	e.SetExtension("bool", true)
+	e.SetExtension("URI", &url.URL{
+		Host: "test-uri",
+	})
+	e.SetExtension("URIRef", types.URIRef{URL: url.URL{
+		Host: "test-uriref",
+	}})
+	e.SetExtension("bytes", []byte(test))
+	e.SetExtension("timestamp", stdtime.Date(2021, 2, 1, 1, 1, 1, 1, stdtime.UTC))
+	e.SetSubject(test)
+	e.SetSource(test)
+	e.SetType(test)
+	e.SetDataSchema(test)
+
+	// Using the CloudEventAttributeValue because it is convenient and is an
+	// independent protobuf message. Any protobuf message would work but this
+	// one is already generated and included in the source.
+	payload := &pb.CloudEventAttributeValue{
+		Attr: &pb.CloudEventAttributeValue_CeBoolean{
+			CeBoolean: true,
+		},
+	}
+	require.NoError(e.SetData(format.ContentTypeProtobuf, payload))
+
+	b, err := format.Protobuf.Marshal(&e)
+	require.NoError(err)
+	var e2 event.Event
+	require.NoError(format.Protobuf.Unmarshal(b, &e2))
+	require.Equal(e, e2)
+
+	payload2 := &pb.CloudEventAttributeValue{}
+	require.NoError(e2.DataAs(payload2))
+	require.True(payload2.GetCeBoolean())
 }


### PR DESCRIPTION
* Add protobuf datacodec

This adds the ability to send and receive protobuf encoded data within
the envelope.

Signed-off-by: Kevin Conway <kevinconway@invisionapp.com>

* Move pb.Any handling to protobuf format

This refactors the original protobuf datacodec so that it is generally
useful as a codec within other formats. Previously, the coded wrapped
and unwrapped every value in an Any container because this is required
when the protobuf codec and format are used together. Now, the format
handles wrapping the protobuf encoded binary data in the Any type.

Signed-off-by: Kevin Conway <kevinconway@invisionapp.com>

* Add init to register protobuf codec

Signed-off-by: Kevin Conway <kevinconway@invisionapp.com>