### PR TITLE
Fix race condition in MQTT protocol when sending messages

### DIFF
--- a/protocol/mqtt_paho/v2/protocol.go
+++ b/protocol/mqtt_paho/v2/protocol.go
@@ -20,7 +20,6 @@ import (
 
 type Protocol struct {
 	client          *paho.Client
-	config          *paho.ClientConfig
 	connOption      *paho.Connect
 	publishOption   *paho.Publish
 	subscribeOption *paho.Subscribe
@@ -89,7 +88,7 @@ func (p *Protocol) Send(ctx context.Context, m binding.Message, transformers ...
 	var err error
 	defer m.Finish(err)
 
-	msg := p.publishOption
+	msg := p.publishMsg()
 	if cecontext.TopicFrom(ctx) != "" {
 		msg.Topic = cecontext.TopicFrom(ctx)
 		cecontext.WithTopic(ctx, "")
@@ -105,6 +104,16 @@ func (p *Protocol) Send(ctx context.Context, m binding.Message, transformers ...
 		return err
 	}
 	return err
+}
+
+// publishMsg generate a new paho.Publish message from the p.publishOption
+func (p *Protocol) publishMsg() *paho.Publish {
+	return &paho.Publish{
+		QoS:        p.publishOption.QoS,
+		Retain:     p.publishOption.Retain,
+		Topic:      p.publishOption.Topic,
+		Properties: p.publishOption.Properties,
+	}
 }
 
 func (p *Protocol) OpenInbound(ctx context.Context) error {

--- a/test/integration/mqtt_paho/concurrent_test.go
+++ b/test/integration/mqtt_paho/concurrent_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The CloudEvents Authors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mqtt_paho
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
+)
+
+func TestConcurrentSendingEvent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	topicName := "test-ce-client-" + uuid.New().String()
+
+	readyCh := make(chan bool)
+	defer close(readyCh)
+
+	senderNum := 10  // 10 gorutine to sending the events
+	eventNum := 1000 // each gorutine sender publishs 1,000 events
+
+	var g errgroup.Group
+
+	// start a receiver
+	c, err := cloudevents.NewClient(protocolFactory(ctx, t, topicName), cloudevents.WithUUIDs())
+	require.NoError(t, err)
+	g.Go(func() error {
+		// verify all of events can be recieved
+		count := senderNum * eventNum
+		var mu sync.Mutex
+		return c.StartReceiver(ctx, func(event cloudevents.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			count--
+			if count == 0 {
+				readyCh <- true
+			}
+		})
+	})
+	// wait for 5 seconds to ensure the receiver starts safely
+	time.Sleep(5 * time.Second)
+
+	// start a sender client to pulish events concurrently
+	client, err := cloudevents.NewClient(protocolFactory(ctx, t, topicName), cloudevents.WithUUIDs())
+	require.NoError(t, err)
+
+	evt := cloudevents.NewEvent()
+	evt.SetType("com.cloudevents.sample.sent")
+	evt.SetSource("concurrent-sender")
+	err = evt.SetData(cloudevents.ApplicationJSON, map[string]interface{}{"message": "Hello, World!"})
+	require.NoError(t, err)
+
+	for i := 0; i < senderNum; i++ {
+		g.Go(func() error {
+			for j := 0; j < eventNum; j++ {
+				result := client.Send(
+					cecontext.WithTopic(ctx, topicName),
+					evt,
+				)
+				if result != nil {
+					return result
+				}
+			}
+			return nil
+		})
+	}
+
+	// wait until all the events are received
+	handleEvent(ctx, readyCh, cancel, t)
+
+	require.NoError(t, g.Wait())
+}
+
+func handleEvent(ctx context.Context, readyCh <-chan bool, cancel context.CancelFunc, t *testing.T) {
+	for {
+		select {
+		case <-ctx.Done():
+			require.Fail(t, "Test failed: timeout reached before events were received")
+			return
+		case <-readyCh:
+			cancel()
+			t.Logf("Test passed: events successfully received")
+			return
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Resolved: https://github.com/cloudevents/sdk-go/issues/1093

**Summary:**

**Reason:** This issue occurs when a single client sends events across multiple goroutines. Specifically, in the code here:
https://github.com/cloudevents/sdk-go/blob/1aecb204b50da7dae3d5586030c7047479334bdc/protocol/mqtt_paho/v2/protocol.go#L92-L101
at line 98, the MQTT `msg` is designed to hold a single `binding.Message` (or Event) payload. However, in a multi-goroutine environment, multiple `m` values may be written to the shared `msg`, causing a panic like `bytes.Buffer: too large`.

**Solution:** Instead of sharing the same `msg` across goroutines, we will create a copy of it each time a message is sent.
