### PR TITLE
Fix nil time assertions for go 1.17

### DIFF
--- a/v2/types/value_test.go
+++ b/v2/types/value_test.go
@@ -241,8 +241,8 @@ func TestTime(t *testing.T) {
 
 	x.err(nil, "invalid CloudEvents value: <nil>")
 	x.err(5, "cannot convert 5 to time.Time")
-	x.err((*time.Time)(nil), "invalid CloudEvents value: (*time.Time)(nil)")
-	x.err((*types.Timestamp)(nil), "invalid CloudEvents value: (*types.Timestamp)(nil)")
+	x.err((*time.Time)(nil), fmt.Sprintf("invalid CloudEvents value: %#v", (*time.Time)(nil)))
+	x.err((*types.Timestamp)(nil), fmt.Sprintf("invalid CloudEvents value: %#v", (*types.Timestamp)(nil)))
 	x.err("not a time", "parsing time \"not a time\" as \"2006-01-02T15:04:05.999999999Z07:00\": cannot parse \"not a time\" as \"2006\"")
 }
 


### PR DESCRIPTION
https://pkg.go.dev/time#Time.GoString added in Go 1.17 means this error string will be different depending on which version we are on.

/assign @n3wscott @embano1

Fixes #721