### PR TITLE
Add possibility to add a single header field dynamically

### DIFF
--- a/v2/protocol/http/headers.go
+++ b/v2/protocol/http/headers.go
@@ -7,11 +7,12 @@ package http
 
 import (
 	"context"
-	"github.com/cloudevents/sdk-go/v2/binding"
 	"net/http"
 	"net/textproto"
 	"strings"
 	"unicode"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
 
 	"github.com/cloudevents/sdk-go/v2/binding/spec"
 )
@@ -52,4 +53,10 @@ func HeaderFrom(ctx context.Context) http.Header {
 
 func WithCustomHeader(ctx context.Context, header http.Header) context.Context {
 	return context.WithValue(ctx, headerKey, header)
+}
+
+func WithCustomHeaderField(ctx context.Context, name string, value string) context.Context {
+	headers := HeaderFrom(ctx)
+	headers.Set(name, value)
+	return WithCustomHeader(ctx, headers)
 }

--- a/v2/protocol/http/headers_test.go
+++ b/v2/protocol/http/headers_test.go
@@ -44,3 +44,51 @@ func TestHeaderFrom(t *testing.T) {
 		})
 	}
 }
+
+func TestWithCustomHeaderField(t *testing.T) {
+	type args struct {
+		ctx   context.Context
+		name  string
+		value string
+	}
+	tests := []struct {
+		name string
+		args args
+		want http.Header
+	}{
+		{
+			name: "no headers in context before",
+			args: args{
+				ctx:   context.TODO(),
+				name:  "Header",
+				value: "value",
+			},
+			want: map[string][]string{
+				"Header": {"value"},
+			},
+		},
+		{
+			name: "headers in context before",
+			args: args{
+				ctx: WithCustomHeader(context.TODO(), map[string][]string{
+					"Header": {"value"},
+				}),
+				name:  "Header-2",
+				value: "value-2",
+			},
+			want: map[string][]string{
+				"Header":   {"value"},
+				"Header-2": {"value-2"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithCustomHeaderField(tt.args.ctx, tt.args.name, tt.args.value)
+			got := HeaderFrom(ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WithCustomHeaderField() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently there is no direct option to add a single header to the context on a "per-request" basis. To add for example a Header before we send a cloud event, we have to do the following:

```
headers := http.HeaderFrom(ctx)
headers.Set("Foo", "bar")
ctx = http.WithCustomHeader(ctx, headers)

client.Send(ctx, ....)
```

This PR addresses it, and adds the possibility to add a single header, so we end up with the following:
```
http.WithCustomHeaderField(ctx, "Foo", "bar")
client.Send(ctx, ....)
```

**Hints for reviewers**
* We have already the possibility to add a single header, when we create the client (`WithHeader()` option). However it would be good to have something more fine grained, which can be set on a "per-request" basis