### PR TITLE
fix(nats_jetstream): add WithStreamName option to bypass stream lookup

### DIFF
--- a/protocol/nats_jetstream/v3/options.go
+++ b/protocol/nats_jetstream/v3/options.go
@@ -63,6 +63,16 @@ func WithSendSubject(sendSubject string) ProtocolOption {
 	}
 }
 
+// WithStreamName sets the explicit stream name to use for send and receive operations.
+// This bypasses the automatic stream lookup via StreamNameBySubject, which is useful
+// when multiple streams exist for the same subject.
+func WithStreamName(streamName string) ProtocolOption {
+	return func(p *Protocol) error {
+		p.streamName = streamName
+		return nil
+	}
+}
+
 // WithConsumerConfig creates a unordered consumer used in the protocol receiver.
 // This option is mutually exclusive with WithOrderedConsumerConfig.
 func WithConsumerConfig(consumerConfig *jetstream.ConsumerConfig) ProtocolOption {

--- a/protocol/nats_jetstream/v3/protocol.go
+++ b/protocol/nats_jetstream/v3/protocol.go
@@ -56,6 +56,7 @@ type Protocol struct {
 	// sender
 	publishOpts []jetstream.PublishOpt
 	sendSubject string
+	streamName  string
 }
 
 // New creates a new NATS protocol.
@@ -121,7 +122,10 @@ func (p *Protocol) Send(ctx context.Context, in binding.Message, transformers ..
 	}()
 
 	if _, err = p.jetStream.StreamNameBySubject(ctx, subject); err != nil {
-		return err
+		// If an explicit stream name was provided, skip the lookup
+		if p.streamName == "" {
+			return err
+		}
 	}
 
 	writer := new(bytes.Buffer)
@@ -241,6 +245,11 @@ func (p *Protocol) createJetstreamConsumer(ctx context.Context) error {
 // getStreamFromSubjects finds the unique stream for the set of filter subjects
 // If more than one stream is found, returns ErrMoreThanOneStream
 func (p *Protocol) getStreamFromSubjects(ctx context.Context) (string, error) {
+	// If an explicit stream name was provided, use it directly
+	if p.streamName != "" {
+		return p.streamName, nil
+	}
+
 	var subjects []string
 	if p.consumerConfig != nil && p.consumerConfig.FilterSubject != "" {
 		subjects = []string{p.consumerConfig.FilterSubject}


### PR DESCRIPTION
## Problem

When multiple NATS JetStream streams share the same subject, the SDK throws
ErrMoreThanOneStream during both Send and OpenInbound because it auto-looks up
the stream name via StreamNameBySubject. There is no way for users to specify
the stream name explicitly.

Fixes #1240

## Solution

Add WithStreamName ProtocolOption that sets an explicit stream name on the
Protocol struct. When set, both Send and createJetstreamConsumer skip the
StreamNameBySubject lookup and use the provided name directly.

## Changes

- Add WithStreamName option in options.go
- Add streamName field to Protocol struct
- Skip StreamNameBySubject in Send when streamName is set
- Skip getStreamFromSubjects when streamName is set (returns it directly)