### PR TITLE
Support ACK when receiving malformed events

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -98,6 +98,7 @@ type ceClient struct {
 	eventDefaulterFns         []EventDefaulter
 	pollGoroutines            int
 	blockingCallback          bool
+	ackMalformedEvent         bool
 }
 
 func (c *ceClient) applyOptions(opts ...Option) error {
@@ -202,7 +203,13 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 		return fmt.Errorf("client already has a receiver")
 	}
 
-	invoker, err := newReceiveInvoker(fn, c.observabilityService, c.inboundContextDecorators, c.eventDefaulterFns...)
+	invoker, err := newReceiveInvoker(
+		fn,
+		c.observabilityService,
+		c.inboundContextDecorators,
+		c.eventDefaulterFns,
+		c.ackMalformedEvent,
+	)
 	if err != nil {
 		return err
 	}

--- a/v2/client/http_receiver.go
+++ b/v2/client/http_receiver.go
@@ -14,7 +14,7 @@ import (
 )
 
 func NewHTTPReceiveHandler(ctx context.Context, p *thttp.Protocol, fn interface{}) (*EventReceiver, error) {
-	invoker, err := newReceiveInvoker(fn, noopObservabilityService{}, nil) //TODO(slinkydeveloper) maybe not nil?
+	invoker, err := newReceiveInvoker(fn, noopObservabilityService{}, nil, nil, false) //TODO(slinkydeveloper) maybe not nil?
 	if err != nil {
 		return nil, err
 	}

--- a/v2/client/options.go
+++ b/v2/client/options.go
@@ -126,3 +126,16 @@ func WithBlockingCallback() Option {
 		return nil
 	}
 }
+
+// WithAckMalformedevents causes malformed events received within StartReceiver to be acknowledged
+// rather than being permanently not-acknowledged. This can be useful when a protocol does not
+// provide a responder implementation and would otherwise cause the receiver to be partially or
+// fully stuck.
+func WithAckMalformedEvent() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			c.ackMalformedEvent = true
+		}
+		return nil
+	}
+}

--- a/v2/client/options_test.go
+++ b/v2/client/options_test.go
@@ -136,3 +136,31 @@ func TestWith_Defaulters(t *testing.T) {
 		})
 	}
 }
+
+func TestWithAckMalformedEvent(t *testing.T) {
+	testCases := []struct {
+		name     string
+		opts     []Option
+		expected bool
+	}{
+		{
+			name: "unset",
+		},
+		{
+			name:     "set",
+			opts:     []Option{WithAckMalformedEvent()},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &ceClient{}
+			client.applyOptions(tc.opts...)
+
+			if client.ackMalformedEvent != tc.expected {
+				t.Errorf("unexpected ackMalformedEvent; want: %t; got: %t", tc.expected, client.ackMalformedEvent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
My team faced much the same issue as outlined in #757; malformed events are sent to a Kafka topic and clients endlessly fail to read the event. While this is hard to induce when the sender uses the Go CloudEvents SDK, there are a good amount of Python clients across our services which unfortunately lack validation that might prevent this.

I've elected to make this behaviour configurable via client options, as suggested in #757. This would be appropriate to use when no `protocol.Responder` implementation is available, as is the case with the `kafka_sarama` module. I explored wrapping the existing `protocol.Receiver` implementation to allow it to behave like `protocol.Responder`, but that ended up being a lot of code compared to the light touch that could be applied here.