### PR TITLE
fix: properly handle zero-length JSON slices in event unmarshal

### DIFF
--- a/v2/event/event_unmarshal.go
+++ b/v2/event/event_unmarshal.go
@@ -383,7 +383,17 @@ func consumeDataAsBytes(e *Event, isBase64 bool, b []byte) error {
 		return nil
 	}
 
-	e.DataEncoded = b
+	// Parse as JSON to verify validity and handle zero-length slices properly
+	var parsed interface{}
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		return fmt.Errorf("invalid JSON data: %w", err)
+	}
+	data, err := json.Marshal(parsed)
+	if err != nil {
+		return err
+	}
+	e.DataEncoded = data
+	e.DataBase64 = false
 	return nil
 }
 


### PR DESCRIPTION
Fixes #1193

When an event has DataEncoded set directly from raw JSON bytes with a zero-length
slice (e.g., []byte{}), the marshal/unmarshal round-trip produces invalid JSON.
The POC demonstrates this:

```go
ev.DataEncoded = []byte{}
data, _ := ev.MarshalJSON()
// produces {"data": null} instead of {"data": []}

var res ce.Event
res.UnmarshalJSON(dta) // fails
```

Fix: parse JSON through json.Unmarshal/Marshal to ensure proper representation
of zero-length slices as [] instead of null.