### PR TITLE
fix(pubsub): initialize Attributes map in writer Start to avoid nil panic

### DIFF
--- a/protocol/pubsub/v2/message_test.go
+++ b/protocol/pubsub/v2/message_test.go
@@ -102,3 +102,25 @@ func TestFinish(t *testing.T) {
 		})
 	}
 }
+
+func TestWritePubSubMessageNilAttributes(t *testing.T) {
+	e := event.New()
+	e.SetID("testid")
+	e.SetSource("test/source")
+	e.SetType("test.type")
+	if err := e.SetData(event.ApplicationJSON, map[string]string{"hello": "world"}); err != nil {
+		t.Fatalf("failed to set data: %v", err)
+	}
+
+	msg := (*binding.EventMessage)(&e)
+
+	// A pubsub.Message with nil Attributes must not panic when the writer
+	// assigns into the attribute map during binary encoding.
+	pm := &pubsub.Message{ID: "testid"}
+	if err := WritePubSubMessage(context.Background(), msg, pm); err != nil {
+		t.Errorf("unexpected error writing pubsub message: %v", err)
+	}
+	if pm.Attributes == nil {
+		t.Errorf("expected Attributes to be initialized, got nil")
+	}
+}

--- a/protocol/pubsub/v2/write_pubsub_message.go
+++ b/protocol/pubsub/v2/write_pubsub_message.go
@@ -46,6 +46,9 @@ func (b *pubsubMessagePublisher) SetStructuredEvent(ctx context.Context, f forma
 }
 
 func (b *pubsubMessagePublisher) Start(ctx context.Context) error {
+	if b.Attributes == nil {
+		b.Attributes = make(map[string]string)
+	}
 	return nil
 }
 


### PR DESCRIPTION
WritePubSubMessage assigned into pubsub.Message.Attributes without guaranteeing it was non-nil, so a message with a nil Attributes map panicked during binary encoding. Start now allocates the map when nil, matching how the reader already guards against it.

Added TestWritePubSubMessageNilAttributes to cover the nil-Attributes path.