### PR TITLE
Convert ECONNRESET error to a normal close to avoid an endless loop in the go routine

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -210,7 +210,7 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 		return fmt.Errorf("mismatched receiver callback without protocol.Receiver supported by protocol")
 	}
 	if invoker.IsResponder() && c.responder == nil {
-		return fmt.Errorf("mismatched receiver callback without protocol.Responder supported by protocol")
+		return fmt.Errorf("mismatched responder callback without protocol.Responder supported by protocol")
 	}
 	c.invoker = invoker
 
@@ -243,7 +243,6 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 				if err == io.EOF { // Normal close
 					return
 				}
-
 				if err != nil {
 					cecontext.LoggerFrom(ctx).Warn("Error while receiving a message: ", err)
 					continue


### PR DESCRIPTION
This PR is intended to fix an issue we observed on our lab setup where:
    When the connection was reset by a peer the receiver got stuck in this go routine:
    https://github.com/cloudevents/sdk-go/blob/ff0a142752d3253c3b974246c07f450421714f23/v2/client/client.go#L229
    and our logs were flooded by the this warning log..
    https://github.com/cloudevents/sdk-go/blob/ff0a142752d3253c3b974246c07f450421714f23/v2/client/client.go#L248
    
   To get around this per @duglin's suggestion we are converting the `connection reset` error in the respond function to a normal close `EOF` so the go routine would exit normally.