### PR TITLE
`event.Event.UnmarshalJSON` dereferences a nil pointer

### DIFF
--- a/v2/event/event_unmarshal.go
+++ b/v2/event/event_unmarshal.go
@@ -166,11 +166,11 @@ func readJsonFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 				}
 				if datacontentencoding != nil {
 					con.DataContentEncoding, err = toStrPtr(datacontentencoding)
-					if *con.DataContentEncoding != Base64 {
-						err = ValidationError{"datacontentencoding": errors.New("invalid datacontentencoding value, the only allowed value is 'base64'")}
-					}
 					if err != nil {
 						return err
+					}
+					if con.DataContentEncoding == nil || *con.DataContentEncoding != Base64 {
+						return ValidationError{"datacontentencoding": errors.New("invalid datacontentencoding value, the only allowed value is 'base64'")}
 					}
 					appendFlag(&state, dataBase64Flag)
 				}

--- a/v2/event/event_unmarshal_test.go
+++ b/v2/event/event_unmarshal_test.go
@@ -1134,6 +1134,18 @@ func TestUnmarshalWithOrderingError(t *testing.T) {
 			Add("type", "com.example.test").
 			Add("source", "http://example.com/source").
 			End(),
+		// Regression test for a nil-pointer dereference panic when
+		// datacontentencoding is the empty string and is cached before
+		// specversion is seen. toStrPtr("") returns (nil, nil), and the
+		// cached-field branch in ReadJson used to dereference that nil
+		// pointer directly.
+		"empty datacontentencoding with datacontentencoding -> specversion": new(orderedJsonObjectBuilder).Start().
+			Add("datacontentencoding", "").
+			Add("specversion", "0.3").
+			Add("id", "ABC-123").
+			Add("type", "com.example.test").
+			Add("source", "http://example.com/source").
+			End(),
 		// Same regression, but with specversion first and no datacontenttype,
 		// so the raw token is captured via iterator.SkipAndReturnBytes()
 		// and still routed through consumeDataAsBytes.


### PR DESCRIPTION
`event.Event.UnmarshalJSON` dereferences a nil pointer when a CloudEvents v0.3 structured-JSON event contains `"datacontentencoding":""` before the `"specversio n"` field. The helper `toStrPtr` returns `(nil, nil)` for an empty string, and t he caller immediately dereferences the result. Because JSON decoding runs inside
 `binding.ToEvent`, outside any `recover()` in the per-message receiver goroutin
e, an unauthenticated HTTP request with `Content-Type: application/cloudevents+j son` and this body terminates any default CloudEvents HTTP receiver process.

thanks to @KrisKennawayDD for the report