### PR TITLE
feat(client): Add option to make receive callback blocking

### DIFF
--- a/test/integration/http/blocking_test.go
+++ b/test/integration/http/blocking_test.go
@@ -45,6 +45,7 @@ type BlockingSenderReceiverTestOutput struct {
 type BlockingSenderReceiverTestCases map[string]BlockingSenderReceiverTest
 
 func TestNonBlockingSenderReceiver(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 
 	testCases := BlockingSenderReceiverTestCases{
@@ -103,6 +104,7 @@ func TestNonBlockingSenderReceiver(t *testing.T) {
 }
 
 func TestBlockingSenderReceiver(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 
 	testCases := BlockingSenderReceiverTestCases{

--- a/test/integration/http/blocking_test.go
+++ b/test/integration/http/blocking_test.go
@@ -8,10 +8,11 @@ package http
 import (
 	"context"
 	"fmt"
-	"go.uber.org/atomic"
 	"sync"
 	"testing"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/cloudevents/sdk-go/v2/client"
 
@@ -32,12 +33,18 @@ type BlockingSenderReceiverTest struct {
 	now          time.Time
 	event        *cloudevents.Event
 	receiverWait time.Duration
+	timeout      time.Duration
 	want         int
+}
+
+type BlockingSenderReceiverTestOutput struct {
+	duration time.Duration
+	got      int
 }
 
 type BlockingSenderReceiverTestCases map[string]BlockingSenderReceiverTest
 
-func TestBlockingSenderReceiver(t *testing.T) {
+func TestNonBlockingSenderReceiver(t *testing.T) {
 	now := time.Now()
 
 	testCases := BlockingSenderReceiverTestCases{
@@ -54,6 +61,7 @@ func TestBlockingSenderReceiver(t *testing.T) {
 			},
 			receiverWait: 1 * time.Second,
 			want:         10,
+			timeout:      5 * time.Second,
 		},
 		"50 at 5 second": {
 			now: now,
@@ -68,6 +76,7 @@ func TestBlockingSenderReceiver(t *testing.T) {
 			},
 			receiverWait: 5 * time.Second,
 			want:         50,
+			timeout:      15 * time.Second,
 		},
 		"100 at 10 seconds": {
 			now: now,
@@ -82,6 +91,65 @@ func TestBlockingSenderReceiver(t *testing.T) {
 			},
 			receiverWait: 10 * time.Second,
 			want:         100,
+			timeout:      30 * time.Second,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			ReceiverNonBlocking(t, tc)
+		})
+	}
+}
+
+func TestBlockingSenderReceiver(t *testing.T) {
+	now := time.Now()
+
+	testCases := BlockingSenderReceiverTestCases{
+		"10 at 100 milisecond": {
+			now: now,
+			event: &cloudevents.Event{
+				Context: cloudevents.EventContextV1{
+					Type:            "unit.test.client.sent.10.1",
+					Source:          *cloudevents.ParseURIRef("/unit/test/client"),
+					Subject:         strptr("resource"),
+					DataContentType: cloudevents.StringOfApplicationJSON(),
+				}.AsV1(),
+				DataEncoded: toBytes(map[string]interface{}{"hello": "unittest"}),
+			},
+			receiverWait: 100 * time.Millisecond,
+			want:         10,
+			timeout:      5 * time.Second,
+		},
+		"50 at 20 milisecond": {
+			now: now,
+			event: &cloudevents.Event{
+				Context: cloudevents.EventContextV1{
+					Type:            "unit.test.client.sent.50.5",
+					Source:          *cloudevents.ParseURIRef("/unit/test/client"),
+					Subject:         strptr("resource"),
+					DataContentType: cloudevents.StringOfApplicationJSON(),
+				}.AsV1(),
+				DataEncoded: toBytes(map[string]interface{}{"hello": "unittest"}),
+			},
+			receiverWait: 20 * time.Millisecond,
+			want:         50,
+			timeout:      5 * time.Second,
+		},
+		"100 at 10 milisecond": {
+			now: now,
+			event: &cloudevents.Event{
+				Context: cloudevents.EventContextV1{
+					Type:            "unit.test.client.sent.100.10",
+					Source:          *cloudevents.ParseURIRef("/unit/test/client"),
+					Subject:         strptr("resource"),
+					DataContentType: cloudevents.StringOfApplicationJSON(),
+				}.AsV1(),
+				DataEncoded: toBytes(map[string]interface{}{"hello": "unittest"}),
+			},
+			receiverWait: 10 * time.Millisecond,
+			want:         100,
+			timeout:      5 * time.Second,
 		},
 	}
 
@@ -94,7 +162,37 @@ func TestBlockingSenderReceiver(t *testing.T) {
 
 const verbose = false
 
-func ReceiverBlocking(t *testing.T, tc BlockingSenderReceiverTest, copts ...client.Option) {
+func ReceiverNonBlocking(t *testing.T, tc BlockingSenderReceiverTest) {
+	output := receive(t, tc, client.WithPollGoroutines(1))
+
+	if tc.want != output.got {
+		t.Errorf("expected %d, got %d", tc.want, output)
+	}
+
+	// Look at how long the test took.
+	dm := output.duration.Milliseconds()
+	tw := tc.receiverWait.Milliseconds() * 110 / 100 // 110% budget.
+	if dm > tw {
+		t.Errorf("expected test duration to be around ~%d ms, actual %d ms", tc.receiverWait.Milliseconds(), dm)
+	}
+}
+
+func ReceiverBlocking(t *testing.T, tc BlockingSenderReceiverTest) {
+	output := receive(t, tc, client.WithPollGoroutines(1), client.WithBlockingCallback())
+
+	if tc.want != output.got {
+		t.Errorf("expected %d, got %d", tc.want, output)
+	}
+
+	// Look at how long the test took.
+	dm := output.duration.Milliseconds()
+	tw := tc.receiverWait.Milliseconds() * int64(tc.want) // no concurrent processing
+	if dm < tw {
+		t.Errorf("expected test duration to be over %d ms, actual %d ms", tw, dm)
+	}
+}
+
+func receive(t *testing.T, tc BlockingSenderReceiverTest, copts ...client.Option) *BlockingSenderReceiverTestOutput {
 	opts := make([]cehttp.Option, 0)
 	opts = append(opts, cloudevents.WithPort(0)) // random port
 
@@ -113,7 +211,7 @@ func ReceiverBlocking(t *testing.T, tc BlockingSenderReceiverTest, copts ...clie
 	testID := uuid.New().String()
 	tc.event.SetExtension(unitTestIDKey, testID)
 
-	recvCtx, recvCancel := context.WithTimeout(context.Background(), tc.receiverWait*3)
+	recvCtx, recvCancel := context.WithTimeout(context.Background(), tc.timeout)
 	defer recvCancel()
 
 	wg := new(sync.WaitGroup)
@@ -141,7 +239,7 @@ func ReceiverBlocking(t *testing.T, tc BlockingSenderReceiverTest, copts ...clie
 
 	then := time.Now()
 
-	sendCtx, sendCancel := context.WithTimeout(context.Background(), tc.receiverWait*2)
+	sendCtx, sendCancel := context.WithTimeout(context.Background(), tc.timeout)
 	defer sendCancel()
 	sendCtx = cloudevents.ContextWithTarget(sendCtx, fmt.Sprintf("http://localhost:%d", protocol.GetListeningPort()))
 
@@ -159,16 +257,8 @@ func ReceiverBlocking(t *testing.T, tc BlockingSenderReceiverTest, copts ...clie
 
 	time.Sleep(tc.receiverWait) // cool off just in case we have some more sleepers.
 
-	if int32(tc.want) != got.Load() {
-		t.Errorf("expected %d, got %d", tc.want, got.Load())
-	}
-
-	// Look at how long the test took.
-
-	dm := duration.Milliseconds()
-	tw := tc.receiverWait.Milliseconds() * 110 / 100 // 110% budget.
-
-	if dm > tw {
-		t.Errorf("expected test duration to be ~%d ms, actual %d ms", tc.receiverWait.Milliseconds(), dm)
+	return &BlockingSenderReceiverTestOutput{
+		duration: duration,
+		got:      int(got.Load()),
 	}
 }

--- a/v2/client/options.go
+++ b/v2/client/options.go
@@ -8,6 +8,7 @@ package client
 import (
 	"context"
 	"fmt"
+
 	"github.com/cloudevents/sdk-go/v2/binding"
 )
 
@@ -109,6 +110,18 @@ func WithInboundContextDecorator(dec func(context.Context, binding.Message) cont
 	return func(i interface{}) error {
 		if c, ok := i.(*ceClient); ok {
 			c.inboundContextDecorators = append(c.inboundContextDecorators, dec)
+		}
+		return nil
+	}
+}
+
+// WithBlockingCallback makes the callback passed into StartReceiver is executed as a blocking call,
+// i.e. in each poll go routine, the next event will not be received until the callback on current event completes.
+// To make event processing serialized (no concurrency), use this option along with WithPollGoroutines(1)
+func WithBlockingCallback() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			c.blockingCallback = true
 		}
 		return nil
 	}


### PR DESCRIPTION
Addresses https://github.com/cloudevents/sdk-go/issues/770 

- Add an option for the callback on receiver to be blocking or nonblocking
- Updated `blocking_test` to ensure when `pollRoutines` is `1` AND it's blocking, the events are processed in serialized manner.

### Manual Testing

Run the example receiver code: https://gist.github.com/liu-cong/a132fe8629715419c7a58ee20001d071
It retrieves the Ce-Sleep attribute from the event and sleep for that period of time.

Then send a few events to the receiver using curl, 
```shell
curl -v localhost:8080
  -X POST \
  -H "Ce-Sleep: 20s" \
  -H "Ce-Id: 1" \
  -H "Ce-Specversion: 1.0" \
  -H "Ce-Type: type" \
  -H "Ce-Source: source" \
  -H "Content-Type: application/json" \
  -d '{"msg":"Test!"}
```

#### Without `blockingCallback` flag

`cloudevents.NewClient(p, client.WithPollGoroutines(1))`

Sent 3 events, finish at the same time

<img width="628" alt="image" src="https://user-images.githubusercontent.com/60989824/167281355-062763bd-07c9-4c01-a78e-1f30ab91cdcb.png">

#### With `blockingCallback` flag

`cloudevents.NewClient(p, client.WithBlockingCallback(), client.WithPollGoroutines(1))`

<img width="427" alt="image" src="https://user-images.githubusercontent.com/60989824/167281404-2063e030-fbda-4325-a8e3-6b2a2cf5c1ed.png">

Finished one after another


Signed-off-by: James Yu <jyu@confluent.io>