### PR TITLE
Blind SSRF via unvalidated WebHook-Request-Callback

### DIFF
--- a/v2/protocol/http/abuse_protection.go
+++ b/v2/protocol/http/abuse_protection.go
@@ -7,9 +7,12 @@ package http
 
 import (
 	"context"
+	"fmt"
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
 	"go.uber.org/zap"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -42,12 +45,12 @@ func (p *Protocol) OptionsHandler(rw http.ResponseWriter, req *http.Request) {
 
 	// The spec does not say we need to validate the origin, just the request origin.
 	// After the handshake, we will validate the origin.
-	if origin, ok := p.ValidateRequestOrigin(req); !ok {
+	origin, ok := p.ValidateRequestOrigin(req)
+	if !ok {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
-	} else {
-		headers.Set("WebHook-Allowed-Origin", origin)
 	}
+	headers.Set("WebHook-Allowed-Origin", origin)
 
 	allowedRateRequired := false
 	if _, ok := req.Header[http.CanonicalHeaderKey("WebHook-Request-Rate")]; ok {
@@ -70,8 +73,15 @@ func (p *Protocol) OptionsHandler(rw http.ResponseWriter, req *http.Request) {
 	cb := req.Header.Get("WebHook-Request-Callback")
 	if cb != "" {
 		if p.WebhookConfig.AutoACKCallback {
+			cbURL, err := validateCallbackURL(cb, origin)
+			if err != nil {
+				cecontext.LoggerFrom(req.Context()).Errorw("OPTIONS handler rejected web hook request callback.", zap.Error(err), zap.String("callback", cb))
+				rw.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
 			go func() {
-				reqAck, err := http.NewRequest(http.MethodPost, cb, nil)
+				reqAck, err := http.NewRequest(http.MethodPost, cbURL.String(), nil)
 				if err != nil {
 					cecontext.LoggerFrom(req.Context()).Errorw("OPTIONS handler failed to create http request attempting to ack callback.", zap.Error(err), zap.String("callback", cb))
 					return
@@ -128,4 +138,71 @@ func (p *Protocol) validateOrigin(ro string) (string, bool) {
 	}
 
 	return ro, false
+}
+
+// validateCallbackURL validates a client-supplied WebHook-Request-Callback
+// URL before the server is allowed to issue an outbound request to it. This
+// guards against SSRF: without these checks an attacker could point the
+// callback at internal services (loopback, RFC1918, link-local, cloud
+// metadata endpoints, etc.) simply by spoofing the WebHook-Request-Origin
+// header used for the (attacker-controlled) origin check.
+//
+// validatedOrigin is the allow-list entry that the request's origin matched
+// (as returned by ValidateRequestOrigin). Unless that entry is the wildcard
+// "*", the callback's host must equal, or be a subdomain of, the validated
+// origin, which ties the callback destination to an operator-configured
+// allow-list rather than to attacker-controlled input alone. Independently
+// of that check, the callback is always rejected if its host is (or
+// resolves to) a loopback, private, link-local, unspecified, or multicast
+// address, since those are never legitimate public webhook destinations.
+func validateCallbackURL(cb string, validatedOrigin string) (*url.URL, error) {
+	u, err := url.Parse(cb)
+	if err != nil {
+		return nil, fmt.Errorf("invalid callback URL: %w", err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("callback URL scheme %q is not allowed, only http and https are supported", u.Scheme)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("callback URL is missing a host")
+	}
+
+	if !hostMatchesOrigin(host, validatedOrigin) {
+		return nil, fmt.Errorf("callback host %q does not match the validated origin %q", host, validatedOrigin)
+	}
+
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve callback host %q: %w", host, err)
+	}
+	for _, ip := range ips {
+		if isDisallowedCallbackIP(ip) {
+			return nil, fmt.Errorf("callback host %q resolves to disallowed address %s", host, ip)
+		}
+	}
+
+	return u, nil
+}
+
+// hostMatchesOrigin reports whether host is allowed as a webhook callback
+// destination given the origin allow-list entry that the request's origin
+// matched. The wildcard "*" allows any host; otherwise host must be exactly
+// validatedOrigin or a subdomain of it.
+func hostMatchesOrigin(host, validatedOrigin string) bool {
+	return validatedOrigin == "*" || host == validatedOrigin || strings.HasSuffix(host, "."+validatedOrigin)
+}
+
+// isDisallowedCallbackIP reports whether ip is a loopback, private,
+// link-local, unspecified, or multicast address that should never be a
+// valid webhook callback destination.
+func isDisallowedCallbackIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast()
 }

--- a/v2/protocol/http/abuse_protection_test.go
+++ b/v2/protocol/http/abuse_protection_test.go
@@ -6,8 +6,12 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -83,4 +87,138 @@ func TestValidateOriginPrefixBypass(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHostMatchesOrigin is a unit test for the host/origin allow-list
+// matching logic used by validateCallbackURL.
+func TestHostMatchesOrigin(t *testing.T) {
+	tests := []struct {
+		name            string
+		host            string
+		validatedOrigin string
+		want            bool
+	}{
+		{"exact match", "trusted.example.com", "trusted.example.com", true},
+		{"subdomain match", "sub.trusted.example.com", "trusted.example.com", true},
+		{"wildcard allows anything", "anything.attacker.tld", "*", true},
+		{"suffix bypass is rejected", "trusted.example.com.attacker.tld", "trusted.example.com", false},
+		{"concatenated bypass is rejected", "trusted.example.comevil.net", "trusted.example.com", false},
+		{"unrelated host is rejected", "evil.tld", "trusted.example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, hostMatchesOrigin(tt.host, tt.validatedOrigin))
+		})
+	}
+}
+
+// TestValidateCallbackURL is a unit-level regression test for the SSRF fix
+// in validateCallbackURL: WebHook-Request-Callback must use http/https, its
+// host must match (or be a subdomain of) the validated origin unless that
+// origin is the wildcard "*", and its resolved address must never be
+// loopback/private/link-local/unspecified/multicast. Literal IP addresses
+// are used throughout so the test never performs a real DNS lookup.
+// See advisory-05-webhook-callback-ssrf.md.
+func TestValidateCallbackURL(t *testing.T) {
+	tests := []struct {
+		name            string
+		callback        string
+		validatedOrigin string
+		wantErr         bool
+	}{
+		{
+			name:            "matching host and public IP is allowed",
+			callback:        "http://93.184.216.34/ack",
+			validatedOrigin: "93.184.216.34",
+			wantErr:         false,
+		},
+		{
+			name:            "wildcard origin allows public IP",
+			callback:        "https://93.184.216.34/ack",
+			validatedOrigin: "*",
+			wantErr:         false,
+		},
+		{
+			name:            "wildcard origin still blocks loopback destinations",
+			callback:        "http://127.0.0.1:8080/internal",
+			validatedOrigin: "*",
+			wantErr:         true,
+		},
+		{
+			name:            "wildcard origin still blocks cloud metadata address",
+			callback:        "http://169.254.169.254/latest/meta-data",
+			validatedOrigin: "*",
+			wantErr:         true,
+		},
+		{
+			name:            "wildcard origin still blocks private RFC1918 address",
+			callback:        "http://10.0.0.5/admin",
+			validatedOrigin: "*",
+			wantErr:         true,
+		},
+		{
+			name:            "host mismatch with validated origin is rejected",
+			callback:        "http://127.0.0.1:8080/internal",
+			validatedOrigin: "trusted.example.com",
+			wantErr:         true,
+		},
+		{
+			name:            "disallowed scheme is rejected",
+			callback:        "file:///etc/passwd",
+			validatedOrigin: "*",
+			wantErr:         true,
+		},
+		{
+			name:            "unparsable URL is rejected",
+			callback:        "http://%zz",
+			validatedOrigin: "*",
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateCallbackURL(tt.callback, tt.validatedOrigin)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestOptionsHandlerCallbackSSRFBlocked is an end-to-end regression test
+// reproducing the advisory's SSRF PoC: an attacker spoofs
+// WebHook-Request-Origin to pass the (attacker-controlled) origin check and
+// supplies an internal callback URL. The OPTIONS handler must not issue any
+// outbound request to that internal server.
+func TestOptionsHandlerCallbackSSRFBlocked(t *testing.T) {
+	var hit string
+	var mu sync.Mutex
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hit = fmt.Sprintf("%s %s", r.Method, r.URL.String())
+		mu.Unlock()
+	}))
+	defer internal.Close()
+
+	p, err := New(WithDefaultOptionsHandlerFunc(
+		[]string{"POST"}, 100, []string{"trusted.example.com"}, true /* AutoACKCallback */))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodOptions, "http://victim/", nil)
+	req.Header.Set("WebHook-Request-Origin", "trusted.example.com")
+	req.Header.Set("WebHook-Request-Callback", internal.URL+"/internal/admin?x=1")
+	rw := httptest.NewRecorder()
+	p.ServeHTTP(rw, req)
+
+	// Give any (incorrectly) spawned background goroutine a chance to fire.
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, hit, "internal server must never receive the SSRF callback")
+	require.Equal(t, http.StatusBadRequest, rw.Code)
 }


### PR DESCRIPTION
Blind SSRF via unvalidated WebHook-Request-Callback when AutoACKCallback is enabled.

When a CloudEvents HTTP receiver is configured with `WebhookConfig.AutoACKCallba ck = true`, the built-in `Protocol.OptionsHandler` reads the client-supplied `We bHook-Request-Callback` header and issues an outbound `POST` to that URL via `ht tp.DefaultClient` with no validation of scheme, host, or port. Because the only gate — `WebHook-Request-Origin` validation — compares a header value the client fully controls, an unauthenticated remote attacker can make the server send HTTP
 requests to arbitrary destinations, including loopback, RFC1918, and cloud-meta
data addresses (blind SSRF).

thanks to @KrisKennawayDD for the report