### PR TITLE
Allow Context to Configure Default Timeout

### DIFF
--- a/v2/protocol/http/options.go
+++ b/v2/protocol/http/options.go
@@ -83,6 +83,38 @@ func WithShutdownTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithReadTimeout overwrites the default read timeout (600s) of the http
+// server. The specified timeout must not be negative. A timeout of 0 disables
+// read timeouts in the http server.
+func WithReadTimeout(timeout time.Duration) Option {
+	return func(p *Protocol) error {
+		if p == nil {
+			return fmt.Errorf("http read timeout option can not set nil protocol")
+		}
+		if timeout < 0 {
+			return fmt.Errorf("http read timeout must not be negative")
+		}
+		p.readTimeout = &timeout
+		return nil
+	}
+}
+
+// WithWriteTimeout overwrites the default write timeout (600s) of the http
+// server. The specified timeout must not be negative. A timeout of 0 disables
+// write timeouts in the http server.
+func WithWriteTimeout(timeout time.Duration) Option {
+	return func(p *Protocol) error {
+		if p == nil {
+			return fmt.Errorf("http write timeout option can not set nil protocol")
+		}
+		if timeout < 0 {
+			return fmt.Errorf("http write timeout must not be negative")
+		}
+		p.writeTimeout = &timeout
+		return nil
+	}
+}
+
 func checkListen(p *Protocol, prefix string) error {
 	switch {
 	case p.listener.Load() != nil:

--- a/v2/protocol/http/protocol.go
+++ b/v2/protocol/http/protocol.go
@@ -70,6 +70,18 @@ type Protocol struct {
 	// If 0, DefaultShutdownTimeout is used.
 	ShutdownTimeout time.Duration
 
+	// readTimeout defines the http.Server ReadTimeout It is the maximum duration
+	// for reading the entire request, including the body. If not overwritten by an
+	// option, the default value (600s) is used
+	readTimeout *time.Duration
+
+	// writeTimeout defines the http.Server WriteTimeout It is the maximum duration
+	// before timing out writes of the response. It is reset whenever a new
+	// request's header is read. Like ReadTimeout, it does not let Handlers make
+	// decisions on a per-request basis. If not overwritten by an option, the
+	// default value (600s) is used
+	writeTimeout *time.Duration
+
 	// Port is the port configured to bind the receiver to. Defaults to 8080.
 	// If you want to know the effective port you're listening to, use GetListeningPort()
 	Port int
@@ -114,6 +126,17 @@ func New(opts ...Option) (*Protocol, error) {
 
 	if p.ShutdownTimeout == 0 {
 		p.ShutdownTimeout = DefaultShutdownTimeout
+	}
+
+	// use default timeout from abuse protection value
+	defaultTimeout := DefaultTimeout
+
+	if p.readTimeout == nil {
+		p.readTimeout = &defaultTimeout
+	}
+
+	if p.writeTimeout == nil {
+		p.writeTimeout = &defaultTimeout
 	}
 
 	if p.isRetriableFunc == nil {

--- a/v2/protocol/http/protocol_lifecycle.go
+++ b/v2/protocol/http/protocol_lifecycle.go
@@ -40,8 +40,8 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 	p.server = &http.Server{
 		Addr:         listener.Addr().String(),
 		Handler:      attachMiddleware(p.Handler, p.middleware),
-		ReadTimeout:  DefaultTimeout,
-		WriteTimeout: DefaultTimeout,
+		ReadTimeout:  *p.readTimeout,
+		WriteTimeout: *p.writeTimeout,
 	}
 
 	// Shutdown

--- a/v2/protocol/http/protocol_test.go
+++ b/v2/protocol/http/protocol_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestNew(t *testing.T) {
 	dst := DefaultShutdownTimeout
+	ot := DefaultTimeout
 
 	testCases := map[string]struct {
 		opts    []Option
@@ -36,6 +37,8 @@ func TestNew(t *testing.T) {
 			want: &Protocol{
 				Client:          http.DefaultClient,
 				ShutdownTimeout: dst,
+				readTimeout:     &ot,
+				writeTimeout:    &ot,
 				Port:            -1,
 			},
 		},


### PR DESCRIPTION
Adds options to the `Protocol` to set the `Read` and `Write` on the HTTP Client Handler for Cloud Events.

Resolves Issue: https://github.com/cloudevents/sdk-go/issues/1041