### PR TITLE
Keep the receive-handler consumer alive until ServeHTTP returns

### DIFF
--- a/v2/client/http_receiver.go
+++ b/v2/client/http_receiver.go
@@ -31,10 +31,28 @@ type EventReceiver struct {
 }
 
 func (r *EventReceiver) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	// Prepare to handle the message if there's one (context cancellation will ensure this closes)
+	// The goroutine below must stay alive until r.p.ServeHTTP has returned, rather than
+	// until the request context is cancelled.
+	//
+	// r.p.ServeHTTP hands the message over on the unbuffered Protocol.incoming channel and
+	// blocks there until some consumer picks it up. Waiting on the request context lets this
+	// goroutine exit -- on client disconnect -- while the message it was meant to pick up is
+	// still pending. That permanently breaks the 1:1 pairing between ServeHTTP calls and
+	// consumers: from then on every request is served by the *next* request's goroutine, so
+	// each one blocks until further traffic arrives. See #1224.
+	//
+	// The cancellation cannot simply be dropped: r.p.ServeHTTP has paths that return without
+	// sending anything (rate limiting, OPTIONS, GET) and Protocol.incoming is never closed, so
+	// the goroutine would then block forever. Cancelling on return handles both cases -- while
+	// a message is pending its producer has not returned yet, so at least one consumer is
+	// guaranteed to still be waiting.
+	waitCtx, stopWaiting := context.WithCancel(context.Background())
+	defer stopWaiting()
+
+	// Prepare to handle the message if there's one
 	go func() {
 		ctx := req.Context()
-		msg, respFn, err := r.p.Respond(ctx)
+		msg, respFn, err := r.p.Respond(waitCtx)
 		if err != nil {
 			cecontext.LoggerFrom(context.TODO()).Debugw("failed to call Respond", zap.Error(err))
 		} else if err := r.invoker.Invoke(ctx, msg, respFn); err != nil {

--- a/v2/client/http_receiver_test.go
+++ b/v2/client/http_receiver_test.go
@@ -11,7 +11,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 
@@ -119,4 +122,81 @@ func TestEventReceiverServeHTTP_Webhook(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, strconv.Itoa(cehttp.DefaultAllowedRate), res.Header.Get("WebHook-Allowed-Rate"))
+}
+
+// TestEventReceiverServeHTTP_ConsumerPairing is a regression test for #1224.
+//
+// Protocol.ServeHTTP hands the inbound message over on an unbuffered channel and blocks
+// until a consumer picks it up. NewHTTPReceiveHandler starts exactly one consumer per
+// ServeHTTP call, so the two must stay paired.
+//
+// If a consumer is allowed to exit on request cancellation while the message it was meant
+// to pick up is still pending, that pairing is permanently offset: from then on every
+// request is served by the *next* request's consumer, so each one blocks until further
+// traffic arrives. On a low-traffic endpoint this shows up as requests hanging until the
+// client or gateway times out.
+//
+// The first case below is where the offset is introduced -- and without the fix the very
+// first ServeHTTP never returns, because its own consumer is gone and no other request
+// follows to take the message.
+//
+// Note the cancellation cannot simply be dropped either: Protocol.ServeHTTP has paths that
+// return without sending anything (rate limiting, OPTIONS, GET -- see the tests above) and
+// Protocol.incoming is never closed, so an unconditionally waiting consumer would leak.
+func TestEventReceiverServeHTTP_ConsumerPairing(t *testing.T) {
+	p, err := cloudevents.NewHTTP()
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var handled []string
+
+	httpHandler, err := client.NewHTTPReceiveHandler(context.Background(), p,
+		func(_ context.Context, e cloudevents.Event) {
+			mu.Lock()
+			handled = append(handled, e.ID())
+			mu.Unlock()
+		})
+	require.NoError(t, err)
+
+	newRequest := func(ctx context.Context, id string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"hello":"world"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("ce-specversion", "1.0")
+		req.Header.Set("ce-type", "test.type")
+		req.Header.Set("ce-source", "test-source")
+		req.Header.Set("ce-id", id)
+		return req.WithContext(ctx)
+	}
+
+	serve := func(ctx context.Context, id string) <-chan struct{} {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			httpHandler.ServeHTTP(httptest.NewRecorder(), newRequest(ctx, id))
+		}()
+		return done
+	}
+
+	requireReturns := func(id string, done <-chan struct{}) {
+		t.Helper()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("ServeHTTP did not return for request %q", id)
+		}
+	}
+
+	// A request whose client has already gone away.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	requireReturns("cancelled", serve(cancelled, "cancelled"))
+
+	// Healthy requests must each complete on their own, without a following request
+	// arriving to unblock them.
+	requireReturns("first", serve(context.Background(), "first"))
+	requireReturns("second", serve(context.Background(), "second"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.ElementsMatch(t, []string{"cancelled", "first", "second"}, handled)
 }


### PR DESCRIPTION
Fixes #1224.

### The invariant that was broken

`Protocol.ServeHTTP` hands the inbound message over on the **unbuffered** `Protocol.incoming`
channel and blocks there until a consumer picks it up. `NewHTTPReceiveHandler` starts exactly
one consumer goroutine per `ServeHTTP` call, so the two have to stay paired.

That consumer waited on the **request** context. When a client disconnects during the
hand-off, the consumer exits while the message it was meant to pick up is still pending, and
the pairing is permanently offset by one: from then on every request is served by the *next*
request's consumer, so each one blocks until further traffic arrives.

That is also why it is easy to miss — on a busy endpoint the next request arrives within
milliseconds and nothing looks wrong; on a quiet one requests hang until the client or the
gateway gives up. Restarting the process is the only way to clear it.

### The fix

Wait on a context that is cancelled when `ServeHTTP` returns, instead of the request context.
While a message is pending its producer has not returned yet, so at least one consumer is
guaranteed to still be waiting for it.

### Why the cancellation cannot simply be dropped

This looked like the obvious fix at first and it is wrong: `Protocol.ServeHTTP` has paths that
return **without** sending anything —

- rate-limiter rejection (`!ok` → 429)
- `http.MethodOptions`
- `http.MethodGet`

`Protocol.incoming` is never closed, and `net/http` cancels the request context when the
handler returns, so today that cancellation is what lets the consumer of such a request exit.
An unconditionally waiting consumer would block forever on every OPTIONS request, GET request
and rate-limited request.

Cancelling on `ServeHTTP` return covers both cases: it releases consumers whose request never
produced a message, and it keeps alive those whose message is still in flight.

### Scope

Two lines of behaviour change in `v2/client/http_receiver.go`; the rest of the diff is the
comment explaining the invariant. No change to `protocol/http`, no new exported API, and
nothing that requires a newer Go version than the module already declares.

`Invoke` still receives `req.Context()`, so the context seen by receiver functions is
unchanged. The new context is only ever passed to `Respond`, which uses it solely for the
`select` — it reads no values and propagates no deadline — and its lifetime is bounded by the
handler via `defer`, so a consumer can never outlive its `ServeHTTP` call. Deriving it from
`context.Background()` rather than from the request context keeps this working on the Go
version the module declares (`context.WithoutCancel` is Go 1.21).

### Test

`TestEventReceiverServeHTTP_ConsumerPairing` in `v2/client/http_receiver_test.go`.

It serves a request whose context is already cancelled, then two healthy ones, and asserts
each `ServeHTTP` returns and each event reaches the receiver function. Without the fix the
first `ServeHTTP` never returns — its own consumer is gone and no further request follows to
take the message — so the test fails on a timeout:

```
--- FAIL: TestEventReceiverServeHTTP_ConsumerPairing (10.00s)
    http_receiver_test.go:192: ServeHTTP did not return for request "cancelled"
```

With the fix it passes immediately. The full `v2` suite passes; `gofmt` and `go vet` are clean.

I deliberately did not add a goroutine-count assertion for the no-send paths — it tends to be
flaky in shared test binaries. The reasoning is captured in the comment instead, and the
existing `TestEventReceiverServeHTTP_Options` / `_Webhook` tests cover those paths
functionally.
