### PR TITLE
Webhook abuse-protection origin allow-list bypass

### DIFF
--- a/v2/protocol/http/abuse_protection.go
+++ b/v2/protocol/http/abuse_protection.go
@@ -117,9 +117,12 @@ func (p *Protocol) validateOrigin(ro string) (string, bool) {
 		if ao == "*" {
 			return ao, true
 		}
-		// TODO: it is not clear what the rules for allowed hosts are.
-		// Need to find docs for this. For now, test for prefix.
-		if strings.HasPrefix(ro, ao) {
+		// Require an exact match, or a match anchored at a DNS-label
+		// boundary (e.g. "sub.trusted.example.com" is allowed by
+		// "trusted.example.com", but "trusted.example.com.attacker.tld"
+		// is not). A plain strings.HasPrefix check would let any origin
+		// that merely starts with an allowed value bypass the allow-list.
+		if ro == ao || strings.HasSuffix(ro, "."+ao) {
 			return ao, true
 		}
 	}

--- a/v2/protocol/http/abuse_protection_test.go
+++ b/v2/protocol/http/abuse_protection_test.go
@@ -1,0 +1,86 @@
+/*
+ Copyright 2021 The CloudEvents Authors
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateOriginPrefixBypass is a regression test for a bypass in
+// Protocol.validateOrigin: it used to accept any request origin that merely
+// started with an allowed origin (via strings.HasPrefix), letting an
+// attacker who controls a hostname like "trusted.example.com.attacker.tld"
+// pass validation against an allow-list entry of "trusted.example.com".
+// See advisory-04-webhook-origin-prefix-bypass.md.
+func TestValidateOriginPrefixBypass(t *testing.T) {
+	tests := []struct {
+		name          string
+		allowedOrigin string
+		requestOrigin string
+		wantOK        bool
+	}{
+		{
+			name:          "exact match is allowed",
+			allowedOrigin: "trusted.example.com",
+			requestOrigin: "trusted.example.com",
+			wantOK:        true,
+		},
+		{
+			name:          "subdomain is allowed",
+			allowedOrigin: "trusted.example.com",
+			requestOrigin: "sub.trusted.example.com",
+			wantOK:        true,
+		},
+		{
+			name:          "wildcard is allowed",
+			allowedOrigin: "*",
+			requestOrigin: "anything.attacker.tld",
+			wantOK:        true,
+		},
+		{
+			name:          "suffix bypass is rejected",
+			allowedOrigin: "trusted.example.com",
+			requestOrigin: "trusted.example.com.attacker.tld",
+			wantOK:        false,
+		},
+		{
+			name:          "concatenated bypass is rejected",
+			allowedOrigin: "trusted.example.com",
+			requestOrigin: "trusted.example.comevil.net",
+			wantOK:        false,
+		},
+		{
+			name:          "userinfo-style bypass is rejected",
+			allowedOrigin: "trusted.example.com",
+			requestOrigin: "trusted.example.com:9999@evil",
+			wantOK:        false,
+		},
+		{
+			name:          "unrelated origin is rejected",
+			allowedOrigin: "trusted.example.com",
+			requestOrigin: "evil.tld",
+			wantOK:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Protocol{WebhookConfig: &WebhookConfig{AllowedOrigins: []string{tt.allowedOrigin}}}
+			r, err := http.NewRequest(http.MethodOptions, "/", nil)
+			require.NoError(t, err)
+			r.Header.Set("WebHook-Request-Origin", tt.requestOrigin)
+
+			allowed, ok := p.ValidateRequestOrigin(r)
+			require.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				require.Equal(t, tt.allowedOrigin, allowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The built-in CloudEvents HTTP webhook abuse-protection handler (`Protocol.Option sHandler`) validates the `WebHook-Request-Origin` / `Origin` header against the configured `WebhookConfig.AllowedOrigins` using `strings.HasPrefix`. An origin s uch as `trusted.example.com.attacker.tld` therefore satisfies an allow-list entr y of `trusted.example.com`, letting an attacker who controls any hostname that b egins with an allowed value pass origin validation and complete the abuse-protec tion handshake.

thanks to @KrisKennawayDD for the report