### PR TITLE
fix: LIKE expression with invalid string literals returns a parse error instead of panicking

### DIFF
--- a/sql/v2/parser/expression_visitor.go
+++ b/sql/v2/parser/expression_visitor.go
@@ -6,6 +6,7 @@
 package parser
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -175,9 +176,13 @@ func (v *expressionVisitor) VisitLikeExpression(ctx *gen.LikeExpressionContext) 
 	if patternContext.DQUOTED_STRING_LITERAL() != nil {
 		// Parse double quoted string
 		pattern = dQuotedStringToString(patternContext.DQUOTED_STRING_LITERAL().GetText())
-	} else {
+	} else if patternContext.SQUOTED_STRING_LITERAL() != nil {
 		// Parse single quoted string
 		pattern = sQuotedStringToString(patternContext.SQUOTED_STRING_LITERAL().GetText())
+	} else {
+		// not a string, return an error
+		v.parsingErrors = append(v.parsingErrors, fmt.Errorf("failed to parse LIKE expression: the pattern was not a string literal"))
+		return noopExpression{}
 	}
 
 	likeExpression, err := expression.NewLikeExpression(v.Visit(ctx.Expression()).(cesql.Expression), pattern)

--- a/sql/v2/test/tck/like_expression.yaml
+++ b/sql/v2/test/tck/like_expression.yaml
@@ -115,4 +115,11 @@ tests:
     result: false
   - name: With type coercion from bool (4)
     expression: "FALSE LIKE 'fal%'"
-    result: true 
+    result: true
+
+  - name: Invalid string literal in comparison causes parse error
+    expression: "x LIKE 123"
+    result: false
+    error: parse
+    eventOverrides:
+      x: "123"


### PR DESCRIPTION
Fixes #931 

When visiting the nodes of the AST while parsing the LIKE expression, it looks like we assumed that we would have a valid string literal. However, it is possible that there is no valid string literal, in which case we have to handle that and return an error rather than continuing to parse (and subsequently panicking)