### PR TITLE
Use the correct method name in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ func main() {
 
 ```go
 func handler(w http.ResponseWriter, r *http.Request) {
-	event, err := cloudevents.NewCloudEventFromHTTPRequest(r)
+	event, err := cloudevents.NewEventFromHTTPRequest(r)
 	if err != nil {
 		log.Print("failed to parse CloudEvent from request: %v", err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)


### PR DESCRIPTION
Method name should be `NewEventFromHTTPRequest` not `NewCloudEventFromHTTPRequest`. 