### PR TITLE
Clean up the previous user properties from MQTT protocol  

### DIFF
--- a/protocol/mqtt_paho/v2/protocol.go
+++ b/protocol/mqtt_paho/v2/protocol.go
@@ -90,7 +90,6 @@ func (p *Protocol) Send(ctx context.Context, m binding.Message, transformers ...
 	defer m.Finish(err)
 
 	msg := p.publishOption
-	msg.Properties.User = make(paho.UserProperties, 0)
 	if cecontext.TopicFrom(ctx) != "" {
 		msg.Topic = cecontext.TopicFrom(ctx)
 		cecontext.WithTopic(ctx, "")

--- a/protocol/mqtt_paho/v2/protocol.go
+++ b/protocol/mqtt_paho/v2/protocol.go
@@ -90,6 +90,7 @@ func (p *Protocol) Send(ctx context.Context, m binding.Message, transformers ...
 	defer m.Finish(err)
 
 	msg := p.publishOption
+	msg.Properties.User = make(paho.UserProperties, 0)
 	if cecontext.TopicFrom(ctx) != "" {
 		msg.Topic = cecontext.TopicFrom(ctx)
 		cecontext.WithTopic(ctx, "")

--- a/protocol/mqtt_paho/v2/write_message.go
+++ b/protocol/mqtt_paho/v2/write_message.go
@@ -58,10 +58,10 @@ func (b *pubMessageWriter) SetStructuredEvent(ctx context.Context, f format.Form
 
 func (b *pubMessageWriter) Start(ctx context.Context) error {
 	if b.Properties == nil {
-		b.Properties = &paho.PublishProperties{
-			User: make([]paho.UserProperty, 0),
-		}
+		b.Properties = &paho.PublishProperties{}
 	}
+	// the UserProperties of publish message is used to load event extensions
+	b.Properties.User = make([]paho.UserProperty, 0)
 	return nil
 }
 


### PR DESCRIPTION
Since we use the MQTT `Properties.User` to load the extension of the cloudevents. It can't contain the previous extension. 