### PR TITLE
Add NATS Ack/Nak to nats jetstream V3 Finish

### DIFF
--- a/protocol/nats_jetstream/v3/options.go
+++ b/protocol/nats_jetstream/v3/options.go
@@ -42,7 +42,7 @@ func WithConnection(conn *nats.Conn) ProtocolOption {
 // WithJetStreamOptions sets jetstream options used in the protocol sender and receiver
 func WithJetStreamOptions(jetStreamOpts []jetstream.JetStreamOpt) ProtocolOption {
 	return func(p *Protocol) error {
-		p.jetSteamOpts = jetStreamOpts
+		p.jetStreamOpts = jetStreamOpts
 		return nil
 	}
 }

--- a/protocol/nats_jetstream/v3/options_test.go
+++ b/protocol/nats_jetstream/v3/options_test.go
@@ -474,7 +474,7 @@ func TestWithJetStreamOptions(t *testing.T) {
 			wants: wants{
 				err: nil,
 				protocol: &Protocol{
-					jetSteamOpts: jetStreamOpts,
+					jetStreamOpts: jetStreamOpts,
 				},
 			},
 		},

--- a/protocol/nats_jetstream/v3/protocol.go
+++ b/protocol/nats_jetstream/v3/protocol.go
@@ -29,8 +29,8 @@ type Protocol struct {
 	natsOpts []nats.Option
 
 	// jetstream options
-	jetSteamOpts []jetstream.JetStreamOpt
-	jetStream    jetstream.JetStream
+	jetStreamOpts []jetstream.JetStreamOpt
+	jetStream     jetstream.JetStream
 
 	// receiver
 	incoming              chan msgErr
@@ -76,7 +76,7 @@ func New(ctx context.Context, opts ...ProtocolOption) (*Protocol, error) {
 		}
 	}
 
-	if p.jetStream, errConnection = jetstream.New(p.conn, p.jetSteamOpts...); errConnection != nil {
+	if p.jetStream, errConnection = jetstream.New(p.conn, p.jetStreamOpts...); errConnection != nil {
 		return nil, errConnection
 	}
 


### PR DESCRIPTION
In some cases, an explicit ACK/NACK may be necessary.  Currently, there is no way to NACK a message.  Also, in some cases, the NATS server may not automatically ACK a message.

This logic explicitly looks for an error that is `protocol.ResultNACK`, for when to do a `Nak`.  
If the error is `nil` or `protocol.ResultACK`, then a `Ack` is done.
When an unknown error occurs, the original behavior of `return nil` is invoked.

Testing with a live system can be done by temporarily modifying:
https://github.com/cloudevents/sdk-go/blob/main/v2/protocol/test/test.go#L41
that is called from:
https://github.com/cloudevents/sdk-go/blob/main/test/integration/nats_jetstream/v3/nats_test.go#L29

