### PR TITLE
fix(docs): mark MQTT as supported in feature table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ err := json.Unmarshal(bytes, &event)
 | [JSON Event Format](event_data_structure.md#marshalunmarshal-event-to-json)             | :heavy_check_mark:                                    | :heavy_check_mark:                                    |
 | [Sarama Kafka Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/samples/kafka) | :heavy_check_mark:                                    | :heavy_check_mark:                                    |
 | [Confluent Kafka Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/samples/kafka_confluent) | :heavy_check_mark:                                    | :heavy_check_mark:                                    |
-| MQTT Protocol Binding                                                                   | :x:                                                   | :x:                                                   |
+| [MQTT Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/samples/mqtt)   | :heavy_check_mark:                                    | :heavy_check_mark:                                    |
 | [NATS Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/samples/nats)   | :heavy_check_mark:                                    | :heavy_check_mark:                                    |
 | [STAN Protocol Binding](https://github.com/cloudevents/sdk-go/tree/main/samples/stan)   | :heavy_check_mark:                                    | :heavy_check_mark:                                    |
 | Web hook                                                                                | :x:                                                   | :x:                                                   |


### PR DESCRIPTION
MQTT is marked as unsupported in docs/index.md but protocol/mqtt_paho/ and samples/mqtt/ contain full implementations.