### PR TITLE
fix golangci-lint-action

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Go Lint on ./v2
         if: steps.golangci_configuration.outputs.files_exists == 'true'
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.29
           working-directory: v2


### PR DESCRIPTION
Error message:
```
level=error msg="Running error: buildir: failed to load package goarch: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool"
```

Upgrade `golangci-lint-action` to v3 https://github.com/golangci/golangci-lint-action/issues/434

Signed-off-by: Iñigo Horcajo <inigohu@gmail.com>