### PR TITLE
fix: pubsub ack must rely on protocol.IsAck

### DIFF
--- a/protocol/pubsub/v2/message.go
+++ b/protocol/pubsub/v2/message.go
@@ -126,9 +126,8 @@ func (m *Message) GetExtension(name string) interface{} {
 func (m *Message) Finish(err error) error {
 	if protocol.IsACK(err) {
 		m.internal.Ack()
-		return nil
+	} else {
+		m.internal.Nack()
 	}
-
-	m.internal.Nack()
 	return err
 }

--- a/protocol/pubsub/v2/message.go
+++ b/protocol/pubsub/v2/message.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/binding/format"
 	"github.com/cloudevents/sdk-go/v2/binding/spec"
+	"github.com/cloudevents/sdk-go/v2/protocol"
 )
 
 const (
@@ -120,14 +121,14 @@ func (m *Message) GetExtension(name string) interface{} {
 }
 
 // Finish marks the message to be forgotten.
-// If err is nil, the underlying Pubsub message will be acked;
-// otherwise nacked and return the error.
+// Regarding protocol.IsAck, the Pubsub message will be acked or not.
+// If not acked, the original error will be returned.
 func (m *Message) Finish(err error) error {
-	if err != nil {
-		m.internal.Nack()
-		return err
+	if protocol.IsACK(err) {
+		m.internal.Ack()
+		return nil
 	}
 
-	m.internal.Ack()
-	return nil
+	m.internal.Nack()
+	return err
 }

--- a/protocol/pubsub/v2/message.go
+++ b/protocol/pubsub/v2/message.go
@@ -120,9 +120,8 @@ func (m *Message) GetExtension(name string) interface{} {
 	return m.internal.Attributes[prefix+name]
 }
 
-// Finish marks the message to be forgotten.
-// Regarding protocol.IsAck, the Pubsub message will be acked or not.
-// If not acked, the original error will be returned.
+// Finish marks the message to be forgotten and returns the provided error without modification.
+// If err is nil or of type protocol.ResultACK the PubSub message will be acknowledged, otherwise nack-ed.
 func (m *Message) Finish(err error) error {
 	if protocol.IsACK(err) {
 		m.internal.Ack()

--- a/protocol/pubsub/v2/message_test.go
+++ b/protocol/pubsub/v2/message_test.go
@@ -13,6 +13,7 @@ import (
 	"cloud.google.com/go/pubsub"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/protocol"
 )
 
 func TestReadStructured(t *testing.T) {
@@ -61,6 +62,22 @@ func TestFinish(t *testing.T) {
 			},
 			err:     fmt.Errorf("error"),
 			wantErr: true,
+		},
+		{
+			name: "result not acked",
+			pm: &pubsub.Message{
+				ID: "testid",
+			},
+			err:     protocol.NewReceipt(false, "error"),
+			wantErr: true,
+		},
+		{
+			name: "result acked",
+			pm: &pubsub.Message{
+				ID: "testid",
+			},
+			err:     protocol.NewReceipt(true, "error"),
+			wantErr: false,
 		},
 		{
 			name: "no errors",

--- a/protocol/pubsub/v2/message_test.go
+++ b/protocol/pubsub/v2/message_test.go
@@ -77,7 +77,7 @@ func TestFinish(t *testing.T) {
 				ID: "testid",
 			},
 			err:     protocol.NewReceipt(true, "error"),
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "no errors",

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -47,6 +47,13 @@ type Client interface {
 	// * func(event.Event) (*event.Event, protocol.Result)
 	// * func(context.Context, event.Event) *event.Event
 	// * func(context.Context, event.Event) (*event.Event, protocol.Result)
+	// Details about the "fn" function returned values:
+	// * When using protocol.NewReceipt, protocol.ResultACK or protocol.ResultNACK as a result
+	//   (*protocol.Receipt implements protocol.Result) rather than an error,
+	//   protocols that support message ack will react regarding Receipt.ACK field.
+	// * A nil result is taken into account as a protocol.Receipt with acked enabled.
+	// * Also, Receipts whose ACK field is true will not trigger warning logs.
+	//   Note that you may use ObservabilityService to setup a custom logging policy.
 	StartReceiver(ctx context.Context, fn interface{}) error
 }
 

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -52,8 +52,6 @@ type Client interface {
 	//   (*protocol.Receipt implements protocol.Result) rather than an error,
 	//   protocols that support message ack will react regarding Receipt.ACK field.
 	// * A nil result is taken into account as a protocol.Receipt with acked enabled.
-	// * Also, Receipts whose ACK field is true will not trigger warning logs.
-	//   Note that you may use ObservabilityService to setup a custom logging policy.
 	StartReceiver(ctx context.Context, fn interface{}) error
 }
 

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -51,7 +51,7 @@ type Client interface {
 	// * When using protocol.NewReceipt, protocol.ResultACK or protocol.ResultNACK as a result
 	//   (*protocol.Receipt implements protocol.Result) rather than an error,
 	//   protocols that support message ack will react regarding Receipt.ACK field.
-	// * A nil result is taken into account as a protocol.Receipt with acked enabled.
+	// * A nil result is taken into account as a protocol.Receipt with acked disabled.
 	StartReceiver(ctx context.Context, fn interface{}) error
 }
 

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -36,14 +36,16 @@ type Client interface {
 	// This call is blocking.
 	// Valid fn signatures are:
 	// * func()
-	// * func(context.Context)
-	// * func(event.Event)
-	// * func(context.Context, event.Event)
-	// * func(event.Event) *event.Event
-	// * func(context.Context, event.Event) *event.Event
-	// These signatures are available with an additional error returned:
 	// * func() error
-	// * ...
+	// * func(context.Context)
+	// * func(context.Context) error
+	// * func(event.Event)
+	// * func(event.Event) error
+	// * func(context.Context, event.Event)
+	// * func(context.Context, event.Event) error
+	// * func(event.Event) *event.Event
+	// * func(event.Event) (*event.Event, error)
+	// * func(context.Context, event.Event) *event.Event
 	// * func(context.Context, event.Event) (*event.Event, error)
 	// The error returned may impact the messages processing made by the protocol
 	// used (example: message acknowledgement). Please refer to each protocol's

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -36,22 +36,18 @@ type Client interface {
 	// This call is blocking.
 	// Valid fn signatures are:
 	// * func()
-	// * func() error
 	// * func(context.Context)
-	// * func(context.Context) protocol.Result
 	// * func(event.Event)
-	// * func(event.Event) protocol.Result
 	// * func(context.Context, event.Event)
-	// * func(context.Context, event.Event) protocol.Result
 	// * func(event.Event) *event.Event
-	// * func(event.Event) (*event.Event, protocol.Result)
 	// * func(context.Context, event.Event) *event.Event
-	// * func(context.Context, event.Event) (*event.Event, protocol.Result)
-	// Details about the "fn" function returned values:
-	// * When using protocol.NewReceipt, protocol.ResultACK or protocol.ResultNACK as a result
-	//   (*protocol.Receipt implements protocol.Result) rather than an error,
-	//   protocols that support message ack will react regarding Receipt.ACK field.
-	// * A nil result is taken into account as a protocol.Receipt with acked disabled.
+	// These signatures are available with an additional error returned:
+	// * func() error
+	// * ...
+	// * func(context.Context, event.Event) (*event.Event, error)
+	// The error returned may impact the messages processing made by the protocol
+	// used (example: message acknowledgement). Please refer to each protocol's
+	// package documentation of the function "Finish(err error) error".
 	StartReceiver(ctx context.Context, fn interface{}) error
 }
 


### PR DESCRIPTION
PUB/SUB Message acking is missing protocol.Result support.
For example, stan seems to properly handle it: https://github.com/cloudevents/sdk-go/blob/main/protocol/stan/v2/message.go#L66.

This PR fixes the issue with related tests.

Old cases supported:

| Function result                     | Acked/Nacked | Finish result       |
|-------------------------------------|--------------|---------------------|
| nil                                 | ACKED        | nil                 |
| any error | NACKED       | the original error  |

New behaviour:

| Function result                     | Acked/Nacked | Finish result       |
|-------------------------------------|--------------|---------------------|
| nil                                 | ACKED        | nil                 |
| any error except cloudevents.Result | NACKED       | the original error  |
| cloudevents.Result (param acked)    | ACKED        | nil                 |
| cloudevents.Result (param nacked)   | NACKED       | the protocol.Result |