### PR TITLE
Modify doc NewCloudEventFromHTTPRequest -> NewEventFromHTTPRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ func main() {
 
 ```go
 func handler(w http.ResponseWriter, r *http.Request) {
-	event, err := cloudevents.NewCloudEventFromHTTPRequest(r)
+	event, err := cloudevents.NewEventFromHTTPRequest(r)
 	if err != nil {
 		log.Print("failed to parse CloudEvent from request: %v", err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ func main() {
 
 ```go
 func handler(w http.ResponseWriter, r *http.Request) {
-	event, err := cloudevents.NewCloudEventFromHTTPRequest(r)
+	event, err := cloudevents.NewEventFromHTTPRequest(r)
 	if err != nil {
 		log.Print("failed to parse CloudEvent from request: %v", err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)


### PR DESCRIPTION
#835

[This pull request](https://github.com/cloudevents/sdk-go/pull/799/files) has a difference between the document and the implementation.

The document defines it as NewCloudEventFromHTTPRequest, but it is actually NewEventFromHTTPRequet.