### PR TITLE
add unordered, unknown datacontenttype test and errors to v2/event

### DIFF
--- a/v2/event/event_unmarshal.go
+++ b/v2/event/event_unmarshal.go
@@ -370,6 +370,9 @@ func consumeDataAsBytes(e *Event, isBase64 bool, b []byte) error {
 		iter := jsoniter.ParseBytes(jsoniter.ConfigFastest, b)
 		src := iter.ReadString() // handles escaping
 		e.DataEncoded = []byte(src)
+		if iter.Error != nil {
+			return fmt.Errorf("unexpected data payload for media type %q, expected a string: %w", mt, iter.Error)
+		}
 		return nil
 	}
 
@@ -397,6 +400,9 @@ func consumeData(e *Event, isBase64 bool, iter *jsoniter.Iterator) error {
 		// If not json, then data is encoded as string
 		src := iter.ReadString() // handles escaping
 		e.DataEncoded = []byte(src)
+		if iter.Error != nil {
+			return fmt.Errorf("unexpected data payload for media type %q, expected a string: %w", mt, iter.Error)
+		}
 		return nil
 	}
 

--- a/v2/event/event_unmarshal_test.go
+++ b/v2/event/event_unmarshal_test.go
@@ -8,6 +8,7 @@ package event_test
 import (
 	"encoding/base64"
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"net/url"
 	"strings"
 	"testing"
@@ -1018,6 +1019,48 @@ func TestUnmarshalWithOrderingError(t *testing.T) {
 
 			require.Error(t, err)
 		})
+	}
+}
+
+func TestCloudEventUnmarshalling_invalidOrdering(t *testing.T) {
+	// Order should not matter.
+	{
+		structuredEventWithDataAfterDataContentType := `{
+			"specversion": "1.0",
+			"datacontenttype": "application",
+			"id": "test123",
+			"source": "/test/source",
+			"type": "test.event.type",
+			"time": "2021-07-21T01:00:59.365Z",
+			"data": {
+				"test": "test"
+			}
+		}`
+
+		e := &event.Event{}
+		err := e.UnmarshalJSON([]byte(structuredEventWithDataAfterDataContentType))
+		t.Logf("err1, %v", err)
+		assert.NotNil(t, err)
+		assert.Empty(t, e.Data())
+	}
+	{
+		structuredEventWithDataBeforeDataContentType := `{
+			"specversion": "1.0",
+			"data": {
+				"test": "test"
+			},
+			"datacontenttype": "application",
+			"id": "test123",
+			"source": "/test/source",
+			"type": "test.event.type",
+			"time": "2021-07-21T01:00:59.365Z"
+		}`
+
+		e := &event.Event{}
+		err := e.UnmarshalJSON([]byte(structuredEventWithDataBeforeDataContentType))
+		t.Logf("err2, %v", err)
+		assert.NotNil(t, err)
+		assert.Empty(t, e.Data())
 	}
 }
 


### PR DESCRIPTION
fixes: https://github.com/cloudevents/sdk-go/issues/782

Signed-off-by: Scott Nichols <n3wscott@chainguard.dev>