### PR TITLE
Publish a PubSub message WithAttributes

### DIFF
--- a/protocol/pubsub/v2/protocol.go
+++ b/protocol/pubsub/v2/protocol.go
@@ -119,6 +119,10 @@ func (t *Protocol) Send(ctx context.Context, in binding.Message, transformers ..
 		msg.OrderingKey = key
 	}
 
+	if attributes, ok := ctx.Value(withAttributesKey{}).(map[string]string); ok {
+		msg.Attributes = attributes
+	}
+
 	if err := WritePubSubMessage(ctx, in, msg, transformers...); err != nil {
 		return err
 	}
@@ -238,4 +242,11 @@ type withOrderingKey struct{}
 // WithOrderingKey allows to set the Pub/Sub ordering key for publishing events.
 func WithOrderingKey(ctx context.Context, key string) context.Context {
 	return context.WithValue(ctx, withOrderingKey{}, key)
+}
+
+type withAttributesKey struct{}
+
+// WithAttributes allows to set the key-value pairs the Pub/Sub is labelled with for publishing events.
+func WithAttributes(ctx context.Context, attributes map[string]string) context.Context {
+	return context.WithValue(ctx, withAttributesKey{}, attributes)
 }

--- a/protocol/pubsub/v2/write_pubsub_message.go
+++ b/protocol/pubsub/v2/write_pubsub_message.go
@@ -46,7 +46,9 @@ func (b *pubsubMessagePublisher) SetStructuredEvent(ctx context.Context, f forma
 }
 
 func (b *pubsubMessagePublisher) Start(ctx context.Context) error {
-	b.Attributes = make(map[string]string)
+	if b.Attributes == nil {
+		b.Attributes = make(map[string]string)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is a complement to #737, so it's possible to publish a PubSub message `WithAttributes` that the filter then can be applied to. Otherwise we have to abuse the extension feature + filter on these attributes with the ”ce-”-prefix which feels like a hack. 