### PR TITLE
fix: handle zero length slice data in JSON marshalling (fixes #1193)

### DIFF
--- a/v2/event/event_marshal.go
+++ b/v2/event/event_marshal.go
@@ -152,10 +152,15 @@ func WriteJson(in *Event, writer io.Writer) error {
 
 		// If IsJSON and no encoding to base64, we don't need to perform additional steps
 		if isJSON(mediaType) && !isBase64 {
-			stream.WriteObjectField("data")
-			_, err := stream.Write(in.DataEncoded)
-			if err != nil {
-				return fmt.Errorf("error while writing data: %w", err)
+			if len(in.DataEncoded) == 0 {
+				stream.WriteObjectField("data")
+				stream.WriteNil()
+			} else {
+				stream.WriteObjectField("data")
+				_, err := stream.Write(in.DataEncoded)
+				if err != nil {
+					return fmt.Errorf("error while writing data: %w", err)
+				}
 			}
 		} else {
 			if in.Context.GetSpecVersion() == CloudEventsVersionV1 && isBase64 {

--- a/v2/event/event_marshal_1193_test.go
+++ b/v2/event/event_marshal_1193_test.go
@@ -1,0 +1,38 @@
+package event_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+func TestZeroLengthSliceMarshalJSON(t *testing.T) {
+	ev := event.New(event.CloudEventsVersionV1)
+	ev.SetDataContentType(event.ApplicationJSON)
+	ev.SetType("type")
+	ev.SetSource("source")
+	ev.SetID("id")
+	ev.DataEncoded = []byte{}
+
+	if err := ev.Validate(); err != nil {
+		t.Fatalf("validate failed: %s", err)
+	}
+
+	dta, err := ev.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal failed: %s", err)
+	}
+
+	// Check if it's valid JSON
+	var raw json.RawMessage
+	if err := json.Unmarshal(dta, &raw); err != nil {
+		t.Fatalf("output is NOT valid JSON: %s\noutput: %s", err, string(dta))
+	}
+	t.Logf("JSON output: %s", string(dta))
+
+	var res event.Event
+	if err := res.UnmarshalJSON(dta); err != nil {
+		t.Fatalf("unmarshal failed: %s", err)
+	}
+}


### PR DESCRIPTION
Fixes #1193

When event has data that is a non-nil, zero length slice (empty byte slice), JSON marshalling produces malformed JSON with `{"data":}` which is invalid.

The fix checks for empty DataEncoded when mediaType is JSON and writes `null` instead of raw bytes.

Added test case that reproduces the issue and verifies the roundtrip (marshal -> unmarshal) works correctly.
