### PR TITLE
fix(pubsub): nack message when context is cancelled during delivery

### DIFF
--- a/protocol/pubsub/v2/protocol.go
+++ b/protocol/pubsub/v2/protocol.go
@@ -206,6 +206,12 @@ func (t *Protocol) startSubscriber(ctx context.Context, sub subscriptionWithTopi
 		select {
 		case t.incoming <- *m:
 		case <-ctx.Done():
+			// The subscriber is shutting down before the message was handed
+			// off. Nack it so Pub/Sub redelivers immediately instead of
+			// waiting out the ack deadline (which with exactly-once delivery
+			// can delay redelivery by minutes).
+			logger.Warnf("context cancelled while delivering message %s; nacking for redelivery", m.ID)
+			m.Nack()
 		}
 	})
 }


### PR DESCRIPTION
When the subscriber context is cancelled while a message is still being handed to the inbound channel, the message was silently dropped without Ack or Nack. Pub/Sub then held it in-flight until the ack deadline expired, delaying redelivery by minutes under exactly-once delivery. Nacking on ctx.Done lets the server redeliver immediately.