### PR TITLE
HTTP Protocol: add RequestData in Context option.

### DIFF
--- a/v2/protocol/http/context.go
+++ b/v2/protocol/http/context.go
@@ -1,0 +1,48 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"context"
+
+	nethttp "net/http"
+	"net/url"
+)
+
+type requestKey struct{}
+
+// RequestData holds the http.Request information subset that can be
+// used to retrieve HTTP information for an incoming CloudEvent.
+type RequestData struct {
+	URL        *url.URL
+	Header     nethttp.Header
+	RemoteAddr string
+	Host       string
+}
+
+// WithRequestDataAtContext uses the http.Request to add RequestData
+//  information to the Context.
+func WithRequestDataAtContext(ctx context.Context, r *nethttp.Request) context.Context {
+	if r == nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, requestKey{}, &RequestData{
+		URL:        r.URL,
+		Header:     r.Header,
+		RemoteAddr: r.RemoteAddr,
+		Host:       r.Host,
+	})
+}
+
+// RequestDataFromContext retrieves RequestData from the Context.
+// If not set nil is returned.
+func RequestDataFromContext(ctx context.Context) *RequestData {
+	if req := ctx.Value(requestKey{}); req != nil {
+		return req.(*RequestData)
+	}
+	return nil
+}

--- a/v2/protocol/http/context_test.go
+++ b/v2/protocol/http/context_test.go
@@ -1,0 +1,126 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"context"
+	nethttp "net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	tMethod = nethttp.MethodPost
+)
+
+func TestWithRequest(t *testing.T) {
+	testCases := map[string]struct {
+		request *nethttp.Request
+
+		expectedRequest *RequestData
+	}{
+		"request": {
+			request: newRequest("http://testhost:8080/test/path.json"),
+			expectedRequest: &RequestData{
+				Host:   "testhost:8080",
+				URL:    newURL("http://testhost:8080/test/path.json"),
+				Header: nethttp.Header{},
+			},
+		},
+		"request with headers": {
+			request: newRequest("http://testhost:8080/test/path.json",
+				requestOptionAddHeader("key1", "value1"),
+				requestOptionAddHeader("key2", "value2.1"),
+				requestOptionAddHeader("key2", "value2.2"),
+			),
+			expectedRequest: &RequestData{
+				Host: "testhost:8080",
+				URL:  newURL("http://testhost:8080/test/path.json"),
+				Header: nethttp.Header{
+					"Key1": []string{"value1"},
+					"Key2": []string{"value2.1", "value2.2"},
+				},
+			},
+		},
+		"request with host header": {
+			request: newRequest("http://testhost:8080/test/path.json",
+				requestOptionHostHeader("alternative.host"),
+			),
+			expectedRequest: &RequestData{
+				Host:   "alternative.host",
+				URL:    newURL("http://testhost:8080/test/path.json"),
+				Header: nethttp.Header{},
+			},
+		},
+		"request with remote address": {
+			request: newRequest("http://testhost:8080/test/path.json",
+				requestOptionRemoteAddr("requester.address"),
+			),
+			expectedRequest: &RequestData{
+				Host:       "testhost:8080",
+				URL:        newURL("http://testhost:8080/test/path.json"),
+				Header:     nethttp.Header{},
+				RemoteAddr: "requester.address",
+			},
+		},
+		"nil request": {
+			request:         nil,
+			expectedRequest: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := WithRequestDataAtContext(context.TODO(), tc.request)
+
+			req := RequestDataFromContext(ctx)
+			assert.Equal(t, req, tc.expectedRequest)
+		})
+	}
+}
+
+type requestOption func(*nethttp.Request)
+
+func newRequest(url string, opts ...requestOption) *nethttp.Request {
+	r, err := nethttp.NewRequest(tMethod, url, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+func requestOptionAddHeader(key, value string) requestOption {
+	return func(r *nethttp.Request) {
+		r.Header.Add(key, value)
+	}
+}
+
+func requestOptionHostHeader(host string) requestOption {
+	return func(r *nethttp.Request) {
+		r.Host = host
+	}
+}
+
+func requestOptionRemoteAddr(addr string) requestOption {
+	return func(r *nethttp.Request) {
+		r.RemoteAddr = addr
+	}
+}
+
+func newURL(u string) *url.URL {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}

--- a/v2/protocol/http/options.go
+++ b/v2/protocol/http/options.go
@@ -287,3 +287,15 @@ func WithRateLimiter(rl RateLimiter) Option {
 		return nil
 	}
 }
+
+// WithRequestDataAtContextMiddleware adds to the Context RequestData.
+// This enables a user's dispatch handler to inspect HTTP request information by
+// retrieving it from the Context.
+func WithRequestDataAtContextMiddleware() Option {
+	return WithMiddleware(func(next nethttp.Handler) nethttp.Handler {
+		return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			ctx := WithRequestDataAtContext(r.Context(), r)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+}


### PR DESCRIPTION
Closes https://github.com/cloudevents/sdk-go/issues/742

@n3wscott this is not implemented exactly as described in the issue.

> The way I would do this is I would make a context helper in the cloudevents http package, make a new struct with these fields, copy them over before leaving the serve http method into the context using the helper context method.

Instead of adding it at the [ServeHTTP](https://github.com/cloudevents/sdk-go/blob/77f73c28a5a032a26ce0c344addc3ef4b14d60ac/v2/protocol/http/protocol.go#L285) method this PR leverages the http.Options, so this feature is an opt-in.

My main concern is that requests will hit the middleware prior to the `RateLimiter` which feels like the wrong order, but that's the case for all middlewares here. I don't consider that an issue in this PR and if we were to improve the pattern I would suggest moving the `RateLimiting` feature also as an option (in a different PR).
