### PR TITLE
Add WithHost Option

### DIFF
--- a/v2/alias.go
+++ b/v2/alias.go
@@ -173,6 +173,7 @@ var (
 
 	WithTarget          = http.WithTarget
 	WithHeader          = http.WithHeader
+	WithHost            = http.WithHost
 	WithShutdownTimeout = http.WithShutdownTimeout
 	//WithEncoding           = http.WithEncoding
 	//WithStructuredEncoding = http.WithStructuredEncoding // TODO: expose new way

--- a/v2/protocol/http/options.go
+++ b/v2/protocol/http/options.go
@@ -72,6 +72,26 @@ func WithHeader(key, value string) Option {
 	}
 }
 
+// WithHost sets the outbound host header for all cloud events when using an HTTP request
+func WithHost(value string) Option {
+	return func(p *Protocol) error {
+		if p == nil {
+			return fmt.Errorf("http host option can not set nil protocol")
+		}
+		value = strings.TrimSpace(value)
+		if value != "" {
+			if p.RequestTemplate == nil {
+				p.RequestTemplate = &nethttp.Request{
+					Method: nethttp.MethodPost,
+				}
+			}
+			p.RequestTemplate.Host = value
+			return nil
+		}
+		return fmt.Errorf("http host option was empty string")
+	}
+}
+
 // WithShutdownTimeout sets the shutdown timeout when the http server is being shutdown.
 func WithShutdownTimeout(timeout time.Duration) Option {
 	return func(p *Protocol) error {


### PR DESCRIPTION
Implements suggested solution #2 from [Issue #1069](https://github.com/cloudevents/sdk-go/issues/1069). 

Adds a new `WithHost` option for HTTP Protocols to enable the ability to set the HTTP `Host` header manually.