### PR TITLE
fix: omit protobuf data for events without payload

### DIFF
--- a/binding/format/protobuf/v2/protobuf.go
+++ b/binding/format/protobuf/v2/protobuf.go
@@ -108,10 +108,12 @@ func ToProto(e *event.Event) (*pb.CloudEvent, error) {
 		}
 		container.Attributes[name] = attr
 	}
-	container.Data = &pb.CloudEvent_BinaryData{
-		BinaryData: e.Data(),
+	if e.Data() != nil {
+		container.Data = &pb.CloudEvent_BinaryData{
+			BinaryData: e.Data(),
+		}
 	}
-	if e.DataContentType() == ContentTypeProtobuf {
+	if e.Data() != nil && e.DataContentType() == ContentTypeProtobuf {
 		anymsg := &anypb.Any{
 			TypeUrl: e.DataSchema(),
 			Value:   e.Data(),

--- a/binding/format/protobuf/v2/protobuf_test.go
+++ b/binding/format/protobuf/v2/protobuf_test.go
@@ -6,6 +6,7 @@
 package format_test
 
 import (
+	"encoding/json"
 	"net/url"
 	"reflect"
 	"testing"
@@ -92,6 +93,36 @@ func TestProtobufFormatWithProtobufCodec(t *testing.T) {
 	payload2 := &pb.CloudEventAttributeValue{}
 	require.NoError(e2.DataAs(payload2))
 	require.True(payload2.GetCeBoolean())
+}
+
+func TestProtobufFormatWithoutDataDoesNotCreateInvalidJSON(t *testing.T) {
+	require := require.New(t)
+
+	e := event.New()
+	e.SetID("id")
+	e.SetSource("source")
+	e.SetType("type")
+	e.SetDataContentType(event.ApplicationJSON)
+
+	b, err := format.Protobuf.Marshal(&e)
+	require.NoError(err)
+
+	var e2 event.Event
+	require.NoError(format.Protobuf.Unmarshal(b, &e2))
+	require.Nil(e2.DataEncoded)
+
+	jsonData, err := e2.MarshalJSON()
+	require.NoError(err)
+	require.JSONEq(`{
+		"specversion":"1.0",
+		"id":"id",
+		"source":"source",
+		"type":"type",
+		"datacontenttype":"application/json"
+	}`, string(jsonData))
+
+	var out event.Event
+	require.NoError(json.Unmarshal(jsonData, &out))
 }
 
 func TestFromProto(t *testing.T) {


### PR DESCRIPTION
Fixes #1193

protobuf marshal always sets `data`, even when the event has no payload.
after a protobuf round trip that becomes `DataEncoded=[]byte{}`, then JSON marshal emits busted JSON:

```json
{"specversion":"1.0","id":"id","source":"source","type":"type","datacontenttype":"application/json","data":}
```

Repro on `main`:

```go
ev := ce.NewEvent(ce.VersionV1)
ev.SetID("id")
ev.SetSource("source")
ev.SetType("type")
ev.SetDataContentType(ce.ApplicationJSON)

b, _ := format.Protobuf.Marshal(&ev)
var out ce.Event
_ = format.Protobuf.Unmarshal(b, &out)
_, _ = out.MarshalJSON()
```

This patch skips protobuf `data` when `e.Data() == nil`, so no payload stays no payload. small fix, but pretty real.

Tests:
- add a regression test for protobuf -> event -> json round trip with no data
- `go test ./...` in `binding/format/protobuf/v2`
- `go test ./...` in `v2`
