### PR TITLE
Update Go version in workflows

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -15,7 +15,7 @@ jobs:
     name: CloudEvents Conformance
     strategy:
       matrix:
-        go-version: [1.23]
+        go-version: [1.24]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.23]
+        go-version: [1.24]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/go-format.yaml
+++ b/.github/workflows/go-format.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.23
+          go-version: 1.24
           cache-dependency-path: v2/go.sum
         id: go
 

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.23
+          go-version: 1.24
           cache-dependency-path: v2/go.sum
         id: go
 

--- a/.github/workflows/go-unit-test.yaml
+++ b/.github/workflows/go-unit-test.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit Test
     strategy:
       matrix:
-        go-version: [1.23]
+        go-version: [1.24]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Only test one go version: the integration tests don't seem to pass if NATS runs more one running at a time.
-        go-version: [1.23]
+        go-version: [1.24]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/observability.yaml
+++ b/.github/workflows/observability.yaml
@@ -15,7 +15,7 @@ jobs:
     name: CloudEvents Observability
     strategy:
       matrix:
-        go-version: [1.23]
+        go-version: [1.24]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.23
+          go-version: 1.24
           cache-dependency-path: v2/go.sum
 
       - name: Install Dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.23
+          go-version: 1.24
           cache-dependency-path: v2/go.sum
 
       - run: git pull
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.23
+          go-version: 1.24
           cache-dependency-path: v2/go.sum
 
       - name: Checkout Code

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.23
+          go-version: 1.24
           cache-dependency-path: v2/go.sum
 
       - name: Run update dependencies script

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library will help you to:
 _Note:_ Supported
 [CloudEvents specification](https://github.com/cloudevents/spec): 0.3, 1.0
 
-_Note:_ Tested and supported go version(s): 1.23+
+_Note:_ Minimum Go version required: 1.23 (tested with 1.24+)
 
 ## Get started
 


### PR DESCRIPTION
Addresses an issue with https://github.com/cloudevents/sdk-go/actions/runs/17366826821 due to `go: google.golang.org/genproto@v0.0.0-20250826171959-ef028d996bc1 requires go >= 1.24.0 (running go 1.23.12)`