### PR TITLE
kafka pkg changed to shopify

### DIFF
--- a/samples/kafka/message-handle-non-cloudevents/main.go
+++ b/samples/kafka/message-handle-non-cloudevents/main.go
@@ -11,9 +11,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/IBM/sarama"
-	"github.com/google/uuid"
-
+	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"

--- a/samples/kafka/receiver/main.go
+++ b/samples/kafka/receiver/main.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/IBM/sarama"
+	"github.com/Shopify/sarama"
 
 	"github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"

--- a/samples/kafka/sender-receiver/main.go
+++ b/samples/kafka/sender-receiver/main.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"sync/atomic"
 
-	"github.com/IBM/sarama"
+	"github.com/Shopify/sarama"
 
 	"github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"

--- a/samples/kafka/sender/main.go
+++ b/samples/kafka/sender/main.go
@@ -9,9 +9,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/IBM/sarama"
-	"github.com/google/uuid"
-
+	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )


### PR DESCRIPTION
fix: samples kafka  sarama pkg type errors


```
import (
	"context"
	"fmt"
	"log"

	"github.com/IBM/sarama"

	"github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
	cloudevents "github.com/cloudevents/sdk-go/v2"
)

func main() {
	saramaConfig := sarama.NewConfig()
	saramaConfig.Version = sarama.V2_0_0_0

	receiver, err := kafka_sarama.NewConsumer([]string{"127.0.0.1:9092"}, saramaConfig, "test-group-id", "test-topic")
```