### PR TITLE
add ability to use PullConsumers with NATS jetstream with a specified callback

### DIFF
--- a/protocol/nats_jetstream/v2/options.go
+++ b/protocol/nats_jetstream/v2/options.go
@@ -12,6 +12,8 @@ import (
 )
 
 var ErrInvalidQueueName = errors.New("invalid queue name for QueueSubscriber")
+var ErrInvalidDurableName = errors.New("invalid durable name for PullSubscriber")
+var ErrInvalidCallbackFunc = errors.New("invalid callback function for PullSubscriber")
 
 // NatsOptions is a helper function to group a variadic nats.ProtocolOption into
 // []nats.Option that can be used by either Sender, Consumer or Protocol
@@ -47,6 +49,20 @@ func WithQueueSubscriber(queue string) ConsumerOption {
 			return ErrInvalidQueueName
 		}
 		c.Subscriber = &QueueSubscriber{Queue: queue}
+		return nil
+	}
+}
+
+// WithPullSubscriber configures the Consumer to pull messages when subscribing
+func WithPullSubscriber(durable string, fetchCallback FetchCallbackFunc) ConsumerOption {
+	return func(c *Consumer) error {
+		if durable == "" {
+			return ErrInvalidDurableName
+		}
+		if fetchCallback == nil {
+			return ErrInvalidCallbackFunc
+		}
+		c.Subscriber = &PullSubscriber{Durable: durable, FetchCallback: fetchCallback}
 		return nil
 	}
 }

--- a/protocol/nats_jetstream/v2/subscriber.go
+++ b/protocol/nats_jetstream/v2/subscriber.go
@@ -36,3 +36,19 @@ func (s *QueueSubscriber) Subscribe(jsm nats.JetStreamContext, subject string, c
 }
 
 var _ Subscriber = (*QueueSubscriber)(nil)
+
+// FetchCallbackFunc defines a callback where Fetch should be called against nats.Subscription
+type FetchCallbackFunc func(natsSub *nats.Subscription) ([]*nats.Msg, error)
+
+// PullSubscriber creates pull subscriptions
+type PullSubscriber struct {
+	Durable       string
+	FetchCallback FetchCallbackFunc
+}
+
+// Subscribe implements Subscriber.Subscribe
+func (s *PullSubscriber) Subscribe(jsm nats.JetStreamContext, subject string, cb nats.MsgHandler, opts ...nats.SubOpt) (*nats.Subscription, error) {
+	return jsm.PullSubscribe(subject, s.Durable, opts...)
+}
+
+var _ Subscriber = (*PullSubscriber)(nil)

--- a/test/integration/nats_jetstream/nats_test.go
+++ b/test/integration/nats_jetstream/nats_test.go
@@ -55,6 +55,17 @@ func TestSendReceiveStructuredAndBinary(t *testing.T) {
 			},
 		},
 		{
+			name: "pull subscriber - structured",
+			args: args{
+				opts: []ce_nats.ProtocolOption{
+					ce_nats.WithConsumerOptions(
+						ce_nats.WithPullSubscriber(uuid.New().String(), fetchCallback),
+					),
+				},
+				bindingEncoding: binding.EncodingStructured,
+			},
+		},
+		{
 			name: "regular subscriber - binary",
 			args: args{
 				bindingEncoding: binding.EncodingBinary,
@@ -65,6 +76,17 @@ func TestSendReceiveStructuredAndBinary(t *testing.T) {
 				opts: []ce_nats.ProtocolOption{
 					ce_nats.WithConsumerOptions(
 						ce_nats.WithQueueSubscriber(uuid.New().String()),
+					),
+				},
+				bindingEncoding: binding.EncodingBinary,
+			},
+		},
+		{
+			name: "pull subscriber - binary",
+			args: args{
+				opts: []ce_nats.ProtocolOption{
+					ce_nats.WithConsumerOptions(
+						ce_nats.WithPullSubscriber(uuid.New().String(), fetchCallback),
 					),
 				},
 				bindingEncoding: binding.EncodingBinary,
@@ -135,6 +157,10 @@ func testProtocol(t testing.TB, natsConn *nats.Conn, opts ...ce_nats.ProtocolOpt
 		err = p.Close(context.TODO())
 		require.NoError(t, err)
 	}, p.Sender, p.Consumer
+}
+
+func fetchCallback(natsSub *nats.Subscription) ([]*nats.Msg, error) {
+	return natsSub.Fetch(1)
 }
 
 func BenchmarkSendReceive(b *testing.B) {


### PR DESCRIPTION
In many cases, the reciever of a message might want some ability to exercise control over the fetching.  Also, with NATS, there are options inside the NATS server that might be beneficial to use a pull-based consumer.