### PR TITLE
switch from bitnami nats to nats:latest for jetstream

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -44,13 +44,6 @@ jobs:
         ports:
           - 4222:4222
 
-      jetstream:
-        image: bitnami/nats:latest
-        env: 
-          NATS_EXTRA_ARGS: "--jetstream --port 4223"
-        ports:
-          - 4223:4223
-
       amqp:
         image: scholzj/qpid-dispatch
         env:
@@ -89,7 +82,14 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: v2/go.sum
         id: go
-        
+
+      - name: run jetstream
+        run: |
+          docker run --name nats-server -p 4223:4223 -d nats:2.12.0 -js       
+
       - name: Test
         run: ./hack/integration-test.sh
 
+      - name: stop jetstream
+        run: docker stop nats-server
+        if: always()


### PR DESCRIPTION
Cannot use github actions `services` during CI because of limitation in github actions in supplying  `-js` argument to container