### PR TITLE
Helper function to create event from HTTP Request or Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ func main() {
 }
 ```
 
+## Create a CloudEvent from an HTTP Request
+
+```go
+func handler(w http.ResponseWriter, r *http.Request) {
+	event, err := cloudevents.NewCloudEventFromHttpRequest(r)
+	if err != nil {
+		log.Print("failed to parse CloudEvent from request: %v", err)
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+	}
+	w.Write([]byte(*event.String()))
+}
+```
+
 ## Serialize/Deserialize a CloudEvent
 
 To marshal a CloudEvent into JSON:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ func main() {
 
 ```go
 func handler(w http.ResponseWriter, r *http.Request) {
-	event, err := cloudevents.NewCloudEventFromHttpRequest(r)
+	event, err := cloudevents.NewCloudEventFromHTTPRequest(r)
 	if err != nil {
 		log.Print("failed to parse CloudEvent from request: %v", err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,19 @@ func main() {
 }
 ```
 
+## Create a CloudEvent from an HTTP Request
+
+```go
+func handler(w http.ResponseWriter, r *http.Request) {
+	event, err := cloudevents.NewCloudEventFromHttpRequest(r)
+	if err != nil {
+		log.Print("failed to parse CloudEvent from request: %v", err)
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+	}
+	w.Write([]byte(*event.String()))
+}
+```
+
 ## Serialize/Deserialize a CloudEvent
 
 To marshal a CloudEvent into JSON:

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ func main() {
 
 ```go
 func handler(w http.ResponseWriter, r *http.Request) {
-	event, err := cloudevents.NewCloudEventFromHttpRequest(r)
+	event, err := cloudevents.NewCloudEventFromHTTPRequest(r)
 	if err != nil {
 		log.Print("failed to parse CloudEvent from request: %v", err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)

--- a/v2/alias.go
+++ b/v2/alias.go
@@ -134,6 +134,10 @@ var (
 
 	ToMessage = binding.ToMessage
 
+	// Event Creation
+	NewEventFromHttpRequest  = http.NewEventFromHttpRequest
+	NewEventFromHttpResponse = http.NewEventFromHttpResponse
+
 	// HTTP Messages
 
 	WriteHTTPRequest = http.WriteRequest

--- a/v2/alias.go
+++ b/v2/alias.go
@@ -135,8 +135,8 @@ var (
 	ToMessage = binding.ToMessage
 
 	// Event Creation
-	NewEventFromHttpRequest  = http.NewEventFromHttpRequest
-	NewEventFromHttpResponse = http.NewEventFromHttpResponse
+	NewEventFromHTTPRequest  = http.NewEventFromHTTPRequest
+	NewEventFromHTTPResponse = http.NewEventFromHTTPResponse
 
 	// HTTP Messages
 

--- a/v2/protocol/http/utility.go
+++ b/v2/protocol/http/utility.go
@@ -14,7 +14,7 @@ import (
 )
 
 // NewEventFromHttpRequest returns an Event.
-func NewEventFromHttpRequest(req *nethttp.Request) (*event.Event, error) {
+func NewEventFromHTTPRequest(req *nethttp.Request) (*event.Event, error) {
 	msg := NewMessageFromHttpRequest(req)
 	return binding.ToEvent(context.Background(), msg, nil)
 }

--- a/v2/protocol/http/utility.go
+++ b/v2/protocol/http/utility.go
@@ -13,19 +13,14 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event"
 )
 
-// NewEventFromHttpRequest returns an Event.
+// NewEventFromHTTPRequest returns an Event.
 func NewEventFromHTTPRequest(req *nethttp.Request) (*event.Event, error) {
 	msg := NewMessageFromHttpRequest(req)
 	return binding.ToEvent(context.Background(), msg)
 }
 
-// NewEventFromHttpResponse returns an Event.
+// NewEventFromHTTPResponse returns an Event.
 func NewEventFromHTTPResponse(resp *nethttp.Response) (*event.Event, error) {
-	msg := NewMessageFromHTTPResponse(resp)
-	return binding.ToEvent(context.Background(), msg, nil)
+	msg := NewMessageFromHttpResponse(resp)
+	return binding.ToEvent(context.Background(), msg)
 }
-
-// Write tests
-// Add to pkg docs
-// Add to SDK site
-// Move code to preferred home.

--- a/v2/protocol/http/utility.go
+++ b/v2/protocol/http/utility.go
@@ -21,7 +21,7 @@ func NewEventFromHTTPRequest(req *nethttp.Request) (*event.Event, error) {
 
 // NewEventFromHttpResponse returns an Event.
 func NewEventFromHTTPResponse(resp *nethttp.Response) (*event.Event, error) {
-	msg := NewMessageFromHttpResponse(resp)
+	msg := NewMessageFromHTTPResponse(resp)
 	return binding.ToEvent(context.Background(), msg, nil)
 }
 

--- a/v2/protocol/http/utility.go
+++ b/v2/protocol/http/utility.go
@@ -1,0 +1,31 @@
+/*
+ Copyright 2022 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"context"
+	nethttp "net/http"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+// NewEventFromHttpRequest returns an Event.
+func NewEventFromHttpRequest(req *nethttp.Request) (*event.Event, error) {
+	msg := NewMessageFromHttpRequest(req)
+	return binding.ToEvent(context.Background(), msg, nil)
+}
+
+// NewEventFromHttpResponse returns an Event.
+func NewEventFromHttpResponse(resp *nethttp.Response) (*event.Event, error) {
+	msg := NewMessageFromHttpResponse(resp)
+	return binding.ToEvent(context.Background(), msg, nil)
+}
+
+// Write tests
+// Add to pkg docs
+// Add to SDK site
+// Move code to preferred home.

--- a/v2/protocol/http/utility.go
+++ b/v2/protocol/http/utility.go
@@ -20,7 +20,7 @@ func NewEventFromHTTPRequest(req *nethttp.Request) (*event.Event, error) {
 }
 
 // NewEventFromHttpResponse returns an Event.
-func NewEventFromHttpResponse(resp *nethttp.Response) (*event.Event, error) {
+func NewEventFromHTTPResponse(resp *nethttp.Response) (*event.Event, error) {
 	msg := NewMessageFromHttpResponse(resp)
 	return binding.ToEvent(context.Background(), msg, nil)
 }

--- a/v2/protocol/http/utility.go
+++ b/v2/protocol/http/utility.go
@@ -16,7 +16,7 @@ import (
 // NewEventFromHttpRequest returns an Event.
 func NewEventFromHTTPRequest(req *nethttp.Request) (*event.Event, error) {
 	msg := NewMessageFromHttpRequest(req)
-	return binding.ToEvent(context.Background(), msg, nil)
+	return binding.ToEvent(context.Background(), msg)
 }
 
 // NewEventFromHttpResponse returns an Event.

--- a/v2/protocol/http/utility_test.go
+++ b/v2/protocol/http/utility_test.go
@@ -35,11 +35,16 @@ func TestNewEventFromHttpRequest(t *testing.T) {
 	for _, tt := range tests {
 		test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
 			t.Run(tt.name, func(t *testing.T) {
-				ctx := context.Background()
+				ctx := context.TODO()
+				if tt.encoding == binding.EncodingStructured {
+					ctx = binding.WithForceStructured(ctx)
+				} else if tt.encoding == binding.EncodingBinary {
+					ctx = binding.WithForceBinary(ctx)
+				}
+
 				req := httptest.NewRequest("POST", "http://localhost", nil)
 				require.NoError(t, WriteRequest(ctx, (*binding.EventMessage)(&eventIn), req))
 
-				NewEventFromHttpRequest(req)
 				got, err := NewEventFromHttpRequest(req)
 				require.NoError(t, err)
 				// Equals fails with diff like:

--- a/v2/protocol/http/utility_test.go
+++ b/v2/protocol/http/utility_test.go
@@ -1,0 +1,92 @@
+/*
+ Copyright 2022 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/test"
+)
+
+func TestNewEventFromHttpRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		encoding binding.Encoding
+	}{{
+		name:     "Structured encoding",
+		encoding: binding.EncodingStructured,
+	}, {
+		name:     "Binary encoding",
+		encoding: binding.EncodingBinary,
+	}}
+
+	for _, tt := range tests {
+		test.EachEvent(t, test.Events(), func(t *testing.T, eventIn event.Event) {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := context.Background()
+				req := httptest.NewRequest("POST", "http://localhost", nil)
+				require.NoError(t, WriteRequest(ctx, (*binding.EventMessage)(&eventIn), req))
+
+				NewEventFromHttpRequest(req)
+				got, err := NewEventFromHttpRequest(req)
+				require.NoError(t, err)
+				// Equals fails with diff like:
+				// - 	"exbinary": []uint8{0x00, 0x01, 0x02, 0x03},
+				// + 	"exbinary": string("AAECAw=="),
+				// - 	"exint":    int32(42),
+				// + 	"exint":    string("42"),
+				// test.AssertEventEquals(t, eventIn, *got)
+				test.AssertEvent(t, *got, test.IsValid())
+			})
+		})
+	}
+}
+
+func TestNewEventFromHttpResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *http.Response
+	}{{
+		name: "Structured encoding",
+		resp: &http.Response{
+			Header: http.Header{
+				"Content-Type": {event.ApplicationCloudEventsJSON},
+			},
+			Body:          ioutil.NopCloser(bytes.NewReader([]byte(`{"data":"foo","datacontenttype":"application/json","id":"id","source":"source","specversion":"1.0","type":"type"}`))),
+			ContentLength: 113,
+		},
+	}, {
+		name: "Binary encoding",
+		resp: &http.Response{
+			Header: func() http.Header {
+				h := http.Header{}
+				h.Set("ce-specversion", "1.0")
+				h.Set("ce-source", "unittest")
+				h.Set("ce-type", "unittest")
+				h.Set("ce-id", "unittest")
+				h.Set("Content-Type", "application/json")
+				return h
+			}(),
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewEventFromHttpResponse(tt.resp)
+			require.NoError(t, err)
+			test.AssertEvent(t, *got, test.IsValid())
+		})
+	}
+}

--- a/v2/protocol/http/utility_test.go
+++ b/v2/protocol/http/utility_test.go
@@ -45,14 +45,8 @@ func TestNewEventFromHttpRequest(t *testing.T) {
 				req := httptest.NewRequest("POST", "http://localhost", nil)
 				require.NoError(t, WriteRequest(ctx, (*binding.EventMessage)(&eventIn), req))
 
-				got, err := NewEventFromHttpRequest(req)
+				got, err := NewEventFromHTTPRequest(req)
 				require.NoError(t, err)
-				// Equals fails with diff like:
-				// - 	"exbinary": []uint8{0x00, 0x01, 0x02, 0x03},
-				// + 	"exbinary": string("AAECAw=="),
-				// - 	"exint":    int32(42),
-				// + 	"exint":    string("42"),
-				// test.AssertEventEquals(t, eventIn, *got)
 				test.AssertEvent(t, *got, test.IsValid())
 			})
 		})
@@ -89,7 +83,7 @@ func TestNewEventFromHttpResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewEventFromHttpResponse(tt.resp)
+			got, err := NewEventFromHTTPResponse(tt.resp)
 			require.NoError(t, err)
 			test.AssertEvent(t, *got, test.IsValid())
 		})


### PR DESCRIPTION
Fixes #766 

This PR provides two new functions: NewEventFromHttpRequest and NewEventFromHttpResponse. Both are added to v2/alias.go, and NewEventFromHttpRequest is also demonstrated in the README and docs.

I included HttpResponse because I saw the Message methods covered it. I included docs updates because I've visited the README and docs multiple times looking for this function. Happy to remove either if they are considered unnecessary or out of scope.

Creating this PR as a draft because the test coverage I've created routinely segfaults when it begins executing the transformation logic at:

https://github.com/cloudevents/sdk-go/blob/c623f8bfd7c3d7206f0aec5730460d137e3f42a8/v2/binding/to_event.go#L61

Here is an example of how this looks on my machine:

```text
go test -v -run TestNewEventFromHttpRequest
=== RUN   TestNewEventFromHttpRequest
=== RUN   TestNewEventFromHttpRequest/Event{"specversion":"1.0","id":"full-event-0","source":"http://example.com/source","type":"com.example.FullEvent","subject":"topic","datacontenttype":"text/json","dataschema":"http://example.com/schema","time":"2020-03-21T12:34:56.78Z","data":"hello","exurl":"http://example.com/source","extime":"2020-03-21T12:34:56.78Z","exbool":true,"exint":42,"exstring":"exstring","exbinary":"AAECAw=="}
=== RUN   TestNewEventFromHttpRequest/Event{"specversion":"1.0","id":"full-event-0","source":"http://example.com/source","type":"com.example.FullEvent","subject":"topic","datacontenttype":"text/json","dataschema":"http://example.com/schema","time":"2020-03-21T12:34:56.78Z","data":"hello","exurl":"http://example.com/source","extime":"2020-03-21T12:34:56.78Z","exbool":true,"exint":42,"exstring":"exstring","exbinary":"AAECAw=="}/Structured_encoding
--- FAIL: TestNewEventFromHttpRequest (0.00s)
    --- FAIL: TestNewEventFromHttpRequest/Event{"specversion":"1.0","id":"full-event-0","source":"http://example.com/source","type":"com.example.FullEvent","subject":"topic","datacontenttype":"text/json","dataschema":"http://example.com/schema","time":"2020-03-21T12:34:56.78Z","data":"hello","exurl":"http://example.com/source","extime":"2020-03-21T12:34:56.78Z","exbool":true,"exint":42,"exstring":"exstring","exbinary":"AAECAw=="} (0.00s)
        --- FAIL: TestNewEventFromHttpRequest/Event{"specversion":"1.0","id":"full-event-0","source":"http://example.com/source","type":"com.example.FullEvent","subject":"topic","datacontenttype":"text/json","dataschema":"http://example.com/schema","time":"2020-03-21T12:34:56.78Z","data":"hello","exurl":"http://example.com/source","extime":"2020-03-21T12:34:56.78Z","exbool":true,"exint":42,"exstring":"exstring","exbinary":"AAECAw=="}/Structured_encoding (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x141d695]

goroutine 6 [running]:
testing.tRunner.func1.2({0x151cfe0, 0x1982990})
	/Users/clipped/opt/go/libexec/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/Users/clipped/opt/go/libexec/src/testing/testing.go:1392 +0x39f
panic({0x151cfe0, 0x1982990})
	/Users/clipped/opt/go/libexec/src/runtime/panic.go:838 +0x207
github.com/cloudevents/sdk-go/v2/binding.Transformers.Transform(...)
	/Users/clipped/prototypes/snowpea-golang/sdk-go/v2/binding/transformer.go:34
github.com/cloudevents/sdk-go/v2/binding.ToEvent({0xc0000ec100?, 0x1466716?}, {0x1671030, 0xc0000207d0?}, {0xc00006ae78, 0x1, 0x0?})
	/Users/clipped/prototypes/snowpea-golang/sdk-go/v2/binding/to_event.go:65 +0x215
github.com/cloudevents/sdk-go/v2/protocol/http.NewEventFromHttpRequest(0x16707a0?)
	/Users/clipped/prototypes/snowpea-golang/sdk-go/v2/protocol/http/utility.go:19 +0x50
github.com/cloudevents/sdk-go/v2/protocol/http.TestNewEventFromHttpRequest.func1.1(0x0?)
	/Users/clipped/prototypes/snowpea-golang/sdk-go/v2/protocol/http/utility_test.go:42 +0xc6
testing.tRunner(0xc0002b81a0, 0xc0002ae1d0)
	/Users/clipped/opt/go/libexec/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/Users/clipped/opt/go/libexec/src/testing/testing.go:1486 +0x35f
exit status 2
```