### PR TITLE
Fixed incorrect log method in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
-	log.Fatal(c.StartReceiver(context.Background(), receive));
+	if err = c.StartReceiver(context.Background(), receive); err != nil {
+		log.Fatalf("failed to start receiver: %v", err)
+	}
 }
 ```
 


### PR DESCRIPTION
`log.Fatal` is mistakenly used in the following example (in the README file) which should be actually `Println` 

    func main() {
	    // The default client is HTTP.
	    c, err := cloudevents.NewClientHTTP()
	    if err != nil {
		    log.Fatalf("failed to create client, %v", err)
	    }
	    log.Fatal(c.StartReceiver(context.Background(), receive));
    } 

