### PR TITLE
feat: add WithStreamName option to bypass stream resolution

### DIFF
--- a/protocol/nats_jetstream/v3/options.go
+++ b/protocol/nats_jetstream/v3/options.go
@@ -88,3 +88,12 @@ func WithPullConsumerOptions(pullConsumeOpts []jetstream.PullConsumeOpt) Protoco
 		return nil
 	}
 }
+
+// WithStreamName allows the user to specify a stream name directly,
+// bypassing the automatic stream resolution via subjects.
+func WithStreamName(streamName string) ProtocolOption {
+	return func(p *Protocol) error {
+		p.streamName = streamName
+		return nil
+	}
+}

--- a/protocol/nats_jetstream/v3/protocol.go
+++ b/protocol/nats_jetstream/v3/protocol.go
@@ -52,6 +52,7 @@ type Protocol struct {
 	orderedConsumerConfig *jetstream.OrderedConsumerConfig
 	pullConsumeOpts       []jetstream.PullConsumeOpt
 	jetstreamConsumer     jetstream.Consumer
+	streamName            string
 
 	// sender
 	publishOpts []jetstream.PublishOpt
@@ -241,6 +242,11 @@ func (p *Protocol) createJetstreamConsumer(ctx context.Context) error {
 // getStreamFromSubjects finds the unique stream for the set of filter subjects
 // If more than one stream is found, returns ErrMoreThanOneStream
 func (p *Protocol) getStreamFromSubjects(ctx context.Context) (string, error) {
+	// If a stream name was explicitly provided, use it directly
+	if p.streamName != "" {
+		return p.streamName, nil
+	}
+
 	var subjects []string
 	if p.consumerConfig != nil && p.consumerConfig.FilterSubject != "" {
 		subjects = []string{p.consumerConfig.FilterSubject}


### PR DESCRIPTION
Fixes #1240

Adds WithStreamName option to NATS JetStream protocol that allows users to
specify the stream name directly, bypassing automatic stream resolution via
subjects.

This is useful in deployments with multiple streams for the same subject where
the SDK would throw ErrMoreThanOneStream.