### PR TITLE
http: Fixes for Gin http receiver sample

### DIFF
--- a/samples/http/receiver-gin/README.md
+++ b/samples/http/receiver-gin/README.md
@@ -8,8 +8,7 @@ An example of a Gin webframework CloudEvents receiver with a [TektonEvent](https
 Get dependencies
 ```shell
 cd samples/
- go get github.com/gin-gonic/gin
- go get github.com/rs/zerolog/log
+ go get
 
 ```
 
@@ -18,11 +17,11 @@ Run the app
  go run main.go
 ```
 
-Test a CloudEvent
+Send a CloudEvent
 ```shell
 curl -v \
  -H "Ce-Id: e7d95c20-6eb4-4614-946d-27b0ce41c7ff" \
- -H "Ce-Source: /apis///namespaces/dimitar//clone-build-n4qhgl" \
+ -H "Ce-Source: /apis/namespaces/dimitar/clone-build-n4qhgl" \
  -H "Ce-Subject: clone-build-n4qhgl"  \
  -H "Ce-Specversion: 1.0" \
  -H "Ce-Type: dev.tekton.event.pipelinerun.started.v1" \
@@ -39,7 +38,7 @@ Logs output
 Got an Event: Context Attributes,
   specversion: 1.0
   type: dev.tekton.event.pipelinerun.started.v1
-  source: /apis///namespaces/dimitar//clone-build-n4qhgl
+  source: /apis/namespaces/dimitar/clone-build-n4qhgl
   subject: clone-build-n4qhgl
   id: e7d95c20-6eb4-4614-946d-27b0ce41c7ff
   datacontenttype: application/json

--- a/samples/http/receiver-gin/main.go
+++ b/samples/http/receiver-gin/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func receiveTektonEvent(event cloudevents.Event) {
+func receive(event cloudevents.Event) {
 	fmt.Printf("Got an Event: %s", event)
 }
 
@@ -23,7 +23,6 @@ func healthz(c *gin.Context) {
 }
 
 func cloudEventsHandler() gin.HandlerFunc {
-
 	return func(c *gin.Context) {
 		p, err := cloudevents.NewHTTP()
 		if err != nil {
@@ -32,7 +31,7 @@ func cloudEventsHandler() gin.HandlerFunc {
 				Msg("Failed to create protocol")
 		}
 
-		ceh, err := cloudevents.NewHTTPReceiveHandler(c, p, receiveTektonEvent)
+		ceh, err := cloudevents.NewHTTPReceiveHandler(c, p, receive)
 		if err != nil {
 			log.Fatal().
 				Err(err).
@@ -44,7 +43,6 @@ func cloudEventsHandler() gin.HandlerFunc {
 }
 
 func main() {
-
 	r := gin.Default()
 	r.SetTrustedProxies(nil)
 


### PR DESCRIPTION
Fixes for prematurely closed #842 PR. Applied all suggested code and doc changes.

It is worth mentioning the code and instructions come from a real use case of processing Tekton events:
https://tekton.dev/docs/pipelines/events/