### PR TITLE
Reset request body on retry

### DIFF
--- a/v2/protocol/http/protocol_retry.go
+++ b/v2/protocol/http/protocol_retry.go
@@ -6,8 +6,11 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -53,6 +56,24 @@ func (p *Protocol) doWithRetry(ctx context.Context, params *cecontext.RetryParam
 	retry := 0
 	results := make([]protocol.Result, 0)
 
+	var (
+		body []byte
+		err  error
+	)
+
+	if req != nil && req.Body != nil {
+		defer func() {
+			if err = req.Body.Close(); err != nil {
+				cecontext.LoggerFrom(ctx).Warnw("could not close request body", zap.Error(err))
+			}
+		}()
+		body, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			panic(err)
+		}
+		resetBody(req, body)
+	}
+
 	for {
 		msg, result := p.doOnce(req)
 
@@ -90,6 +111,8 @@ func (p *Protocol) doWithRetry(ctx context.Context, params *cecontext.RetryParam
 		}
 
 	DoBackoff:
+		resetBody(req, body)
+
 		// Wait for the correct amount of backoff time.
 
 		// total tries = retry + 1
@@ -101,5 +124,22 @@ func (p *Protocol) doWithRetry(ctx context.Context, params *cecontext.RetryParam
 
 		retry++
 		results = append(results, result)
+	}
+}
+
+// reset body to allow it to be read multiple times, e.g. when retrying http
+// requests
+func resetBody(req *http.Request, body []byte) {
+	if req == nil || req.Body == nil {
+		return
+	}
+
+	req.Body = ioutil.NopCloser(bytes.NewReader(body))
+
+	// do not modify existing GetBody function
+	if req.GetBody == nil {
+		req.GetBody = func() (io.ReadCloser, error) {
+			return ioutil.NopCloser(bytes.NewReader(body)), nil
+		}
 	}
 }


### PR DESCRIPTION
Fixes a bug where requests with a body (event) are not always retried due to the underlying `net/http` throwing `*url.Error` because of body and content-length mismatch (body is empty and not reset upon retry). See #773 for details.

The tests did not catch this as they were not doing behaving as a real HTTP server (just mocking `RoundTripper`) and also not carrying an event body (which would not trigger this behavior). 

- [x] Changed retry tests to use a network connection and HTTP (test) server
- [x] Reset body (if not `nil`) during retries
- [x] Set `GetBody` func only if it is not already set (the sdk already does this currently)

Closes: #773
Signed-off-by: Michael Gasch <mgasch@vmware.com>