### PR TITLE
feat: add exponential backoff with full jitter retry strategy

### DIFF
--- a/samples/http/sender-retry/main.go
+++ b/samples/http/sender-retry/main.go
@@ -34,6 +34,8 @@ func main() {
 	send10(cloudevents.ContextWithRetriesLinearBackoff(ctx, 10*time.Millisecond, 10), c)
 	log.Println("--- Exponential ---")
 	send10(cloudevents.ContextWithRetriesExponentialBackoff(ctx, 10*time.Millisecond, 10), c)
+	log.Println("--- Exponential with Full Jitter ---")
+	send10(cloudevents.ContextWithRetriesExponentialBackoffWithJitter(ctx, 10*time.Millisecond, 10), c)
 }
 
 func send10(ctx context.Context, c cloudevents.Client) {

--- a/v2/alias.go
+++ b/v2/alias.go
@@ -150,11 +150,12 @@ var (
 
 	// Context
 
-	ContextWithTarget                    = context.WithTarget
-	TargetFromContext                    = context.TargetFrom
-	ContextWithRetriesConstantBackoff    = context.WithRetriesConstantBackoff
-	ContextWithRetriesLinearBackoff      = context.WithRetriesLinearBackoff
-	ContextWithRetriesExponentialBackoff = context.WithRetriesExponentialBackoff
+	ContextWithTarget                              = context.WithTarget
+	TargetFromContext                              = context.TargetFrom
+	ContextWithRetriesConstantBackoff              = context.WithRetriesConstantBackoff
+	ContextWithRetriesLinearBackoff                = context.WithRetriesLinearBackoff
+	ContextWithRetriesExponentialBackoff           = context.WithRetriesExponentialBackoff
+	ContextWithRetriesExponentialBackoffWithJitter = context.WithRetriesExponentialBackoffWithJitter
 
 	WithEncodingBinary     = binding.WithForceBinary
 	WithEncodingStructured = binding.WithForceStructured

--- a/v2/context/context.go
+++ b/v2/context/context.go
@@ -92,6 +92,17 @@ func WithRetriesExponentialBackoff(ctx context.Context, period time.Duration, ma
 	})
 }
 
