### PR TITLE
Adding workaround to an overflow error in CE SQL parser

### DIFF
--- a/sql/v2/README.md
+++ b/sql/v2/README.md
@@ -25,3 +25,8 @@ To regenerate the parser, make sure you have [ANTLR4 installed](https://github.c
 ```shell
 antlr4 -Dlanguage=Go -package gen -o gen -visitor -no-listener CESQLParser.g4
 ```
+
+Then you need to run this sed command as a workaround until this ANTLR [issue](https://github.com/antlr/antlr4/issues/2433) is resolved. Without this, building for 32bit platforms will throw an int overflow error: 
+```shell
+sed -i 's/(1<</(int64(1)<</g' gen/cesqlparser_parser.go
+```

--- a/sql/v2/gen/cesqlparser_parser.go
+++ b/sql/v2/gen/cesqlparser_parser.go
@@ -1098,7 +1098,7 @@ func (p *CESQLParserParser) expression(_p int) (localctx IExpressionContext) {
 					p.SetState(41)
 					_la = p.GetTokenStream().LA(1)
 
-					if !(((_la)&-(0x1f+1)) == 0 && ((1<<uint(_la))&((1<<CESQLParserParserSTAR)|(1<<CESQLParserParserDIVIDE)|(1<<CESQLParserParserMODULE))) != 0) {
+					if !(((_la)&-(0x1f+1)) == 0 && ((int64(1)<<uint(_la))&((int64(1)<<CESQLParserParserSTAR)|(int64(1)<<CESQLParserParserDIVIDE)|(int64(1)<<CESQLParserParserMODULE))) != 0) {
 						p.GetErrorHandler().RecoverInline(p)
 					} else {
 						p.GetErrorHandler().ReportMatch(p)
@@ -1146,7 +1146,7 @@ func (p *CESQLParserParser) expression(_p int) (localctx IExpressionContext) {
 					p.SetState(47)
 					_la = p.GetTokenStream().LA(1)
 
-					if !(((_la)&-(0x1f+1)) == 0 && ((1<<uint(_la))&((1<<CESQLParserParserEQUAL)|(1<<CESQLParserParserNOT_EQUAL)|(1<<CESQLParserParserGREATER)|(1<<CESQLParserParserGREATER_OR_EQUAL)|(1<<CESQLParserParserLESS)|(1<<CESQLParserParserLESS_GREATER)|(1<<CESQLParserParserLESS_OR_EQUAL))) != 0) {
+					if !(((_la)&-(0x1f+1)) == 0 && ((int64(1)<<uint(_la))&((int64(1)<<CESQLParserParserEQUAL)|(int64(1)<<CESQLParserParserNOT_EQUAL)|(int64(1)<<CESQLParserParserGREATER)|(int64(1)<<CESQLParserParserGREATER_OR_EQUAL)|(int64(1)<<CESQLParserParserLESS)|(int64(1)<<CESQLParserParserLESS_GREATER)|(int64(1)<<CESQLParserParserLESS_OR_EQUAL))) != 0) {
 						p.GetErrorHandler().RecoverInline(p)
 					} else {
 						p.GetErrorHandler().ReportMatch(p)
@@ -1170,7 +1170,7 @@ func (p *CESQLParserParser) expression(_p int) (localctx IExpressionContext) {
 					p.SetState(50)
 					_la = p.GetTokenStream().LA(1)
 
-					if !(((_la)&-(0x1f+1)) == 0 && ((1<<uint(_la))&((1<<CESQLParserParserAND)|(1<<CESQLParserParserOR)|(1<<CESQLParserParserXOR))) != 0) {
+					if !(((_la)&-(0x1f+1)) == 0 && ((int64(1)<<uint(_la))&((int64(1)<<CESQLParserParserAND)|(int64(1)<<CESQLParserParserOR)|(int64(1)<<CESQLParserParserXOR))) != 0) {
 						p.GetErrorHandler().RecoverInline(p)
 					} else {
 						p.GetErrorHandler().ReportMatch(p)
@@ -2132,7 +2132,7 @@ func (p *CESQLParserParser) FunctionParameterList() (localctx IFunctionParameter
 	p.GetErrorHandler().Sync(p)
 	_la = p.GetTokenStream().LA(1)
 
-	if ((_la-2)&-(0x1f+1)) == 0 && ((1<<uint((_la-2)))&((1<<(CESQLParserParserLR_BRACKET-2))|(1<<(CESQLParserParserNOT-2))|(1<<(CESQLParserParserMINUS-2))|(1<<(CESQLParserParserEXISTS-2))|(1<<(CESQLParserParserTRUE-2))|(1<<(CESQLParserParserFALSE-2))|(1<<(CESQLParserParserDQUOTED_STRING_LITERAL-2))|(1<<(CESQLParserParserSQUOTED_STRING_LITERAL-2))|(1<<(CESQLParserParserINTEGER_LITERAL-2))|(1<<(CESQLParserParserIDENTIFIER-2))|(1<<(CESQLParserParserIDENTIFIER_WITH_NUMBER-2))|(1<<(CESQLParserParserFUNCTION_IDENTIFIER_WITH_UNDERSCORE-2)))) != 0 {
+	if ((_la-2)&-(0x1f+1)) == 0 && ((int64(1)<<uint((_la-2)))&((int64(1)<<(CESQLParserParserLR_BRACKET-2))|(int64(1)<<(CESQLParserParserNOT-2))|(int64(1)<<(CESQLParserParserMINUS-2))|(int64(1)<<(CESQLParserParserEXISTS-2))|(int64(1)<<(CESQLParserParserTRUE-2))|(int64(1)<<(CESQLParserParserFALSE-2))|(int64(1)<<(CESQLParserParserDQUOTED_STRING_LITERAL-2))|(int64(1)<<(CESQLParserParserSQUOTED_STRING_LITERAL-2))|(int64(1)<<(CESQLParserParserINTEGER_LITERAL-2))|(int64(1)<<(CESQLParserParserIDENTIFIER-2))|(int64(1)<<(CESQLParserParserIDENTIFIER_WITH_NUMBER-2))|(int64(1)<<(CESQLParserParserFUNCTION_IDENTIFIER_WITH_UNDERSCORE-2)))) != 0 {
 		{
 			p.SetState(86)
 			p.expression(0)

--- a/sql/v2/go.mod
+++ b/sql/v2/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudevents/sdk-go/sql/v2
 go 1.14
 
 require (
-	github.com/antlr/antlr4 v0.0.0-20210105192202-5c2b686f95e1
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211221011931-643d94fcab96
 	github.com/cloudevents/sdk-go/v2 v2.5.0
 	github.com/stretchr/testify v1.5.1
 	sigs.k8s.io/yaml v1.2.0

--- a/sql/v2/go.sum
+++ b/sql/v2/go.sum
@@ -1,5 +1,5 @@
-github.com/antlr/antlr4 v0.0.0-20210105192202-5c2b686f95e1 h1:9K5yytxEEQc4yIn6c1rvQD6qQilQn9mYIF7pXKPT8i4=
-github.com/antlr/antlr4 v0.0.0-20210105192202-5c2b686f95e1/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211221011931-643d94fcab96 h1:2P/dm3KbCLnRHQN/Ma50elhMx1Si9loEZe5hOrsuvuE=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211221011931-643d94fcab96/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -38,6 +38,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### Description
Current CE SQL generated ANTLR parser throws an int overflow error on 32bit platforms, there's an open issue antlr/antlr4#2433 for it.

This PR modifies the generated parser as a workaround and adds instructions with a sed command in the development README section until the ANTLR go target gets fixed.