### PR TITLE
change jetstream integration CI service from bitnami to nats:latest

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -46,7 +46,7 @@ jobs:
 
       jetstream:
         image: nats:latest
-        options: "-js"
+        options: -js
         ports:
           - 4223:4223
 


### PR DESCRIPTION
bitnami public images are being removed September 29th.

see: https://github.com/bitnami/containers/issues/83267