### PR TITLE
fix automerge by giving better names

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
 
   conformance:
-    name: CloudEvents
+    name: CloudEvents Conformance
     strategy:
       matrix:
         go-version: [1.23]

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Go Lint on ./v2
         if: steps.golangci_configuration.outputs.files_exists == 'true'
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: v1.61
           working-directory: v2

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
 
   integration:
-    name: CloudEvents
+    name: CloudEvents Integration Test
     strategy:
       matrix:
         # Only test one go version: the integration tests don't seem to pass if NATS runs more one running at a time.

--- a/.github/workflows/observability.yaml
+++ b/.github/workflows/observability.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
 
   observability:
-    name: CloudEvents
+    name: CloudEvents Observability
     strategy:
       matrix:
         go-version: [1.23]


### PR DESCRIPTION
better names will allow us to add them to the "auto-merge" checker. Today more than one check shows up as the same name which makes it harder to list them all.

Also, revert dependabot's latest change since it breaks things.