### PR TITLE
ci: bump Go toolchain to 1.26

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -15,7 +15,7 @@ jobs:
     name: CloudEvents Conformance
     strategy:
       matrix:
-        go-version: [1.25]
+        go-version: [1.26]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.25]
+        go-version: [1.26]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/go-format.yaml
+++ b/.github/workflows/go-format.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache-dependency-path: v2/go.sum
         id: go
 

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -35,5 +35,5 @@ jobs:
         if: steps.golangci_configuration.outputs.files_exists == 'true'
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.8.0
+          version: v2.12.2
           working-directory: v2

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache-dependency-path: v2/go.sum
         id: go
 

--- a/.github/workflows/go-unit-test.yaml
+++ b/.github/workflows/go-unit-test.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit Test
     strategy:
       matrix:
-        go-version: [1.25]
+        go-version: [1.26]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Only test one go version: the integration tests don't seem to pass if NATS runs more one running at a time.
-        go-version: [1.25]
+        go-version: [1.26]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/observability.yaml
+++ b/.github/workflows/observability.yaml
@@ -15,7 +15,7 @@ jobs:
     name: CloudEvents Observability
     strategy:
       matrix:
-        go-version: [1.25]
+        go-version: [1.26]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache-dependency-path: v2/go.sum
 
       - name: Install Dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache-dependency-path: v2/go.sum
 
       - run: git pull
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache-dependency-path: v2/go.sum
 
       - name: Checkout Code

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache-dependency-path: v2/go.sum
 
       - name: Run update dependencies script

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This library will help you to:
 _Note:_ Supported
 [CloudEvents specification](https://github.com/cloudevents/spec): 0.3, 1.0
 
-_Note:_ Minimum Go version required: 1.24 (tested with 1.24+). Note that some modules may require a higher Go version, such as `github.com/cloudevents/sdk-go/protocol/pubsub/v2` (Go 1.25), due to module dependencies.
+_Note:_ Minimum Go version required: 1.25 (CI builds and tests with 1.26). Note that some modules may require a higher Go version, such as `github.com/cloudevents/sdk-go/protocol/pubsub/v2` (Go 1.25.8), due to module dependencies.
 
 ## Get started
 

--- a/v2/event/eventcontext_v03.go
+++ b/v2/event/eventcontext_v03.go
@@ -322,7 +322,7 @@ func (ec EventContextV03) String() string {
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
-			b.WriteString(fmt.Sprintf("  %s: %v\n", key, ec.Extensions[key]))
+			fmt.Fprintf(&b, "  %s: %v\n", key, ec.Extensions[key])
 		}
 	}
 

--- a/v2/event/eventcontext_v1.go
+++ b/v2/event/eventcontext_v1.go
@@ -307,7 +307,7 @@ func (ec EventContextV1) String() string {
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
-			b.WriteString(fmt.Sprintf("  %s: %v\n", key, ec.Extensions[key]))
+			fmt.Fprintf(&b, "  %s: %v\n", key, ec.Extensions[key])
 		}
 	}
 

--- a/v2/test/event_matchers.go
+++ b/v2/test/event_matchers.go
@@ -46,7 +46,7 @@ func AnyOf(matchers ...EventMatcher) EventMatcher {
 		var sb strings.Builder
 		sb.WriteString("Cannot match any of the provided matchers\n")
 		for i, err := range errs {
-			sb.WriteString(fmt.Sprintf("%d: %s\n", i+1, err))
+			fmt.Fprintf(&sb, "%d: %s\n", i+1, err)
 		}
 		return errors.New(sb.String())
 	}
@@ -301,7 +301,7 @@ func isEmpty(object interface{}) bool {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
 		return objValue.Len() == 0
 		// pointers are empty if nil or if the value they point to is empty
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if objValue.IsNil() {
 			return true
 		}

--- a/v2/types/allocate.go
+++ b/v2/types/allocate.go
@@ -16,7 +16,7 @@ func Allocate(obj interface{}) (asPtr interface{}, asValue reflect.Value) {
 	}
 
 	switch t := reflect.TypeOf(obj); t.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		reflectPtr := reflect.New(t.Elem())
 		asPtr = reflectPtr.Interface()
 		asValue = reflectPtr

--- a/v2/types/value.go
+++ b/v2/types/value.go
@@ -143,7 +143,7 @@ func Validate(v interface{}) (interface{}, error) {
 		return v, nil
 	}
 	rx := reflect.ValueOf(v)
-	if rx.Kind() == reflect.Ptr && !rx.IsNil() {
+	if rx.Kind() == reflect.Pointer && !rx.IsNil() {
 		// Allow pointers-to convertible types
 		return Validate(rx.Elem().Interface())
 	}


### PR DESCRIPTION
# What changed

`go-version` moves from `1.25` to `1.26` in all ten workflow files under `.github/workflows/`. The `go` directives in `v2/go.mod` and the protocol modules are untouched, so this changes the toolchain CI runs, and not the minimum Go version consumers of the SDK need.

The lint job's golangci-lint pin moves from v2.8.0 to v2.12.2, because v2.8.0 cannot analyze code built with Go 1.26. v2.12.2 reports six issues on `./v2`, all cleared here. govet's `inline` analyzer flags three uses of `reflect.Ptr`, a deprecated alias for `reflect.Pointer` since Go 1.18, and the two constants are identical. staticcheck QF1012 flags three calls of the form `Builder.WriteString(fmt.Sprintf(...))`, now `fmt.Fprintf` on the builder, which drops the intermediate string allocation. Ignoring the `Fprintf` return is safe because `strings.Builder` never returns an error, and errcheck is disabled in `.golangci.yaml`.

The README note on the minimum Go version now reads 1.25 instead of 1.24, and points at `protocol/pubsub/v2` needing 1.25.8. The 1.24 claim has been wrong since `v2/go.mod` moved to `go 1.25.0`.

# Why

The weekly `Update Dependencies` workflow has failed since `github.com/quic-go/quic-go` released v0.62.0, which declares `go >= 1.26.0`. CI pinned `go-version: 1.25` and `actions/setup-go` sets `GOTOOLCHAIN=local`, so `go get -u -t ./...` had no way to satisfy that requirement and exited 1 with `requires go >= 1.26.0 (running go 1.25.14; GOTOOLCHAIN=local)`.

`quic-go` reaches the repository as an indirect dependency of `samples/http`. Bumping only `update-dependencies.yml` would fix the dependency job and then break the others, because `go get -u` raises the `go` directive in `samples/http/go.mod` to `1.26.0` on its own and `hack/build-test.sh` builds the samples. All ten workflows move together for that reason.

Closes #1321

# How to verify

Checked locally with go1.26.2 and `GOTOOLCHAIN=local`, which is what `actions/setup-go` gives the runner, and golangci-lint v2.12.2 to match the new pin.

- `cd samples/http && go get -u -t ./...` succeeds in a throwaway worktree, reporting `go: upgraded go 1.25.0 => 1.26.0` and `go: upgraded github.com/quic-go/quic-go v0.61.0 => v0.62.0`. On go1.25 this is the command that exits 1.
- `cd v2 && golangci-lint run` reports `0 issues.`
- `cd v2 && go build ./... && go vet ./...` is clean.
- `cd v2 && go test ./event/... ./types/... ./test/...` passes.
- The workflow change only takes effect for the `Update Dependencies` job after merge, because that job runs on a schedule against `main`. Every other job exercises Go 1.26 on this PR.
