### PR TITLE
Add expirytime extension support

### DIFF
--- a/v2/extensions/expirytime_extension.go
+++ b/v2/extensions/expirytime_extension.go
@@ -1,0 +1,78 @@
+/*
+ Copyright 2026 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package extensions
+
+import (
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/types"
+)
+
+const (
+	ExpiryTimeExtensionKey = "expirytime"
+)
+
+// ExpiryTimeExtension represents the expirytime extension as defined in
+// https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/expirytime.md
+type ExpiryTimeExtension struct {
+	ExpiryTime time.Time `json:"expirytime"`
+}
+
+// AddExpiryTime sets the expirytime extension on the event.
+func (e ExpiryTimeExtension) AddExpiryTime(ev event.EventWriter) {
+	if !e.ExpiryTime.IsZero() {
+		ev.SetExtension(ExpiryTimeExtensionKey, types.Timestamp{Time: e.ExpiryTime})
+	}
+}
+
+// GetExpiryTime retrieves the expirytime extension from an event.
+func GetExpiryTime(ev event.Event) (ExpiryTimeExtension, bool) {
+	if ext, ok := ev.Extensions()[ExpiryTimeExtensionKey]; ok {
+		if t, err := types.ToTime(ext); err == nil {
+			return ExpiryTimeExtension{ExpiryTime: t}, true
+		}
+	}
+	return ExpiryTimeExtension{}, false
+}
+
+// IsExpired checks whether the event has expired relative to the given time.
+func IsExpired(ev event.Event, now time.Time) bool {
+	if ext, ok := GetExpiryTime(ev); ok {
+		return now.After(ext.ExpiryTime)
+	}
+	return false
+}
+
+func (e *ExpiryTimeExtension) ReadTransformer() binding.TransformerFunc {
+	return func(reader binding.MessageMetadataReader, writer binding.MessageMetadataWriter) error {
+		ext := reader.GetExtension(ExpiryTimeExtensionKey)
+		if ext != nil {
+			formatted, err := types.Format(ext)
+			if err != nil {
+				return err
+			}
+			if formatted != "" {
+				t, err := types.ParseTime(formatted)
+				if err != nil {
+					return err
+				}
+				e.ExpiryTime = t
+			}
+		}
+		return nil
+	}
+}
+
+func (e *ExpiryTimeExtension) WriteTransformer() binding.TransformerFunc {
+	return func(reader binding.MessageMetadataReader, writer binding.MessageMetadataWriter) error {
+		if !e.ExpiryTime.IsZero() {
+			return writer.SetExtension(ExpiryTimeExtensionKey, types.Timestamp{Time: e.ExpiryTime})
+		}
+		return nil
+	}
+}

--- a/v2/extensions/expirytime_extension_test.go
+++ b/v2/extensions/expirytime_extension_test.go
@@ -1,0 +1,180 @@
+/*
+ Copyright 2026 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package extensions_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	bindingtest "github.com/cloudevents/sdk-go/v2/binding/test"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/extensions"
+	"github.com/cloudevents/sdk-go/v2/test"
+)
+
+func TestAddExpiryTime(t *testing.T) {
+	expiry := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	ext := extensions.ExpiryTimeExtension{ExpiryTime: expiry}
+
+	e := event.New()
+	e.SetSource("http://example.com/source")
+	e.SetType("com.example.test")
+	e.SetID("ABC-123")
+
+	ext.AddExpiryTime(&e)
+
+	got, ok := extensions.GetExpiryTime(e)
+	require.True(t, ok)
+	require.True(t, expiry.Equal(got.ExpiryTime))
+}
+
+func TestAddExpiryTime_Zero(t *testing.T) {
+	ext := extensions.ExpiryTimeExtension{}
+
+	e := event.New()
+	e.SetSource("http://example.com/source")
+	e.SetType("com.example.test")
+	e.SetID("ABC-123")
+
+	ext.AddExpiryTime(&e)
+
+	_, ok := extensions.GetExpiryTime(e)
+	require.False(t, ok)
+}
+
+func TestGetExpiryTime_NotSet(t *testing.T) {
+	e := event.New()
+	e.SetSource("http://example.com/source")
+	e.SetType("com.example.test")
+	e.SetID("ABC-123")
+
+	_, ok := extensions.GetExpiryTime(e)
+	require.False(t, ok)
+}
+
+func TestIsExpired(t *testing.T) {
+	expiry := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	ext := extensions.ExpiryTimeExtension{ExpiryTime: expiry}
+
+	e := event.New()
+	e.SetSource("http://example.com/source")
+	e.SetType("com.example.test")
+	e.SetID("ABC-123")
+	ext.AddExpiryTime(&e)
+
+	require.True(t, extensions.IsExpired(e, expiry.Add(time.Hour)))
+	require.False(t, extensions.IsExpired(e, expiry.Add(-time.Hour)))
+}
+
+func TestIsExpired_NoExtension(t *testing.T) {
+	e := event.New()
+	e.SetSource("http://example.com/source")
+	e.SetType("com.example.test")
+	e.SetID("ABC-123")
+
+	require.False(t, extensions.IsExpired(e, time.Now()))
+}
+
+func TestExpiryTime_ReadTransformer_Empty(t *testing.T) {
+	e := test.MinEvent()
+	e.Context = e.Context.AsV1()
+
+	tests := []bindingtest.TransformerTestArgs{
+		{
+			Name:         "Read from Mock Structured message",
+			InputMessage: bindingtest.MustCreateMockStructuredMessage(t, e),
+			WantEvent:    e,
+		},
+		{
+			Name:         "Read from Mock Binary message",
+			InputMessage: bindingtest.MustCreateMockBinaryMessage(e),
+			WantEvent:    e,
+		},
+		{
+			Name:       "Read from Event message",
+			InputEvent: e,
+			WantEvent:  e,
+		},
+	}
+	for _, tt := range tests {
+		ext := extensions.ExpiryTimeExtension{}
+		tt.Transformers = binding.Transformers{ext.ReadTransformer()}
+		bindingtest.RunTransformerTests(t, context.TODO(), []bindingtest.TransformerTestArgs{tt})
+		require.True(t, ext.ExpiryTime.IsZero())
+	}
+}
+
+func TestExpiryTime_ReadTransformer(t *testing.T) {
+	e := test.MinEvent()
+	e.Context = e.Context.AsV1()
+	expiry := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	wantExt := extensions.ExpiryTimeExtension{ExpiryTime: expiry}
+	wantExt.AddExpiryTime(&e)
+
+	// Structured message mock round-trips through JSON, which converts
+	// types.Timestamp to a plain string. Create a separate want event for it.
+	eStructured := e.Clone()
+	eStructured.SetExtension(extensions.ExpiryTimeExtensionKey, "2025-06-01T12:00:00Z")
+
+	tests := []bindingtest.TransformerTestArgs{
+		{
+			Name:         "Read from Mock Structured message",
+			InputMessage: bindingtest.MustCreateMockStructuredMessage(t, e),
+			WantEvent:    eStructured,
+		},
+		{
+			Name:         "Read from Mock Binary message",
+			InputMessage: bindingtest.MustCreateMockBinaryMessage(e),
+			WantEvent:    e,
+		},
+		{
+			Name:       "Read from Event message",
+			InputEvent: e,
+			WantEvent:  e,
+		},
+	}
+	for _, tt := range tests {
+		haveExt := extensions.ExpiryTimeExtension{}
+		tt.Transformers = binding.Transformers{haveExt.ReadTransformer()}
+		bindingtest.RunTransformerTests(t, context.TODO(), []bindingtest.TransformerTestArgs{tt})
+		require.True(t, expiry.Equal(haveExt.ExpiryTime))
+	}
+}
+
+func TestExpiryTime_WriteTransformer(t *testing.T) {
+	e := test.MinEvent()
+	e.Context = e.Context.AsV1()
+	expiry := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	ext := extensions.ExpiryTimeExtension{ExpiryTime: expiry}
+	want := e.Clone()
+	ext.AddExpiryTime(&want)
+
+	bindingtest.RunTransformerTests(t, context.TODO(), []bindingtest.TransformerTestArgs{
+		{
+			Name:         "Write to Mock Structured message",
+			InputMessage: bindingtest.MustCreateMockStructuredMessage(t, e),
+			WantEvent:    want,
+			Transformers: binding.Transformers{ext.WriteTransformer()},
+		},
+		{
+			Name:         "Write to Mock Binary message",
+			InputMessage: bindingtest.MustCreateMockBinaryMessage(e),
+			WantEvent:    want,
+			Transformers: binding.Transformers{ext.WriteTransformer()},
+		},
+		{
+			Name:         "Write to Event message",
+			InputEvent:   e,
+			WantEvent:    want,
+			Transformers: binding.Transformers{ext.WriteTransformer()},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Implement the `expirytime` extension as defined in the [CloudEvents spec](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/expirytime.md)
- Follow the same pattern as the existing `DistributedTracingExtension`
- Provide `AddExpiryTime()`, `GetExpiryTime()`, `IsExpired()` helpers
- Include `ReadTransformer()` / `WriteTransformer()` for binding support

Closes #1258

## Test plan

- [x] Unit tests for set/get expirytime on events
- [x] Unit tests for zero value and missing extension
- [x] Unit tests for `IsExpired()` with expired and non-expired times
- [x] Binding transformer tests (structured, binary, event messages)
- [x] All existing tests pass