### PR TITLE
Replace time.Time.String() with time.Time.Format()

### DIFF
--- a/test/integration/http/direct_v1_test.go
+++ b/test/integration/http/direct_v1_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/cloudevents/sdk-go/v2/types"
 )
 
 func TestSenderReceiver_binary_v1(t *testing.T) {
@@ -101,7 +100,6 @@ func TestSenderReceiver_binary_v1(t *testing.T) {
 
 func TestSenderReceiver_structured_v1(t *testing.T) {
 	now := time.Now()
-
 	testCases := DirectTapTestCases{
 		"Structured v1.0": {
 			now: now,
@@ -131,7 +129,7 @@ func TestSenderReceiver_structured_v1(t *testing.T) {
 				Header: map[string][]string{
 					"content-type": {"application/cloudevents+json"},
 				},
-				Body:          fmt.Sprintf(`{"data":{"hello":"unittest"},"id":"ABC-123","source":"/unit/test/client","specversion":"1.0","subject":"resource","time":%q,"type":"unit.test.client.sent"}`, types.FormatTime(now.UTC())),
+				Body:          fmt.Sprintf(`{"data":{"hello":"unittest"},"id":"ABC-123","source":"/unit/test/client","specversion":"1.0","subject":"resource","time":%q,"type":"unit.test.client.sent"}`, now.Format(time.RFC3339)),
 				ContentLength: 182,
 			},
 		},
@@ -177,7 +175,7 @@ func TestSenderReceiver_data_base64_v1(t *testing.T) {
 				Header: map[string][]string{
 					"content-type": {"application/cloudevents+json"},
 				},
-				Body:          fmt.Sprintf(`{"data_base64":"aGVsbG86IHVuaXR0ZXN0","id":"ABC-123","source":"/unit/test/client","specversion":"1.0","subject":"resource","time":%q,"type":"unit.test.client.sent"}`, now.UTC().Format(time.RFC3339Nano)),
+				Body:          fmt.Sprintf(`{"data_base64":"aGVsbG86IHVuaXR0ZXN0","id":"ABC-123","source":"/unit/test/client","specversion":"1.0","subject":"resource","time":%q,"type":"unit.test.client.sent"}`, now.Format(time.RFC3339)),
 				ContentLength: 191,
 			},
 		},

--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 )
@@ -77,7 +78,7 @@ func WriteJson(in *Event, writer io.Writer) error {
 		if eventContext.Time != nil {
 			stream.WriteMore()
 			stream.WriteObjectField("time")
-			stream.WriteString(eventContext.Time.String())
+			stream.WriteString(eventContext.Time.Format(time.RFC3339Nano))
 		}
 	case *EventContextV1:
 		// Set a bunch of variables we need later
@@ -121,7 +122,7 @@ func WriteJson(in *Event, writer io.Writer) error {
 		if eventContext.Time != nil {
 			stream.WriteMore()
 			stream.WriteObjectField("time")
-			stream.WriteString(eventContext.Time.String())
+			stream.WriteString(eventContext.Time.Format(time.RFC3339Nano))
 		}
 	default:
 		return fmt.Errorf("missing event context")


### PR DESCRIPTION
Resolves #987 
Earlier, we used time.Time.String() to marshal time into a string. According to the go time.Time documentation however, time.Time.String() is only suitable for debugging purposes. This PR replaces time.Time.String with time.Time.Format() with RFC3339 to provide a stable serialized representation of time. 