+// WithRetriesExponentialBackoffWithJitter returns back a new context with retry parameters
+// using exponential backoff with full jitter strategy.
+// MaxTries is the maximum number for retries and period is the base interval.
+func WithRetriesExponentialBackoffWithJitter(ctx context.Context, period time.Duration, maxTries int) context.Context {
+	return WithRetryParams(ctx, &RetryParams{
+		Strategy: BackoffStrategyExponentialWithJitter,
+		Period:   period,
+		MaxTries: maxTries,
+	})
+}
+
 // WithRetryParams returns back a new context with retries parameters.
 func WithRetryParams(ctx context.Context, rp *RetryParams) context.Context {
 	return context.WithValue(ctx, retriesKey, rp)

--- a/v2/context/retry.go
+++ b/v2/context/retry.go
@@ -9,16 +9,18 @@ import (
 	"context"
 	"errors"
 	"math"
+	"math/rand"
 	"time"
 )
 
 type BackoffStrategy string
 
 const (
-	BackoffStrategyNone        = "none"
-	BackoffStrategyConstant    = "constant"
-	BackoffStrategyLinear      = "linear"
-	BackoffStrategyExponential = "exponential"
+	BackoffStrategyNone                  = "none"
+	BackoffStrategyConstant              = "constant"
+	BackoffStrategyLinear                = "linear"
+	BackoffStrategyExponential           = "exponential"
+	BackoffStrategyExponentialWithJitter = "exponential-jitter"
 )
 
 var DefaultRetryParams = RetryParams{Strategy: BackoffStrategyNone}
@@ -36,6 +38,7 @@ type RetryParams struct {
 	// - for constant strategy: the delay interval between retries
 	// - for linear strategy: interval between retries = Period * retries
 	// - for exponential strategy: interval between retries = Period * retries^2
+	// - for exponential-jitter strategy: random interval between 0 and Period * 2^retries
 	Period time.Duration
 }
 
@@ -51,6 +54,19 @@ func (r *RetryParams) BackoffFor(tries int) time.Duration {
 	case BackoffStrategyExponential:
 		exp := math.Exp2(float64(tries))
 		return r.Period * time.Duration(exp)
+	case BackoffStrategyExponentialWithJitter:
+		if r.Period <= 0 {
+			return 0
+		}
+		ceiling := float64(r.Period) * math.Exp2(float64(tries))
+		if ceiling >= float64(math.MaxInt64) {
+			return time.Duration(rand.Int63n(math.MaxInt64))
+		}
+		maxCeil := int64(ceiling)
+		if maxCeil <= 0 {
+			return 0
+		}
+		return time.Duration(rand.Int63n(maxCeil))
 	case BackoffStrategyNone:
 		fallthrough // default
 	default:
@@ -64,7 +80,16 @@ func (r *RetryParams) Backoff(ctx context.Context, tries int) error {
 	if tries > r.MaxTries {
 		return errors.New("too many retries")
 	}
-	ticker := time.NewTicker(r.BackoffFor(tries))
+	d := r.BackoffFor(tries)
+	if d <= 0 {
+		select {
+		case <-ctx.Done():
+			return errors.New("context has been cancelled")
+		default:
+			return nil
+		}
+	}
+	ticker := time.NewTicker(d)
 	select {
 	case <-ctx.Done():
 		ticker.Stop()

--- a/v2/context/retry_test.go
+++ b/v2/context/retry_test.go
@@ -7,6 +7,7 @@ package context
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 )
@@ -37,6 +38,11 @@ func TestRetryParams_Backoff(t *testing.T) {
 		"exponential 1": {
 			ctx:   context.Background(),
 			rp:    &RetryParams{Strategy: BackoffStrategyExponential, MaxTries: 10, Period: 1 * time.Nanosecond},
+			tries: 1,
+		},
+		"exponential jitter 1": {
+			ctx:   context.Background(),
+			rp:    &RetryParams{Strategy: BackoffStrategyExponentialWithJitter, MaxTries: 10, Period: 1 * time.Nanosecond},
 			tries: 1,
 		},
 		"const timeout": {
@@ -115,5 +121,66 @@ func TestRetryParams_BackoffFor(t *testing.T) {
 				t.Errorf("BackoffFor() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRetryParams_BackoffFor_ExponentialWithJitter(t *testing.T) {
+	for _, period := range []time.Duration{0, -1, -time.Second} {
+		rp := &RetryParams{
+			Strategy: BackoffStrategyExponentialWithJitter,
+			MaxTries: 10,
+			Period:   period,
+		}
+		if got := rp.BackoffFor(1); got != 0 {
+			t.Errorf("BackoffFor() with period %v = %v, want 0", period, got)
+		}
+	}
+
+	basePeriod := 10 * time.Millisecond
+	rp := &RetryParams{
+		Strategy: BackoffStrategyExponentialWithJitter,
+		MaxTries: 10,
+		Period:   basePeriod,
+	}
+	for tries := 1; tries <= 5; tries++ {
+		ceiling := time.Duration(float64(basePeriod) * math.Exp2(float64(tries)))
+		for i := 0; i < 50; i++ {
+			got := rp.BackoffFor(tries)
+			if got < 0 || got >= ceiling {
+				t.Errorf("BackoffFor(%d) = %v, want in [0, %v)", tries, got, ceiling)
+			}
+		}
+	}
+
+	for _, tries := range []int{64, 1000} {
+		for i := 0; i < 10; i++ {
+			got := rp.BackoffFor(tries)
+			if got < 0 {
+				t.Errorf("BackoffFor(%d) = %v, want >= 0", tries, got)
+			}
+		}
+	}
+
+	ctx := context.Background()
+	for _, period := range []time.Duration{0, -time.Millisecond} {
+		rp := &RetryParams{
+			Strategy: BackoffStrategyExponentialWithJitter,
+			MaxTries: 10,
+			Period:   period,
+		}
+		if err := rp.Backoff(ctx, 1); err != nil {
+			t.Errorf("Backoff() with period %v error = %v, want nil", period, err)
+		}
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rpZero := &RetryParams{
+		Strategy: BackoffStrategyExponentialWithJitter,
+		MaxTries: 10,
+		Period:   0,
+	}
+	if err := rpZero.Backoff(canceledCtx, 1); err == nil || err.Error() != "context has been cancelled" {
+		t.Errorf("Backoff() with canceled context got %v, want 'context has been cancelled'", err)
 	}
 }

--- a/v2/protocol/http/protocol_retry.go
+++ b/v2/protocol/http/protocol_retry.go
@@ -24,7 +24,7 @@ func (p *Protocol) do(ctx context.Context, req *http.Request) (binding.Message, 
 	params := cecontext.RetriesFrom(ctx)
 
 	switch params.Strategy {
-	case cecontext.BackoffStrategyConstant, cecontext.BackoffStrategyLinear, cecontext.BackoffStrategyExponential:
+	case cecontext.BackoffStrategyConstant, cecontext.BackoffStrategyLinear, cecontext.BackoffStrategyExponential, cecontext.BackoffStrategyExponentialWithJitter:
 		return p.doWithRetry(ctx, params, req)
 	case cecontext.BackoffStrategyNone:
 		fallthrough

--- a/v2/protocol/http/protocol_retry_test.go
+++ b/v2/protocol/http/protocol_retry_test.go
@@ -224,3 +224,30 @@ func newEvent(t *testing.T, encoding string, body interface{}) event.Event {
 
 	return e
 }
+
+func TestRequestWithRetries_exponentialWithJitter(t *testing.T) {
+	mockSrv := &roundTripperTest{
+		statusCodes: []int{503, 200},
+	}
+	srv := httptest.NewServer(mockSrv)
+	defer srv.Close()
+
+	p, err := New(WithClient(http.Client{Timeout: time.Second}))
+	require.NoError(t, err)
+
+	ctx := cecontext.WithTarget(context.Background(), srv.URL)
+	ctx = cecontext.WithLogger(ctx, zaptest.NewLogger(t).Sugar())
+	ctxWithRetries := cecontext.WithRetriesExponentialBackoffWithJitter(ctx, time.Nanosecond, 3)
+
+	dummyEvent := newEvent(t, "", nil)
+	dummyMsg := binding.ToMessage(&dummyEvent)
+	_, got := p.Request(ctxWithRetries, dummyMsg)
+
+	srvCount := func() int {
+		mockSrv.Lock()
+		defer mockSrv.Unlock()
+		return mockSrv.requestCount
+	}
+	assert.Equal(t, 2, srvCount())
+	assert.True(t, protocol.IsACK(got))
+}


### PR DESCRIPTION
Addresses [#1326](https://github.com/cloudevents/sdk-go/issues/1326)

This PR implements an exponential backoff with full jitter retry strategy (`BackoffStrategyExponentialWithJitter`) to prevent [thundering herd](https://redis.io/blog/how-to-tame-the-thundering-herd-problem/) issues during retries.

Changes Made:
- **Main Logic (`v2/context`)**: 
  - Added `BackoffStrategyExponentialWithJitter = "exponential-jitter"` constant.
  - Implemented full jitter calculation in `BackoffFor()` with guards against negative periods, float overflow, and sub-nanosecond intervals.
  - Added `d <= 0` guard in `Backoff()` to avoid `time.NewTicker(0)` runtime panics when jitter evaluates to 0, while properly preserving context cancellation checks.
  - Added `WithRetriesExponentialBackoffWithJitter` helper function.
- **Top-level API (`v2/alias.go`)**: 
  - Re-exported `ContextWithRetriesExponentialBackoffWithJitter`.
- **Protocol (`v2/protocol/http`)**: 
  - Added strategy to HTTP protocol retry dispatch.
- **Samples (`samples/http`)**: 
  - Updated `sender-retry` sample to demonstrate full jitter retry usage.
- **Tests**: 
  - Added unit tests covering edge cases (overflow, zero/negative periods, canceled context) and an HTTP protocol retry integration test.


For tests:
- Ran `cd v2 && go test -v -race ./context/... ./protocol/http/...`
- Ran `./hack/unit-test.sh` across all modules
- Ran `./hack/build-test.sh` across all modules
- Ran `go vet` and `gofmt -s`